### PR TITLE
Add feature "Auto float voltage"

### DIFF
--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -247,6 +247,16 @@ views:
         title: YamBMS - Auto CCL / DCL
       - type: entities
         entities:
+          - entity: select.yambms_demo_yambms_1_automatic_float_voltage
+            name: Automatic Float Voltage
+          - entity: sensor.yambms_demo_yambms_1_auto_float_voltage
+            name: Auto Float Voltage
+          - entity: number.yambms_demo_yambms_1_auto_float_update_interval
+          - entity: number.yambms_demo_yambms_1_auto_float_voltage_step
+            name: Auto Float Voltage Step
+        title: YamBMS - Auto Float
+      - type: entities
+        entities:
           - entity: number.yambms_demo_yambms_1_rebulk_soc
             name: Rebulk SoC
           - entity: number.yambms_demo_yambms_1_rebulk_v

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -247,6 +247,16 @@ views:
         title: YamBMS - Auto CCL / DCL
       - type: entities
         entities:
+          - entity: select.yambms_yambms_1_automatic_float_voltage
+            name: Automatic Float Voltage
+          - entity: sensor.yambms_yambms_1_auto_float_voltage
+            name: Auto Float Voltage
+          - entity: number.yambms_yambms_1_auto_float_update_interval
+          - entity: number.yambms_yambms_1_auto_float_voltage_step
+            name: Auto Float Voltage Step
+        title: YamBMS - Auto Float
+      - type: entities
+        entities:
           - entity: number.yambms_yambms_1_rebulk_soc
             name: Rebulk SoC
           - entity: number.yambms_yambms_1_rebulk_v

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -247,6 +247,16 @@ views:
         title: YamBMS - Auto CCL / DCL
       - type: entities
         entities:
+          - entity: select.yambms_yambms_1_automatic_float_voltage
+            name: Automatic Float Voltage
+          - entity: sensor.yambms_yambms_1_auto_float_voltage
+            name: Auto Float Voltage
+          - entity: number.yambms_yambms_1_auto_float_update_interval
+          - entity: number.yambms_yambms_1_auto_float_voltage_step
+            name: Auto Float Voltage Step
+        title: YamBMS - Auto Float
+      - type: entities
+        entities:
           - entity: number.yambms_yambms_1_rebulk_soc
             name: Rebulk SoC
           - entity: number.yambms_yambms_1_rebulk_v

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -247,6 +247,16 @@ views:
         title: YamBMS - Auto CCL / DCL
       - type: entities
         entities:
+          - entity: select.yambms_yambms_1_automatic_float_voltage
+            name: Automatic Float Voltage
+          - entity: sensor.yambms_yambms_1_auto_float_voltage
+            name: Auto Float Voltage
+          - entity: number.yambms_yambms_1_auto_float_update_interval
+          - entity: number.yambms_yambms_1_auto_float_voltage_step
+            name: Auto Float Voltage Step
+        title: YamBMS - Auto Float
+      - type: entities
+        entities:
           - entity: number.yambms_yambms_1_rebulk_soc
             name: Rebulk SoC
           - entity: number.yambms_yambms_1_rebulk_v

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -247,6 +247,16 @@ views:
         title: YamBMS - Auto CCL / DCL
       - type: entities
         entities:
+          - entity: select.yambms_yambms_1_automatic_float_voltage
+            name: Automatic Float Voltage
+          - entity: sensor.yambms_yambms_1_auto_float_voltage
+            name: Auto Float Voltage
+          - entity: number.yambms_yambms_1_auto_float_update_interval
+          - entity: number.yambms_yambms_1_auto_float_voltage_step
+            name: Auto Float Voltage Step
+        title: YamBMS - Auto Float
+      - type: entities
+        entities:
           - entity: number.yambms_yambms_1_rebulk_soc
             name: Rebulk SoC
           - entity: number.yambms_yambms_1_rebulk_v

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -115,6 +115,21 @@ You can compare `Auto CCL` to a max speed limiter in a car.
 
 Current control should work with any inverter that uses `CAN` control.
 
