### PR TITLE
Add support for LilyGo T-Connect Pro

### DIFF
--- a/packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml
+++ b/packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml
@@ -1,0 +1,150 @@
+# Updated : 2025.04.16
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+# https://github.com/Xinyuan-LilyGO/T-Connect-Pro
+
+substitutions:
+  board_chip: "ESP32-S3"
+  board_name: "LilyGo T-Connect Pro"
+  # uart_esp_1: RS232
+  tx_pin_1: '4'
+  rx_pin_1: '5'
+  # uart_esp_2: RS485
+  tx_pin_2: '17'
+  rx_pin_2: '18'
+  # canbus_esp32_can: CAN
+  tx_pin_4: '6'
+  rx_pin_4: '7'
+
+packages:
+  device_base: !include ../base/device_base.yaml
+  device_base_wifi: !include ../base/device_base_wifi.yaml
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  flash_size: 16MB # ajust according to your ESP32-S3 version
+  cpu_frequency: 240MHz
+  framework:
+    type: esp-idf
+
+esphome:
+  platformio_options:
+    board_build.flash_mode: dio             # use Dual IO (dio) instead of Quad IO (qio) to prevent boot loop after flashing
+
+wifi:
+  id: my_network
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  domain: !secret domain
+
+# ESPHome does not support W5500 and other SPI devices at the same SPI bus:
+# https://github.com/esphome/esphome/discussions/6720
+#ethernet:
+#  id: my_network
+#  type: W5500
+#  clk_pin: 12
+#  mosi_pin: 11
+#  miso_pin: 13
+#  cs_pin: 10
+#  interrupt_pin: 9
+#  reset_pin: 48
+#  clock_speed: 40MHz
+  
+logger:
+  baud_rate: 0 # frees the 3rd UART and avoids some bugs like "WK2168 with canbus" or "BLE client with RS485 modbus"
+
+# SPI for ethernet/LCD/LoRa
+spi:
+  - id: lilygo_spi_bus
+    clk_pin: 12
+    mosi_pin: 11
+    miso_pin: 13
+
+# I2C for touch controller CST226SE
+i2c:
+  sda: 39
+  scl: 40
+
+touchscreen:
+  - platform: cst226
+    id: my_touchscreen
+    interrupt_pin: 3
+    reset_pin: 47
+    
+display:
+  # T-Connect-Pro display
+  # https://esphome.io/components/display/ili9xxx
+  - platform: ili9xxx
+    spi_id: lilygo_spi_bus
+    id: my_display
+    model: ST7796
+    cs_pin: 21
+    dc_pin: 41
+    transform:
+      swap_xy: true
+      mirror_x: true
+      mirror_y: true
+    dimensions:
+      height: 222
+      width: 480
+      offset_height: 49
+      offset_width: 0
+    invert_colors: true
+    color_palette: 8BIT
+    update_interval: 10s
+    data_rate: 40Mhz
+
+# Define a PWM output for the display backlight
+output:
+  - platform: ledc
+    pin: 46
+    id: backlight_pwm
+    
+# ESP32 board without LED
+  - platform: template
+    id: esp_output
+    type: binary
+    write_action:
+      - logger.log: "Inverter Heartbeat Output"
+
+# Define a monochromatic, dimmable light for the backlight
+light:
+  - platform: monochromatic
+    output: backlight_pwm
+    name: "Display Backlight"
+    id: back_light
+    restore_mode: RESTORE_DEFAULT_ON
+
+  # ESP Light used to see the inverter heartbeat
+  # Internal : only specifying an id without a name will implicitly set this to true.
+  - platform: binary
+    id: esp_light
+    output: esp_output
+
+# Relay: IO8
+switch:
+  - platform: gpio
+    name: "Relay"
+    icon: "mdi:electric-switch"
+    pin:
+      number: GPIO8
+      inverted: true
+      mode: OUTPUT_OPEN_DRAIN
+    restore_mode: RESTORE_DEFAULT_OFF

