### PR TITLE
Update YamBMS_HA_Dashboards

### DIFF
--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -456,188 +456,62 @@ views:
             cards:
               - type: markdown
                 content: >-
+
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor.{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor.{}_min_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor.{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% if has_value('sensor.{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
+                  {{ states('sensor.{}_cell_r{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
                   <center>
 
-                  01. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '1' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '1' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_01', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_01', rounded=True) }} Ω <br>
-                  
-                  02. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '2' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '2' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_02', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_02', rounded=True) }} Ω <br>
-
-                  03. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '3' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '3' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_03', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_03', rounded=True) }} Ω <br>
-                  
-                  04. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '4' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '4' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_04', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_04', rounded=True) }} Ω <br>
-                  
-                  05. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '5' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '5' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_05', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_05', rounded=True) }} Ω <br>
-                  
-                  06. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '6' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '6' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_06', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_06', rounded=True) }} Ω <br>
-                  
-                  07. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '7' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '7' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_07', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_07', rounded=True) }} Ω <br>
-                  
-                  08. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '8' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '8' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_08', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_08', rounded=True) }} Ω <br>
+                  {{ cell_v(lead_zero=1, num=1, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=2, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=3, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=4, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=5, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=6, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=7, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=8, entity='yambms_jk_bms_1') }}                  
 
                   </center>
               - type: markdown
                 content: >-
+                  
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor.{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor.{}_min_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor.{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% if has_value('sensor.{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
+                  {{ states('sensor.{}_cell_r{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
                   <center>
                   
-                  09. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '9' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '9' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_09', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_09', rounded=True) }} Ω <br>
-                  
-                  10. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '10' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '10' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_10', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_10', rounded=True) }} Ω <br>
-                  
-                  11. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '11' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '11' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_11', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_11', rounded=True) }} Ω <br>                  
-                  
-                  12. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '12' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '12' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_12', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_12', rounded=True) }} Ω <br>                  
-                  
-                  13. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '13' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '13' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_13', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_13', rounded=True) }} Ω <br>                  
-                  
-                  14. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '14' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '14' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_14', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_14', rounded=True) }} Ω <br>                  
-                  
-                  15. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '15' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '15' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_15', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_15', rounded=True) }} Ω <br>                  
-                  
-                  16. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_1_max_voltage_cell', rounded=True) == '16' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_1_min_voltage_cell', rounded=True) == '16' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_1_cell_voltage_16', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_1_cell_resistance_16', rounded=True) }} Ω <br>                  
+                  {{ cell_v(lead_zero=1, num=9, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=10, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=11, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=12, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=13, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=14, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=15, entity='yambms_jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=16, entity='yambms_jk_bms_1') }}              
                   
                   </center>
           - type: entity-filter
@@ -797,189 +671,58 @@ views:
             cards:
               - type: markdown
                 content: >-
-                  <center>                  
-                  01. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '1' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '1' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_01', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_01', rounded=True) }} Ω <br>                  
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor.{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor.{}_min_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
                   
-                  02. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '2' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '2' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_02', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_02', rounded=True) }} Ω <br>                  
+                  {{ states('sensor.{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% if has_value('sensor.{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
+                  {{ states('sensor.{}_cell_r{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  <br>
                   
-                  03. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '3' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '3' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_03', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_03', rounded=True) }} Ω <br>                  
+                  {% endmacro %}
                   
-                  04. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '4' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '4' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_04', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_04', rounded=True) }} Ω <br>                  
-                  
-                  05. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '5' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '5' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_05', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_05', rounded=True) }} Ω <br>                  
-                  
-                  06. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '6' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '6' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_06', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_06', rounded=True) }} Ω <br>                  
-                  
-                  07. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '7' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '7' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_07', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_07', rounded=True) }} Ω <br>                  
-                  
-                  08. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '8' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '8' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_08', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_08', rounded=True) }} Ω <br>                  
-                  
+                  <center>
+                  {{ cell_v(lead_zero=1, num=1, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=2, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=3, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=4, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=5, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=6, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=7, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=8, entity='yambms_jk_bms_2') }}
                   
                   </center>
               - type: markdown
                 content: >-
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor.{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor.{}_min_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor.{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% if has_value('sensor.{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
+                  {{ states('sensor.{}_cell_r{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
                   <center>
-                  
-                  09. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '9' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '9' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_09', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_09', rounded=True) }} Ω <br>                  
-                  
-                  
-                  10. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '10' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '10' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_10', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_10', rounded=True) }} Ω <br>                  
-                  
-                  11. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '11' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '11' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_11', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_11', rounded=True) }} Ω <br>                  
-                  
-                  12. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '12' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '12' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_12', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_12', rounded=True) }} Ω <br>                  
-                  
-                  13. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '13' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '13' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_13', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_13', rounded=True) }} Ω <br>                  
-                  
-                  14. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '14' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '14' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_14', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_14', rounded=True) }} Ω <br>                  
-                  
-                  15. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '15' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '15' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_15', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_15', rounded=True) }} Ω <br>                  
-                  
-                  16. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '16' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '16' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_16', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_16', rounded=True) }} Ω <br>                  
+                  {{ cell_v(lead_zero=1, num=9, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=10, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=11, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=12, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=13, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=14, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=15, entity='yambms_jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=16, entity='yambms_jk_bms_2') }}
                   
                   </center>
           - type: entity-filter
@@ -1139,187 +882,58 @@ views:
             cards:
               - type: markdown
                 content: >-
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor.{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor.{}_min_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor.{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% if has_value('sensor.{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
+                  {{ states('sensor.{}_cell_r{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
                   <center>
-                  
-                  01. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '1' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '1' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_01', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_01', rounded=True) }} Ω <br>                  
-                  
-                  02. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '2' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '2' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_02', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_02', rounded=True) }} Ω <br>                  
-                  
-                  03. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '3' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '3' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_03', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_03', rounded=True) }} Ω <br>                  
-                  
-                  04. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '4' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '4' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_04', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_04', rounded=True) }} Ω <br>                  
-                  
-                  05. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '5' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '5' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_05', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_05', rounded=True) }} Ω <br>                  
-                  
-                  06. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '6' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '6' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_06', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_06', rounded=True) }} Ω <br>                  
-                  
-                  07. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '7' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '7' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_07', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_07', rounded=True) }} Ω <br>                  
-                  
-                  08. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '8' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '8' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_08', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_08', rounded=True) }} Ω <br>
+                  {{ cell_v(lead_zero=1, num=1, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=1, num=2, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=1, num=3, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=1, num=4, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=1, num=5, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=1, num=6, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=1, num=7, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=1, num=8, entity='yambms_jk_bms_3') }}
                   
                   </center>
               - type: markdown
                 content: >-
