### PR TITLE
Modbus client: Make charging cycles available again

### DIFF
--- a/packages/bms/bms_combine_modbus_client.yaml
+++ b/packages/bms/bms_combine_modbus_client.yaml
@@ -180,7 +180,6 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_controller${bms_id}
     id: bms${bms_id}_charging_cycles
-    internal: true
     name: "${name} ${bms_name} charging cycles"
     register_type: read
     address: 14


### PR DESCRIPTION
Charging cycles was gone from Modbus client BMS. The sensor was marked internal in this commit:

https://github.com/sleeper85/esphome-yambms/commit/a11f2b75c8c08a1a4eb7d1bb86a77cf60e3a4f45#diff-4deac2bbfebe27ff7d159a9fa6bb27fc78ae62175b0ff1e1cc8baddd7cd305fe

and the changes rolled back in this one:

https://github.com/sleeper85/esphome-yambms/commit/d727463717cedc69064e7142793e79113ddf4389#diff-4deac2bbfebe27ff7d159a9fa6bb27fc78ae62175b0ff1e1cc8baddd7cd305fe

but not the internal: true

![image](https://github.com/user-attachments/assets/fa18bab2-0ddb-4da6-bdcd-4393e73a5595)

