### PR TITLE
RS485 Heartbeat

### DIFF
--- a/packages/yambms/yambms_rs485_pylon.yaml
+++ b/packages/yambms/yambms_rs485_pylon.yaml
@@ -1,5 +1,5 @@
 # Updated : 2025.08.02
-# Version : 1.2.2
+# Version : 1.3.0
 # GitHub  : https://github.com/fahmula/esphome-pylontech-rs485
 
 # YamBMS ( Yet another multi-BMS Merging Solution )


### PR DESCRIPTION
This PR adds inverter heartbeat monitoring support for RS-485, closely modeled after the existing CANbus 0x305 implementation.

It introduces:
sensor.inverter_heartbeat — measures time between inverter responses (in ms)
binary_sensor.inverter_online — flags online/offline based on response timeout
switch.rs485_switch_inverter_heartbeat_monitoring — enables or disables tracking

Everything works well so far, but I wanted to raise a point for discussion:

The current Home Assistant dashboard examples assume hardcoded entity names like yambms_canbus_1_status, which means RS-485 users will need to manually update those to something like inverter_online or ${rs485_id}_status.

Would it make sense to:
Generalize the dashboards to use more flexible IDs (e.g. templated ${protocol_id}_status) so they can work for both CAN and RS-485?
Or should we keep the current dashboards CAN-specific, and just add a note or alternate example for RS-485 users?
In the future, do you see value in consolidating the CAN and RS-485 heartbeat logic into a shared proxy abstraction, or should they remain parallel?