### PR TITLE
Add Basen controller version with talk/flow control pin

### DIFF
--- a/packages/bms/bms_combine_BASEN_RS485_controller_talk_pin.yaml
+++ b/packages/bms/bms_combine_BASEN_RS485_controller_talk_pin.yaml
@@ -1,0 +1,40 @@
+# Updated : 2025.10.6
+# Version : 1.1.1
+# GitHub  : https://github.com/GHswitt/esphome-basen
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+substitutions:
+  bms_model: "BASEN"
+  bms_protocol: "RS485"
+  basen_controller_flow_control_pin: null
+
+# +--------------------------------------+
+# | Component settings                   |
+# +--------------------------------------+
+
+external_components:
+  - source: github://GHswitt/esphome-basen@main
+    refresh: 0s
+
+uart:
+  - id: !extend ${basen_uart_id}
+    baud_rate: ${basen_uart_baud_rate}
+
+basen_controller:
+  - uart_id: ${basen_uart_id}
+    flow_control_pin: ${basen_controller_flow_control_pin}
+    id: ${basen_controller_id}


### PR DESCRIPTION
The Waveshare RS485-CAN board uses a pin to control the RS485 transceiver. This requires that components like the Basen controller are using this pin. This commit adds a version of the BMS file with this flow_control_pin.