### PR TITLE
Add options to restrict max. charge and discharge current

### DIFF
--- a/YamBMS_LP_BASEN_RS485.yaml
+++ b/YamBMS_LP_BASEN_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_LP_DEMO.yaml
+++ b/YamBMS_LP_DEMO.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_LP_DEYE-PCS_CAN.yaml
+++ b/YamBMS_LP_DEYE-PCS_CAN.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_LP_JBD.yaml
+++ b/YamBMS_LP_JBD.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_LP_JK-PB_RS485_Modbus.yaml
+++ b/YamBMS_LP_JK-PB_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_LP_PVbrain2.yaml
+++ b/YamBMS_LP_PVbrain2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_LP_YBoard_JK-PB_RS485_Modbus.yaml
+++ b/YamBMS_LP_YBoard_JK-PB_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '60'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '300'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_Local_Packages_example.yaml
+++ b/YamBMS_Local_Packages_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,6 +98,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_BASEN_RS485.yaml
+++ b/YamBMS_RP_BASEN_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_DEMO.yaml
+++ b/YamBMS_RP_DEMO.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_JBD.yaml
+++ b/YamBMS_RP_JBD.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_JK-B_RS485_Modbus.yaml
+++ b/YamBMS_RP_JK-B_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_JK-B_UART_GPS.yaml
+++ b/YamBMS_RP_JK-B_UART_GPS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_JK-PB_RS485_Modbus.yaml
+++ b/YamBMS_RP_JK-PB_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_JK_BLE.yaml
+++ b/YamBMS_RP_JK_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_PVbrain2.yaml
+++ b/YamBMS_RP_PVbrain2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_RP_SEPLOS_V1_V2_RS485.yaml
+++ b/YamBMS_RP_SEPLOS_V1_V2_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/YamBMS_Remote_Packages_example.yaml
+++ b/YamBMS_Remote_Packages_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.26
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -97,6 +97,10 @@ substitutions:
   yambms_eoc_timer: '30'
   # Time in seconds during which the end of charge conditions must be respected (cut-off + cells not equalizing)
   yambms_cutoff_timer: '60'
+  # Max. charge current : corresponds to the maximum charge current that the inverter can deliver.
+  yambms_max_inverter_charge_current: '200' # in Ampere
+  # Max. discharge current : corresponds to the maximum discharge current that the inverter can use.
+  yambms_max_inverter_discharge_current: '250' # in Ampere
   # +--------------------------------------+
   # | Shunt Settings                      |
   # +--------------------------------------+

--- a/packages/bms/bms_combine.yaml
+++ b/packages/bms/bms_combine.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.19
-# Version : 1.5.7
+# Updated : 2025.06.29
+# Version : 1.5.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # This YAML is free software: you can redistribute it and/or
@@ -90,7 +90,11 @@ interval:
                 id(${yambms_id}_var_charging_allowed_counter) += 1;
                 // TOTAL max_charge_current
                 id(${yambms_id}_var_total_max_charge_current) += id(bms${bms_id}_max_charge_current).state;
-
+                // Limit to inverter charge current
+                if(id(${yambms_id}_var_total_max_charge_current) > ${yambms_max_inverter_charge_current})
+                {
+                  id(${yambms_id}_var_total_max_charge_current) = ${yambms_max_inverter_charge_current};
+                }
               }
               // TOTAL bms_blocking_charge_counter
               else id(${yambms_id}_var_bms_blocking_charge_counter) += 1;
@@ -101,6 +105,11 @@ interval:
                 id(${yambms_id}_var_discharging_allowed_counter) += 1;
                 // TOTAL max_discharge_current
                 id(${yambms_id}_var_total_max_discharge_current) += id(bms${bms_id}_max_discharge_current).state;
+                // Limit to inverter discharge current
+                if(id(${yambms_id}_var_total_max_discharge_current) > ${yambms_max_inverter_discharge_current})
+                {
+                  id(${yambms_id}_var_total_max_discharge_current) = ${yambms_max_inverter_discharge_current};
+                }
               }
               // TOTAL bms_blocking_discharge_counter
               else id(${yambms_id}_var_bms_blocking_discharge_counter) += 1;


### PR DESCRIPTION
With multiple battery packs, my max. charge current was somewhere about 700A+. However my inverter only supports about 240A. While this did not create function problems, it is hard to control the charge and discharge current with
'Max charge current (%)' and 'Max discharge current (%)' because the usable range was about 1-20%.

This adds 'yambms_max_inverter_charge_current' and 'yambms_max_inverter_discharge_current' substitutions. They are used to restrict the range of the charge/discharge current for easier control when the battery currents are much higher than the inverter currents. With this the full range of the mentioned control sliders/number can be better used.