### PR TITLE
Adding FLIP_C3 board

### DIFF
--- a/packages/board/board_ESP32-C3_FlipC3.yaml
+++ b/packages/board/board_ESP32-C3_FlipC3.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.11.21
-# Version : 1.0.0
+# Updated : 2025.11.22
+# Version : 1.1.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+# https://wiki.vdbx.io/product/flip_c3
+
 substitutions:
   board_chip: "ESP32-C3"
   board_name: "FlipC3"
@@ -28,16 +30,16 @@ substitutions:
   tx_pin_2: '1'
   rx_pin_2: '0'
   # uart_esp_3
-  tx_pin_3: '0'
-  rx_pin_3: '0'
+  tx_pin_3: '2'
+  rx_pin_3: '3'
   # canbus_esp32_can
-  tx_pin_4: '0'
-  rx_pin_4: '0'
+  tx_pin_4: '7'
+  rx_pin_4: '6'
   # canbus_mcp2515
-  spi_mosi_pin: '0'
-  spi_miso_pin: '0'
-  spi_clk_pin: '0'
-  mcp2515_cs_pin: '0'
+  spi_mosi_pin: '2'
+  spi_miso_pin: '3'
+  spi_clk_pin: '4'
+  mcp2515_cs_pin: '5'
 
 packages:
   device_base: !include ../base/device_base.yaml


### PR DESCRIPTION
The FLIP_C3 is a simple ESP32-C3 board that has an integrated power supply that has a 60V input.  This board can be connected directly to a 48V battery and then be used with the M5Stack Isolated RS485 Unit (U094) to get a RS485 connection back to the master unit.  I successfully used 4 of these units to communicate with the JK-BMS B-Series BMS's.  The FLIP_C3 has an onboard 5V regulator that can power the RS485 module, 2 UART exposed on connectors that can be used for TTL to the BMS and TTL to the RS485 module. In the US it is available on Amazon, product page: https://wiki.vdbx.io/product/flip_c3