### PR TITLE
Support for RP2040

### DIFF
--- a/YamBMS_LP_RPi_Pico_Shunts_Modbus.yaml
+++ b/YamBMS_LP_RPi_Pico_Shunts_Modbus.yaml
@@ -1,0 +1,122 @@
+# Updated : 2025.05.16
+# Version : 1.5.6
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+######################## YamBMS Local Packages Version #########################
+
+# You need to copy the `packages` folder into the same folder as this YAML in order to compile it.
+# Don't forget to configure your WiFi credentials in the secrets.yaml
+
+################################################################################
+
+logger:
+  level: INFO # VERBOSE / DEBUG / INFO / WARN
+
+# +--------------------------------------+
+# | Global Settings                      |
+# +--------------------------------------+
+substitutions:
+  # Name
+  name: '' # Name that can be added as a second prefix after the friendly name, you can leave it blank.
+  hostname: 'yambms' # This is the name of the node. It should always be unique in your ESPHome network.
+  friendly_name : 'YamBMS' # Prefix added in front of all entity names and also to classify them.
+  # +--------------------------------------+
+  # | YamBMS Settings                      |
+  # +--------------------------------------+
+  # Please read the cut-off charging logic README to understand how the YamBMS works
+  yambms_id: 'yambms1'
+  yambms_name: 'YamBMS 1'
+  # +--------------------------------------+
+  # | Shunt Settings                      |
+  # +--------------------------------------+
+  shunt_update_interval: '5s'  # frequency at which Shunt data is refreshed
+  shunt_combine_interval: '1s' # frequency at which Shunt data is combined in YamBMS
+
+  # Modbus options
+  modbus_update_interval: '5s' # frequency with which BMS/Shunt modbus servers are queried
+  modbus_baud_rate: '19200' # 9600 / 19200 / 11520
+  modbus_command_throttle: '0ms' # minimum time in between 2 requests to the device
+  modbus_send_wait_time: '250ms' # time in milliseconds before the next ModBUS command is sent if an answer from a previous command is pending
+
+# +--------------------------------------+
+# | Packages                             |
+# +--------------------------------------+
+
+# PLEASE READ : https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_main_YAML_HowTo.md
+
+packages:
+
+  ################ >>> CONFIG & CUSTOM LP <<< ################
+
+  # Local Packages intended for creating custom codes
+  # or sharing settings between several main.yaml
+
+  # yambms_config: !include yambms_config.yaml
+  # yambms_custom: !include yambms_custom.yaml
+  ############################################################
+
+  device_board: !include packages/board/board_RP2040_RPi_Pico.yaml
+
+  uart_1: !include packages/board/board_options_itf_uart_1.yaml
+  uart_2: !include packages/board/board_options_itf_uart_2.yaml
+  uart_3: !include packages/board/board_options_itf_uart_3.yaml
+  uart_4: !include packages/board/board_options_itf_uart_4.yaml
+  uart_5: !include packages/board/board_options_itf_uart_5.yaml
+  uart_6: !include packages/board/board_options_itf_uart_6.yaml
+
+  modbus: !include
+    file: packages/base/device_modbus.yaml
+    vars:
+      modbus_role: 'server' # client / server
+      modbus_uart_id: 'uart_1' # RS485 board
+      
+  shunt1: !include
+    file: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
+    vars:
+      shunt_id: '1'
+      shunt_name: 'Shunt 1'
+      shunt_uart_id: 'uart_2'
+
+  shunt2: !include
+    file: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
+    vars:
+      shunt_id: '2'
+      shunt_name: 'Shunt 2'
+      shunt_uart_id: 'uart_3'
+
+  shunt3: !include
+    file: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
+    vars:
+      shunt_id: '3'
+      shunt_name: 'Shunt 3'
+      shunt_uart_id: 'uart_4'
+
+  shunt4: !include
+    file: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
+    vars:
+      shunt_id: '4'
+      shunt_name: 'Shunt 4'
+      shunt_uart_id: 'uart_5'
+
+  shunt5: !include
+    file: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
+    vars:
+      shunt_id: '5'
+      shunt_name: 'Shunt 5'
+      shunt_uart_id: 'uart_6'
+