+## Auto Float Voltage
+
+When switching from `Bulk` to `Float`, therefore lowering the `Requested Charge Voltage (CVL)`, some inverters (e.g. Deye SUN-12K) will start to discharge the battery (into the grid) with up to max. discharge current until the
+`Requested Charge Voltage (CVL)` is reached. The reason behind this is that the inverter sees this as battery overvoltage and wants to counter it. 
+As workaround, by enabling `Automatic Float Voltage`, it will lower the `Requested Charge Voltage (CVL)` gradually in small steps until the float voltage is reached, allowing the battery more time to settle down.
+There are two modes available: `Follow` and `Immediately`.
+
+- `Follow`: Waits until the battery voltage itself is below the current `Requested Charge Voltage (CVL)` before lowering `Requested Charge Voltage (CVL)` further. It follows the battery voltage until the target float voltage is reached.
+- `Immediately`: Immediately start lowering the `Requested Charge Voltage (CVL)`, independent of the current battery voltage. That means it can go below the current battery voltage.
+
+This feature might not work with all inverters as good or is not required if these do not discharge the battery.
+
+The voltage steps can be configured (default `0.1V`) with `Auto Float Voltage Step`. The update interval can be configured (default `3 minutes`) with `Auto Float Update Interval`.
+
+
 ## Requested Values
 
 ![Image](../../images/YamBMS_Requested_Values.png "YamBMS_Requested_Values")

--- a/packages/yambms/yambms.yaml
+++ b/packages/yambms/yambms.yaml
@@ -28,6 +28,7 @@ packages:
   yambms_auto_cvl: !include yambms_auto_cvl.yaml
   yambms_auto_ccl: !include yambms_auto_ccl.yaml
   yambms_auto_dcl: !include yambms_auto_dcl.yaml
+  yambms_auto_float: !include yambms_auto_float.yaml
 
 # Execute once
 esphome:
@@ -120,6 +121,10 @@ globals:
     restore_value: no
     initial_value: '0.0'
   - id: ${yambms_id}_auto_dcl
+    type: float
+    restore_value: no
+    initial_value: '0.0'
+  - id: ${yambms_id}_auto_float
     type: float
     restore_value: no
     initial_value: '0.0'
@@ -415,7 +420,7 @@ sensor:
         return (id(${yambms_id}_bulk_voltage).state + id(${yambms_id}_inverter_offset_v).state + id(${yambms_id}_auto_cvl));
       // Float
       else if (id(${yambms_id}_charging_instruction).state == "Float")
-        return (id(${yambms_id}_float_voltage).state + id(${yambms_id}_inverter_offset_v).state);
+        return (id(${yambms_id}_float_voltage).state + id(${yambms_id}_inverter_offset_v).state) + id(${yambms_id}_auto_float);
       // Stop Charging
       else return (id(${yambms_id}_rebulk_voltage).state + id(${yambms_id}_inverter_offset_v).state);
 

