### PR TITLE
Round auto_ccl/auto_dcl value

### DIFF
--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.10
-# Version : 1.2.4
+# Updated : 2025.07.30
+# Version : 1.2.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,7 +98,7 @@ sensor:
     filters:
     - lambda: !lambda |-
               // Variables
-              double auto_ccl = round(min(id(auto_ccl_moving_average).state, x) * 10) / 10;
+              double auto_ccl = round((min(id(auto_ccl_moving_average).state, x) * 10) / 10);
 
               id(${yambms_id}_auto_ccl) = auto_ccl;
               return auto_ccl;

--- a/packages/yambms/yambms_auto_dcl.yaml
+++ b/packages/yambms/yambms_auto_dcl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.06.10
-# Version : 1.2.4
+# Updated : 2025.07.30
+# Version : 1.2.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -98,7 +98,7 @@ sensor:
     filters:
     - lambda: !lambda |-
               // Variables
-              double auto_dcl = round(min(id(auto_dcl_moving_average).state, x) * 10) / 10;
+              double auto_dcl = round((min(id(auto_dcl_moving_average).state, x) * 10) / 10);
 
               id(${yambms_id}_auto_dcl) = auto_dcl;
               return auto_dcl;


### PR DESCRIPTION
Requested charge current had 0,1A steps before with Auto CCL/DCL enabled, round to nearest full integral value.

I think most inverter/charger are not able to control the current with 100mA accuracy and there is no real use case for this precision.
Please correct me if I'm wrong :-)