--- a/packages/board/board_options_display_480x222.yaml
+++ b/packages/board/board_options_display_480x222.yaml
@@ -1,0 +1,112 @@
+# Updated : 2025.04.16
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+# +--------------------------------------+
+# | Display Related                      |
+# +--------------------------------------+
+
+packages:
+  psram: !include board_options_ESP32-S3_PSRAM.yaml
+
+color:
+  - id: my_black
+    hex: "000000"
+  - id: my_red
+    red: 100%
+    green: 0%
+    blue: 0%
+  - id: my_yellow
+    red: 100%
+    green: 100%
+    blue: 0%
+  - id: my_green
+    red: 0%
+    green: 100%
+    blue: 0%
+  - id: my_blue
+    red: 0%
+    green: 0%
+    blue: 100%
+  - id: my_gray
+    red: 50%
+    green: 50%
+    blue: 50%
+  - id: my_white
+    red: 100%
+    green: 100%
+    blue: 100%
+  - id: my_pink
+    hex: ff00ff
+
+font:
+  - file: "gfonts://Roboto"
+    id: roboto_32
+    size: 32
+  - file: "gfonts://Roboto"
+    id: roboto_24
+    size: 24
+  - file: "gfonts://Roboto"
+    id: roboto_12
+    size: 12
+  - file: "gfonts://Roboto"
+    id: roboto_18
+    size: 18
+
+# Auto next page interval
+interval:
+  - interval: ${display_auto_next_page_interval}
+    startup_delay:  10s
+    then:
+      - display.page.show_next: my_display
+      - component.update: my_display
+
+# +--------------------------------------+
+# | Display Handling                     |
+# +--------------------------------------+
+display:
+  # T-Connect-Pro display see https://esphome.io/components/display/ili9xxx.html
+  - id: !extend my_display
+    pages:
+      - id: page1
+        lambda: |-
+          it.rectangle(0,  0, it.get_width(), it.get_height(), id(my_blue));
+          it.rectangle(0, 20, it.get_width(), it.get_height(), id(my_blue));   // header bar
+          it.rectangle(0, 100, it.get_width(), it.get_height(), id(my_blue));  // footer bar
+          it.printf(64, 118, id(roboto_18), id(my_yellow), TextAlign::CENTER, "%s", id(${yambms_id}_charging_status).state.c_str());
+          // ESP status
+          if (id(esp32_online_status).state)
+          {
+            it.print(115, 5, id(roboto_12), id(my_green), TextAlign::TOP_RIGHT, "ESP OK");
+          }
+          else
+          {
+            it.print(115, 5, id(roboto_12), id(my_red), TextAlign::TOP_RIGHT, "ESP KO");
+          }
+          // Inverter communication status (CANBUS / RS485)
+          if (id(inverter_com_status).state)
+          {
+            it.print(2, 5, id(roboto_12), id(my_green), TextAlign::TOP_LEFT, "CAN OK");
+          }
+          else
+          {
+            it.print(2, 5, id(roboto_12), id(my_red), TextAlign::TOP_LEFT, "CAN KO");
+          }
+          it.print((128 / 2), (128 / 3) * 1, id(roboto_24), id(my_gray), TextAlign::CENTER,"SoC %");
+          it.printf((128 / 2), (128 / 3) * 2 - 5, id(roboto_32), id(my_gray), TextAlign::CENTER, "%.1f", id(${yambms_id}_battery_soc).state);
+          


### PR DESCRIPTION
This adds support for the LilyGo T-Connect Pro

I created this PR early so others can see that it is work in progress.

https://lilygo.cc/products/t-connect-pro 
https://github.com/Xinyuan-LilyGO/T-Connect-Pro/tree/main

TODO: 

- ~Display pages~ Disabled by default as updating it increases the loop time too much
- ~Relais~
- ~Alternative configuration file: Ethernet instead of display (ESPHome does not support ethernet and other SPI devices on the same SPI bus)~

I got it up and running as Modbus client:
![IMG_20250416_182043](https://github.com/user-attachments/assets/63f451be-10a3-4627-84e2-2e555f8ac667)
Modbus server is a LilyGo T-Connect with Deye (CAN) and JK (RS485) connected (more to come):
![IMG_20250416_182104](https://github.com/user-attachments/assets/306eeaa9-deff-40eb-9c94-0e10e5953249)