-                  <center>                  
-                  09. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_3_max_voltage_cell', rounded=True) == '9' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_3_min_voltage_cell', rounded=True) == '9' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_3_cell_voltage_09', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_3_cell_resistance_09', rounded=True) }} Ω <br>                  
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor.{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor.{}_min_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
                   
-                  10. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '10' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '10' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_10', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_10', rounded=True) }} Ω <br>                  
+                  {{ states('sensor.{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% if has_value('sensor.{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
+                  {{ states('sensor.{}_cell_r{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  <br>
                   
-                  11. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '11' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '11' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_11', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_11', rounded=True) }} Ω <br>                  
+                  {% endmacro %}
                   
-                  12. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '12' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '12' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_12', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_12', rounded=True) }} Ω <br>                  
-                  
-                  13. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '13' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '13' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_13', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_13', rounded=True) }} Ω <br>                  
-                  
-                  14. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '14' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '14' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_14', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_14', rounded=True) }} Ω <br>                  
-                  
-                  15. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '15' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '15' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_15', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_15', rounded=True) }} Ω <br>                  
-                  
-                  16. &nbsp;&nbsp;&nbsp; {% if states('sensor.yambms_jk_bms_2_max_voltage_cell', rounded=True) == '16' %}
-                  <font color="red">
-                  {% elif states('sensor.yambms_jk_bms_2_min_voltage_cell', rounded=True) == '16' %}
-                  <font color="#3090C9">
-                  {% else %}
-                  <font>
-                  {% endif %}
-                  {{ states('sensor.yambms_jk_bms_2_cell_voltage_16', rounded=True) }} V</font>
-                  &nbsp;&nbsp;&nbsp;/&nbsp;&nbsp;&nbsp;
-                  {{ states('sensor.yambms_jk_bms_2_cell_resistance_16', rounded=True) }} Ω <br>
+                  <center>
+                  {{ cell_v(lead_zero=1, num=9, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=0, num=10, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=0, num=11, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=0, num=12, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=0, num=13, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=0, num=14, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=0, num=15, entity='yambms_jk_bms_3') }}
+                  {{ cell_v(lead_zero=0, num=16, entity='yambms_jk_bms_3') }}
                   
                   </center>
           - type: entity-filter


### PR DESCRIPTION
DO NOT merge before Copy paste and testing the YAML works in HA dashboard editor.

Considerably shortens the file by 3x16 repetitions of same code to 3x2 repeats of same macro definition. If only there was a central key/tag to store macros in yaml, we only need to store the macro one time instead of six!

Things tested working on my end:

* Configurable high and low cell voltage colours
* adjustable voltage spacing number