### PR TITLE
Rename the switch "Force Bulk (top bal)" to "Force Bulk+Balancing"

### DIFF
--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -1,4 +1,4 @@
-# Updated : 2025.12.15
+# Updated : 2025.12.17
 # Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -321,7 +321,7 @@ views:
           - entity: number.yambms_demo_yambms_1_rebulk_v
             name: Rebulk V.
           - entity: switch.yambms_demo_yambms_1_force_bulk_top_bal
-            name: Force Bulk (top bal)
+            name: Force Bulk+Balancing
         title: YamBMS - ReBulk
       - type: entities
         entities:

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -1,4 +1,4 @@
-# Updated : 2025.12.04
+# Updated : 2025.12.17
 # Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -295,7 +295,7 @@ views:
           - entity: number.yambms_yambms_1_rebulk_v
             name: Rebulk V.
           - entity: switch.yambms_yambms_1_force_bulk_top_bal
-            name: Force Bulk (top bal)
+            name: Force Bulk+Balancing
         title: YamBMS - ReBulk
       - type: entities
         entities:

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -1,4 +1,4 @@
-# Updated : 2025.12.04
+# Updated : 2025.12.17
 # Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -295,7 +295,7 @@ views:
           - entity: number.yambms_yambms_1_rebulk_v
             name: Rebulk V.
           - entity: switch.yambms_yambms_1_force_bulk_top_bal
-            name: Force Bulk (top bal)
+            name: Force Bulk+Balancing
         title: YamBMS - ReBulk
       - type: entities
         entities:

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -1,4 +1,4 @@
-# Updated : 2025.11.25
+# Updated : 2025.12.17
 # Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -295,7 +295,7 @@ views:
           - entity: number.yambms_yambms_1_rebulk_v
             name: Rebulk V.
           - entity: switch.yambms_yambms_1_force_bulk_top_bal
-            name: Force Bulk (top bal)
+            name: Force Bulk+Balancing
         title: YamBMS - ReBulk
       - type: entities
         entities:

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -1,4 +1,4 @@
-# Updated : 2025.11.25
+# Updated : 2025.12.17
 # Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -295,7 +295,7 @@ views:
           - entity: number.yambms_yambms_1_rebulk_v
             name: Rebulk V.
           - entity: switch.yambms_yambms_1_force_bulk_top_bal
-            name: Force Bulk (top bal)
+            name: Force Bulk+Balancing
         title: YamBMS - ReBulk
       - type: entities
         entities:

--- a/packages/yambms/yambms_core.yaml
+++ b/packages/yambms/yambms_core.yaml
@@ -1,4 +1,4 @@
-# Updated : 2025.11.25
+# Updated : 2025.12.17
 # Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -157,7 +157,7 @@ switch:
     optimistic: true
     entity_category: config
   - platform: template
-    name: "${name} ${yambms_name} Force Bulk (top bal)"
+    name: "${name} ${yambms_name} Force Bulk+Balancing"
     id: ${yambms_id}_switch_force_bulk
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true


### PR DESCRIPTION
For me it was not clear that the Force Bulk switch waited for balancing to start. It was in the name (top bal), but I set Bulk equal with having always the balancing process in the end, which it is not, depending on the circumstances.

I think renaming it makes it clearer that this switches does something more than just setting the current charge instruction to Bulk as seen the the Force Bulk Logic:

        // +-----------------------------------------------+
        // | Force Bulk Logic                              |
        // +-----------------------------------------------+
        if (id(${yambms_id}_switch_force_bulk).state)
        {
          // Stop Force Bulk when the BMS starts to equalize the cells
          if (id(${yambms_id}_equalizing).state)
          {
            id(${yambms_id}_charge_status) = "Balancing";
            id(${yambms_id}_switch_force_bulk).turn_off();
          }
          // Force Bulk
          else id(${yambms_id}_charge_status) = "Force Bulk";
        }