### PR TITLE
Add Modbus server files for JK BMS (RS485) and DEYE (CAN)

### DIFF
--- a/packages/bms/bms_modbus_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_modbus_DEYE_CAN_module_full.yaml
@@ -1,0 +1,28 @@
+# Updated : 2025.04.22
+# Version : 1.1.1
+# GitHub  : https://github.com/syssi/esphome-jk-bms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+substitutions:
+  bms_model: "DEYE"
+  bms_protocol: "CAN-Modbus"
+
+packages:
+  bms_base: !include bms_base.yaml
+  bms_sensors: !include bms_sensors_DEYE_CAN_module_full.yaml
+  bms_errors_bitmask: !include bms_errors_bitmask_DEYE_CAN.yaml
+  bms_combine: !include bms_modbus_server.yaml

--- a/packages/bms/bms_modbus_JK_RS485_Modbus_bms_standard.yaml
+++ b/packages/bms/bms_modbus_JK_RS485_Modbus_bms_standard.yaml
@@ -1,0 +1,26 @@
+# Updated : 2025.04.22
+# Version : 1.1.1
+# GitHub  : https://github.com/syssi/esphome-jk-bms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+substitutions:
+  bms_model: "JK"
+  bms_protocol: "RS485-Modbus"
+
+packages:
+  bms_sensors: !include bms_sensors_JK_RS485_Modbus_bms_standard.yaml
+  bms_combine: !include bms_modbus_server.yaml


### PR DESCRIPTION
This adds two Modbus server files, one for JK-BMS connected via RS485 and one for DEYE connected via CAN.
With these files the mentioned BMS can be used as Modbus node.