### PR TITLE
Round requested charge/discharge current to nearest integer

### DIFF
--- a/packages/yambms/yambms_combine.yaml
+++ b/packages/yambms/yambms_combine.yaml
@@ -314,7 +314,7 @@ interval:
                 max_charge_current = rate_max_charge_current;
             }
             
-            id(${yambms_id}_max_charge_current).publish_state(max_charge_current);
+            id(${yambms_id}_max_charge_current).publish_state(round(max_charge_current));
 
             // TOTAL max_discharge_current
             float max_discharge_current;
@@ -359,7 +359,7 @@ interval:
                 max_discharge_current = rate_max_discharge_current;
             }
             
-            id(${yambms_id}_max_discharge_current).publish_state(max_discharge_current);
+            id(${yambms_id}_max_discharge_current).publish_state(round(max_discharge_current));
 
             // MIN/MAX values
             // MAX balance_trigger_voltage

--- a/packages/yambms/yambms_core.yaml
+++ b/packages/yambms/yambms_core.yaml
@@ -1,4 +1,4 @@
-# Updated : 2025.11.24
+# Updated : 2025.11.25
 # Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -455,18 +455,18 @@ sensor:
     unit_of_measurement: A
     device_class: current
     state_class: measurement
-    accuracy_decimals: 1
+    accuracy_decimals: 0
     filters:
       - or:
         - throttle: 10s
-        - delta: 0.1
+        - delta: 1
     lambda: |-
       // Charging Allowed
       if ((id(${yambms_id}_charging_instruction).state == "Bulk") | (id(${yambms_id}_charging_instruction).state == "Float")) {
         float requested_charge_current = id(${yambms_id}_max_charge_current).state + id(${yambms_id}_auto_ccl) + id(${yambms_id}_auto_eoc);
         if (requested_charge_current < 0) 
           return 0;
-        return requested_charge_current;
+        return round(requested_charge_current);
       }
       // Charging Not Allowed
       else return 0;
@@ -481,15 +481,15 @@ sensor:
     unit_of_measurement: A
     device_class: current
     state_class: measurement
-    accuracy_decimals: 1
+    accuracy_decimals: 0
     filters:
       - or:
         - throttle: 10s
-        - delta: 0.1
+        - delta: 1
     lambda: |-
       // Discharging Allowed
       if (id(${yambms_id}_discharging_instruction).state == true)
-        return (id(${yambms_id}_max_discharge_current).state + id(${yambms_id}_auto_dcl));
+        return (round(id(${yambms_id}_max_discharge_current).state + id(${yambms_id}_auto_dcl)));
       // Discharging Not Allowed
       else return 0;
 


### PR DESCRIPTION
Because of temperature based current limitation, the requested charge/discharge current could be non-integer values. For the used high-power applications, sub 1A precision is not required and may add noise.

Before:

<img width="751" height="918" alt="image" src="https://github.com/user-attachments/assets/0de1b1d0-3c72-4725-ae10-e98f3cf807cb" />

After:

<img width="742" height="895" alt="image" src="https://github.com/user-attachments/assets/ba07f49e-41da-43f9-832b-7488457cf1b5" />
