### PR TITLE
Rename "battery capacity remaining" to "battery capacity remaining (Ah)"

### DIFF
--- a/packages/bms/bms_combine_JK_RS485_Modbus_bms_minimal.yaml
+++ b/packages/bms/bms_combine_JK_RS485_Modbus_bms_minimal.yaml
@@ -162,7 +162,7 @@ sensor:
       name: "${name} ${bms_name} battery capacity state of charge"
     battery_capacity_remaining:
       id: bms${bms_id}_capacity_remaining_ah
-      name: "${name} ${bms_name} battery capacity remaining"
+      name: "${name} ${bms_name} battery capacity remaining (Ah)"
     charging_cycles:
       id: bms${bms_id}_charging_cycles_raw
       internal: true

--- a/packages/bms/bms_sensors_BASEN_RS485_full.yaml
+++ b/packages/bms/bms_sensors_BASEN_RS485_full.yaml
@@ -415,7 +415,7 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 0
     id: bms${bms_id}_capacity_remaining_ah
-    name: "${name} ${bms_name} battery capacity remaining"
+    name: "${name} ${bms_name} battery capacity remaining (Ah)"
     lambda: |-
       return (id(bms${bms_id}_state_of_charge).state * id(bms${bms_id}_battery_capacity).state) / 100;
     filters:

--- a/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
@@ -354,7 +354,7 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 0
     id: bms${bms_id}_capacity_remaining_ah
-    name: "${name} ${bms_name} battery capacity remaining"
+    name: "${name} ${bms_name} battery capacity remaining (Ah)"
     filters:
       - or:
         - throttle: 10s

--- a/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
@@ -229,7 +229,7 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 0
     id: bms${bms_id}_capacity_remaining_ah
-    name: "${name} ${bms_name} battery capacity remaining"
+    name: "${name} ${bms_name} battery capacity remaining (Ah)"
     lambda: |-
       return (id(bms${bms_id}_state_of_charge).state * id(bms${bms_id}_battery_capacity).state) / 100;
     filters:

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
@@ -139,7 +139,7 @@ sensor:
       name: "${name} ${bms_name} battery capacity state of charge"
     battery_capacity_remaining:
       id: bms${bms_id}_capacity_remaining_ah
-      name: "${name} ${bms_name} battery capacity remaining"
+      name: "${name} ${bms_name} battery capacity remaining (Ah)"
     charging_cycles:
       id: bms${bms_id}_charging_cycles_raw
       internal: true

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_bms_full.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_bms_full.yaml
@@ -317,7 +317,7 @@ sensor:
       name: "${name} ${bms_name} battery capacity state of charge"
     battery_capacity_remaining:
       id: bms${bms_id}_capacity_remaining_ah
-      name: "${name} ${bms_name} battery capacity remaining"
+      name: "${name} ${bms_name} battery capacity remaining (Ah)"
 
     charging_cycles:
       id: bms${bms_id}_charging_cycles_raw

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
@@ -161,7 +161,7 @@ sensor:
       name: "${name} ${bms_name} battery capacity state of charge"
     battery_capacity_remaining:
       id: bms${bms_id}_capacity_remaining_ah
-      name: "${name} ${bms_name} battery capacity remaining"
+      name: "${name} ${bms_name} battery capacity remaining (Ah)"
     charging_cycles:
       id: bms${bms_id}_charging_cycles_raw
       internal: true


### PR DESCRIPTION
After commit a90071bd872cecb43bb3e198e896d15bd649411f (New BMS battery_capacity_remaining manipulated sensor (issue #96)) there are compile issues:

```
Duplicate sensor entity with name ' JK-BMS 1 battery capacity remaining' found. Conflicts with entity ' JK-BMS 1 Battery Capacity Remaining' (id: bms1_battery_capacity_remaining) from component 'sensor.template'. Each entity on a device must have a unique name within its platform.
    Original names: ' JK-BMS 1 battery capacity remaining' and ' JK-BMS 1 Battery Capacity Remaining'
    Both convert to ASCII ID: '_jk-bms_1_battery_capacity_remaining'
    To fix: Add unique ASCII characters (e.g., '1', '2', or 'A', 'B')
            to distinguish them.

sensor.template: [source packages\bms\bms_sensors_BASEN_RS485_full.yaml:414]

  Duplicate sensor entity with name ' Basen-BMS 1 battery capacity remaining' found. Conflicts with entity ' Basen-BMS 1 Battery Capacity Remaining' (id: bms3_battery_capacity_remaining) from component 'sensor.template'. Each entity on a device must have a unique name within its platform.
    Original names: ' Basen-BMS 1 battery capacity remaining' and ' Basen-BMS 1 Battery Capacity Remaining'
    Both convert to ASCII ID: '_basen-bms_1_battery_capacity_remaining'
    To fix: Add unique ASCII characters (e.g., '1', '2', or 'A', 'B')
            to distinguish them.
  platform: template
  unit_of_measurement: Ah
  device_class: battery
  state_class: measurement
```

So I added '(Ah)' to the name. Not sure if this is the right solution.

Another question for this area:
`packages\bms\bms_modbus_server.yaml` and `packages\bms\bms_combine_modbus_client.yaml` are using `bms${bms_id}_battery_capacity_remaining` instead of `bms${bms_id}_battery_capacity_remaining_ah` like the BMS sensors. Is this intentional? If yes I find the naming a little bit confusing.