### PR TITLE
Fix JK powertube temp device id

### DIFF
--- a/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
@@ -196,6 +196,7 @@ sensor:
       device_id: bms_${bms_id}
       name: "${name} ${bms_name} temperature sensor 5"
     temperature_powertube:
+      device_id: bms_${bms_id}
       name: "${name} ${bms_name} temperature powertube"
     battery_capacity_state_of_charge:
       id: bms${bms_id}_state_of_charge


### PR DESCRIPTION
JK powertube temp device id was missing, so was not associated with a sub-device.