### PR TITLE
Add minimal versions for Victron SmartShunt via Modbus

### DIFF
--- a/packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
+++ b/packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
@@ -1,0 +1,31 @@
+# Updated : 2025.04.23
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+packages:
+  shunt_sensors: !include shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
+  shunt_combine: !include shunt_modbus_server.yaml
+
+# +--------------------------------------+
+# | Component settings                   |
+# +--------------------------------------+
+
+uart:
+  - id: !extend ${shunt_uart_id}
+    baud_rate: 19200
+    rx_buffer_size: 256

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
@@ -1,0 +1,66 @@
+# Updated : 2025.04.23
+# Version : 1.1.1
+# GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+packages:
+  shunt_base: !include shunt_base.yaml
+
+# +--------------------------------------+
+# | Component settings                   |
+# +--------------------------------------+
+
+external_components:
+  - source: github://KinDR007/VictronMPPT-ESPHOME@main
+    refresh: 0s
+
+victron:
+  - uart_id: ${shunt_uart_id}
+    id: victron${shunt_id}
+    throttle: ${shunt_update_interval}
+
+# +--------------------------------------+
+# | Component entities                   |
+# +--------------------------------------+
+
+binary_sensor:
+  # online_status
+  - platform: template
+    id: shunt${shunt_id}_online_status
+    name: "${name} ${shunt_name} Online Status"
+    lambda: |-
+      if (id(shunt${shunt_id}_voltage).state > 0)
+        return true;
+      else
+        return false;
+
+sensor:
+  - platform: victron
+    victron_id: victron${shunt_id}
+    battery_voltage:
+      id: shunt${shunt_id}_voltage
+      name: "${name} ${shunt_name} battery voltage"
+    battery_current:
+      id: shunt${shunt_id}_current
+      name: "${name} ${shunt_name} battery current"
+    instantaneous_power:
+      id: shunt${shunt_id}_power
+      name: "${name} ${shunt_name} instantaneous power"
+    state_of_charge:
+      id: shunt${shunt_id}_soc
+      name: "${name} ${shunt_name} state of charge"
+


### PR DESCRIPTION
When using Modbus (server) to send Victron SmartShunt data, not all sensors are required. This commit adds two files to only provide the minimum set for this: Voltage, current, power, SOC.