--- a/packages/yambms/yambms_auto_float.yaml
+++ b/packages/yambms/yambms_auto_float.yaml
@@ -1,0 +1,151 @@
+# Updated : 2025.05.15
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+select:
+  - platform: template
+    name: ${name} ${yambms_name} Automatic Float Voltage
+    id: ${yambms_id}_auto_float_mode
+    options:
+      - "Disabled"
+      - "Follow"
+      - "Immediately"
+    restore_value: true
+    initial_option: "Disabled"
+    optimistic: true
+    entity_category: config
+    set_action:
+      - logger.log:
+          format: "Auto Float chosen option: %s"
+          args: ["x.c_str()"]
+
+number:
+  - platform: template
+    name: "${name} ${yambms_name} Auto Float Voltage Step"
+    id: "${yambms_id}_auto_float_step_v"
+    step: 0.1
+    min_value: 0.1
+    max_value: 0.5
+    restore_value: true
+    mode: "${yambms_input_number_mode}"
+    initial_value: 0.1
+    unit_of_measurement: V
+    icon: mdi:sine-wave
+    optimistic: true
+    entity_category: config
+
+  - platform: template
+    name: "${name} ${yambms_name} Auto Float Update Interval"
+    id: "${yambms_id}_auto_float_interval"
+    step: 1
+    min_value: 1
+    max_value: 10
+    restore_value: true
+    mode: "${yambms_input_number_mode}"
+    initial_value: 3
+    unit_of_measurement: min
+    icon: mdi:timer-sand
+    optimistic: true
+    entity_category: config
+
+sensor:
+  # Filter total voltage (max)
+  - platform: template
+    id: "auto_float_total_voltage"
+    update_interval: 30s
+    lambda: |-
+      return id(${yambms_id}_total_voltage).state;
+    filters:
+      - max:
+          window_size: 4
+
+  # +--------------------------------------+
+  # | Auto Float Voltage Control           |
+  # +--------------------------------------+
+  - platform: template
+    name: ${name} ${yambms_name} Auto Float Voltage
+    id: auto_float
+    update_interval: 60s  # Keep this at 60s, otherwise "Auto Float Update Interval" won't work!
+    unit_of_measurement: V
+    device_class: voltage
+    #internal: true
+    lambda: |-
+            // Variables
+            const auto mode = id(${yambms_id}_auto_float_mode).active_index();        // Mode: 0 - Disabled, 1 - Follow, 2 - Immediately
+            const double bulk_v = id(${yambms_id}_bulk_voltage).state;                // Bulk voltage
+            const double target_float_v = id(${yambms_id}_float_voltage).state;       // Target float voltage
+            const double step_v = id(${yambms_id}_auto_float_step_v).state;           // Voltage step for each decrement
+            const double max_total_v = id(auto_float_total_voltage).state;            // Total voltage (mean and max)
+            const auto update_interval = id(${yambms_id}_auto_float_interval).state;  // Update interval in minutes
+            static double float_v = bulk_v;                                           // Initialize float voltage
+            static uint8_t time_count = 0;                                            // Interval counter
+            bool decrement = false;
+            
+            // Assert that bulk voltage is greater than float voltage
+            if (bulk_v <= target_float_v) {
+              ESP_LOGD("yambms", "Auto Float: Float voltage is greater than bulk voltage. Returning float voltage.");
+              id(${yambms_id}_auto_float) = 0;
+              return target_float_v;
+            }
+
+            // Check if feature is enabled
+            if (!mode) {
+              // Return float voltage if feature is disabled
+              id(${yambms_id}_auto_float) = 0;
+              return target_float_v;
+            }
+            
+            // Detect charge status change to float
+            if (id(${yambms_id}_charge_status) != "Float") {
+              // Start with bulk voltage
+              float_v = bulk_v;
+              time_count = 0;
+            }
+
+            // Check update interval
+            if (++time_count >= update_interval) {
+              // Mode selection: Start immediately or wait for battery to drop below current float voltage
+              if (mode == 1) {
+                // Check battery voltage and wait for the battery voltage to reach current float voltage
+                if ((id(${yambms_id}_total_voltage).state > 0) && (max_total_v <= float_v)) {
+                  decrement = true;
+                }
+              } else {
+                // Start immediately
+                decrement = true;
+              }
+
+              // Reset update interval counter
+              time_count = 0;
+            }
+
+            if (decrement && (float_v > target_float_v)) {
+              // Decrement float voltage
+              float_v -= step_v;
+            }
+
+            if (float_v < target_float_v) {
+              float_v = target_float_v;
+            }
+
+            // Store difference for CVL calculation
+            id(${yambms_id}_auto_float) = float_v - target_float_v;
+
+            return float_v;
+    filters:    
+    - round: 1


### PR DESCRIPTION
## Auto Float Voltage

When switching from `Bulk` to `Float`, therefore lowering the `Requested Charge Voltage (CVL)`, some inverters (e.g. Deye SUN-12K) will start to discharge the battery (into the grid) with up to max. discharge current until the
`Requested Charge Voltage (CVL)` is reached. The reason behind this is that the inverter sees this as battery overvoltage and wants to counter it. 
As workaround, by enabling `Automatic Float Voltage`, it will lower the `Requested Charge Voltage (CVL)` gradually in small steps until the float voltage is reached, allowing the battery more time to settle down.
There are two modes available: `Follow` and `Immediately`.

- `Follow`: Waits until the battery voltage itself is below the current `Requested Charge Voltage (CVL)` before lowering `Requested Charge Voltage (CVL)` further. It follows the battery voltage until the target float voltage is reached.
- `Immediately`: Immediately start lowering the `Requested Charge Voltage (CVL)`, independent of the current battery voltage. That means it can go below the current battery voltage.

This feature might not work with all inverters as good or is not required if these do not discharge the battery.

The voltage steps can be configured (default `0.1V`) with `Auto Float Voltage Step`. The update interval can be configured (default `3 minutes`) with `Auto Float Update Interval`.

With a 2 minute time interval, `Follow` mode looks like this:

![image](https://github.com/user-attachments/assets/4456b784-9ea6-425d-a19e-9959665a9168)

And with one minute time interval. It will still wait for the voltage to drop but it will change the `RCV` faster.
![image](https://github.com/user-attachments/assets/e77c9796-322b-4703-af92-58ed8d476019)

Note: I've a `Inverter Offset V.` of 0.2V.