--- a/packages/board/board_RP2040_RPi_Pico.yaml
+++ b/packages/board/board_RP2040_RPi_Pico.yaml
@@ -1,0 +1,79 @@
+# Updated : 2025.06.18
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+# Raspberry Pi Pico RP2040 board
+# https://esphome.io/components/rp2040/rp2040.html
+# Documentation:
+# https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html
+#
+
+substitutions:
+  board_chip: "RP2040"
+  board_name: "RPi Pico"
+  tx_pin_1: '0'
+  rx_pin_1: '1'
+  tx_pin_2: '2'
+  rx_pin_2: '3'
+  tx_pin_3: '4'
+  rx_pin_3: '5'
+  tx_pin_4: '6'
+  rx_pin_4: '7'
+  tx_pin_5: '10'
+  rx_pin_5: '11'
+  tx_pin_6: '14'
+  rx_pin_6: '15'
+
+packages:
+  device_base: !include ../base/device_base_esphome.yaml
+
+rp2040:
+  board: rpipico
+  framework:
+    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
+    version: 4.5.2
+    # For the RP2040 PIO UARTs to work correctly with the Victron SmartShunt at 19200 baud
+    # we need a fix in the arduino-pico core. See:
+    # https://github.com/earlephilhower/arduino-pico/commit/5e74bbbbb2a22b5ae64fd6a4b0363c7f90a863d2
+    # and https://github.com/earlephilhower/arduino-pico/issues/2928 
+    #source: https://github.com/GHswitt/arduino-pico.git#uart_pio
+    source: https://github.com/earlephilhower/arduino-pico.git#5e74bbb
+
+# +--------------------------------------+
+# | Heartbeat Light                      |
+# +--------------------------------------+
+
+light:
+  # LED used to see the heartbeat
+  # Internal : only specifying an id without a name will implicitly set this to true.
+  - platform: binary
+    output: rp2040_led
+    id: rp2040_light
+
+output:
+  # RP2040 LED
+  - platform: gpio
+    pin: 25
+    id: rp2040_led
+
+interval:
+  - interval: 1000ms
+    then:
+      - output.turn_on: rp2040_led
+      - delay: 500ms
+      - output.turn_off: rp2040_led

--- a/packages/board/board_options_itf_uart_1.yaml
+++ b/packages/board/board_options_itf_uart_1.yaml
@@ -1,0 +1,25 @@
+# Updated : 2025.06.18
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+uart:
+  - id: uart_1
+    tx_pin: ${tx_pin_1}
+    rx_pin: ${rx_pin_1}
+    baud_rate: 19200
+    rx_buffer_size: 256

--- a/packages/board/board_options_itf_uart_2.yaml
+++ b/packages/board/board_options_itf_uart_2.yaml
@@ -1,0 +1,25 @@
+# Updated : 2025.06.18
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+uart:
+  - id: uart_2
+    tx_pin: ${tx_pin_2}
+    rx_pin: ${rx_pin_2}
+    baud_rate: 19200
+    rx_buffer_size: 256

--- a/packages/board/board_options_itf_uart_3.yaml
+++ b/packages/board/board_options_itf_uart_3.yaml
@@ -1,0 +1,25 @@
+# Updated : 2025.06.18
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+uart:
+  - id: uart_3
+    tx_pin: ${tx_pin_3}
+    rx_pin: ${rx_pin_3}
+    baud_rate: 19200
+    rx_buffer_size: 256

--- a/packages/board/board_options_itf_uart_4.yaml
+++ b/packages/board/board_options_itf_uart_4.yaml
@@ -1,0 +1,25 @@
+# Updated : 2025.06.18
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+uart:
+  - id: uart_4
+    tx_pin: ${tx_pin_4}
+    rx_pin: ${rx_pin_4}
+    baud_rate: 19200
+    rx_buffer_size: 256

--- a/packages/board/board_options_itf_uart_5.yaml
+++ b/packages/board/board_options_itf_uart_5.yaml
@@ -1,0 +1,25 @@
+# Updated : 2025.06.18
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+uart:
+  - id: uart_5
+    tx_pin: ${tx_pin_5}
+    rx_pin: ${rx_pin_5}
+    baud_rate: 19200
+    rx_buffer_size: 256

--- a/packages/board/board_options_itf_uart_6.yaml
+++ b/packages/board/board_options_itf_uart_6.yaml
@@ -1,0 +1,25 @@
+# Updated : 2025.06.18
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+uart:
+  - id: uart_6
+    tx_pin: ${tx_pin_6}
+    rx_pin: ${rx_pin_6}
+    baud_rate: 19200
+    rx_buffer_size: 256


### PR DESCRIPTION
This adds support for RP2040 boards. I'm using a RP2040 as Modbus server connected to five Victron SmartShunts, resulting in a usage of six serial ports.