### PR TITLE
Automatically disable shunt when connected BMSs are going offline

### DIFF
--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.14
-# Version : 1.6.0
+# Updated : 2026.01.24
+# Version : 1.6.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -926,4 +926,6 @@ views:
                 name: Shunt 1 Combine enabled
               - entity: binary_sensor.shunt_1_can_be_combined
                 name: Shunt 1 Can be combined
+              - entity: sensor.shunt_1_state
+                name: Shunt 1 State
         column_span: 1

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.14
-# Version : 1.6.0
+# Updated : 2026.01.24
+# Version : 1.6.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -1105,5 +1105,7 @@ views:
                 name: Shunt 1 Combine enabled
               - entity: binary_sensor.shunt_1_can_be_combined
                 name: Shunt 1 Can be combined
+              - entity: sensor.shunt_1_state
+                name: Shunt 1 State
         title: Shunt 1
         column_span: 1

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.14
-# Version : 1.6.0
+# Updated : 2026.01.24
+# Version : 1.6.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -1953,5 +1953,7 @@ views:
                 name: Shunt 1 Combine enabled
               - entity: binary_sensor.shunt_1_can_be_combined
                 name: Shunt 1 Can be combined
+              - entity: sensor.shunt_1_state
+                name: Shunt 1 State
         title: Shunt 1
         column_span: 1

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.14
-# Version : 1.6.0
+# Updated : 2026.01.24
+# Version : 1.6.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -1096,5 +1096,7 @@ views:
                 name: Shunt 1 Combine enabled
               - entity: binary_sensor.shunt_1_can_be_combined
                 name: Shunt 1 Can be combined
+              - entity: sensor.shunt_1_state
+                name: Shunt 1 State
         title: Shunt 1
         column_span: 1

--- a/documents/README/YamBMS_behavior.md
+++ b/documents/README/YamBMS_behavior.md
@@ -30,6 +30,15 @@ As soon as you import a `Shunt` and it can be combined (see condition) the value
 > [!NOTE]
 > If all BMS are `uncombined` the shunt data will no longer be published.
 
+If one shunt is used for multiple batteries, it is possible to provide the BMS IDs the shunt code with the variable `bms_ids`, example: `bms_ids: '{1, 2, 3}'`.
+When the BMS IDs are provided to the shunt and one or more of the BMS are offline, the shunt `Combine` switch will be turned `OFF`.
+This is helpful when one BMS/battery shuts down for a longer time. The `SoC` of the shunt will then not be correct anymore and this avoids that the batteries are
+discharged further then wanted.
+
+> [!NOTE]
+> You need to manually enable the `Combine` switch again if it was disabled automatically.
+> If you do not want that behaviour, do not provide `bms_ids` to the shunt.
+
 ### BMS
 
 Combine condition :

--- a/examples/multi-node/LP_example_multi-node_YamBMS_modbus_client.yaml
+++ b/examples/multi-node/LP_example_multi-node_YamBMS_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.14
-# Version : 1.1.3
+# Updated : 2026.01.24
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -36,6 +36,10 @@ packages:
     vars:
       shunt_id: '1' # must be a number
       shunt_name: 'Shunt 1'
+      # Optional: BMS IDs connected to this shunt
+      # If provided, the shunt will only be used when all listed BMS are online
+      # If not provided, the shunt will be used independently of the BMS online status
+      bms_ids: '{1, 2, 3}'
 
   bms1: !include
     file: packages/bms/bms_combine_modbus_client.yaml

--- a/examples/multi-node/RP_example_multi-node_YamBMS_modbus_client.yaml
+++ b/examples/multi-node/RP_example_multi-node_YamBMS_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.14
-# Version : 1.1.3
+# Updated : 2026.01.24
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -40,6 +40,10 @@ packages:
         vars:
           shunt_id: '1' # must be a number
           shunt_name: 'Shunt 1'
+          # Optional: BMS IDs connected to this shunt
+          # If provided, the shunt will only be used when all listed BMS are online
+          # If not provided, the shunt will be used independently of the BMS online status
+          bms_ids: '{1, 2, 3}'
       # BMS 1
       - path: 'packages/bms/bms_combine_modbus_client.yaml'
         vars:

--- a/examples/single-node/LP_Shunt_example.yaml
+++ b/examples/single-node/LP_Shunt_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.01.25
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -29,6 +29,10 @@
       shunt_id: '1' # must be a number
       shunt_name: 'Shunt 1'
       shunt_uart_id: 'uart_esp_1'
+      # Optional: BMS IDs connected to this shunt
+      # If provided, the shunt will only be used when all listed BMS are online
+      # If not provided, the shunt will be used independently of the BMS online status
+      bms_ids: '{1, 2}'
 
   shunt1: !include
     file: packages/shunt/shunt_combine_Victron_SmartShunt_UART.yaml
@@ -36,6 +40,10 @@
       shunt_id: '1' # must be a number
       shunt_name: 'Shunt 1'
       shunt_uart_id: 'uart_esp_1'
+      # Optional: BMS IDs connected to this shunt
+      # If provided, the shunt will only be used when all listed BMS are online
+      # If not provided, the shunt will be used independently of the BMS online status
+      bms_ids: '{1, 2}'
 
   shunt1: !include
     file: packages/shunt/shunt_combine_Victron_SmartShunt_BLE.yaml
@@ -44,3 +52,7 @@
       shunt_name: 'Shunt 1'
       shunt_mac_address: '60:A4:23:91:8F:55' # Your MAC address
       shunt_encryption_key: '0df4d0395b7d1a876c0c33ecb9e70dcd' # Your encryption key
+      # Optional: BMS IDs connected to this shunt
+      # If provided, the shunt will only be used when all listed BMS are online
+      # If not provided, the shunt will be used independently of the BMS online status
+      bms_ids: '{1, 2}'

--- a/examples/single-node/RP_Shunt_example.yaml
+++ b/examples/single-node/RP_Shunt_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.01.25
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -35,6 +35,10 @@
           shunt_id: '1' # must be a number
           shunt_name: 'Shunt 1'
           shunt_uart_id: 'uart_esp_1'
+          # Optional: BMS IDs connected to this shunt
+          # If provided, the shunt will only be used when all listed BMS are online
+          # If not provided, the shunt will be used independently of the BMS online status
+          bms_ids: '{1, 2}'
 
   # Victron SmartShunt UART
   shunt:
@@ -48,6 +52,10 @@
           shunt_id: '1' # must be a number
           shunt_name: 'Shunt 1'
           shunt_uart_id: 'uart_esp_1'
+          # Optional: BMS IDs connected to this shunt
+          # If provided, the shunt will only be used when all listed BMS are online
+          # If not provided, the shunt will be used independently of the BMS online status
+          bms_ids: '{1, 2}'
 
   # Victron SmartShunt BLE
   shunt:
@@ -62,3 +70,7 @@
           shunt_name: 'Shunt 1'
           shunt_mac_address: '60:A4:23:91:8F:55' # Your MAC address
           shunt_encryption_key: '0df4d0395b7d1a876c0c33ecb9e70dcd' # Your encryption key
+          # Optional: BMS IDs connected to this shunt
+          # If provided, the shunt will only be used when all listed BMS are online
+          # If not provided, the shunt will be used independently of the BMS online status
+          bms_ids: '{1, 2}'

--- a/packages/bms/bms_combine.yaml
+++ b/packages/bms/bms_combine.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.6.0
+# Updated : 2026.01.24
+# Version : 1.6.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # This YAML is free software: you can redistribute it and/or
@@ -50,6 +50,11 @@ interval:
             // The BMS can be combined ?
             if (id(bms${bms_id}_can_be_combined).state)
             {
+              // Store in bitmask
+              id(${yambms_id}_var_bms_online_bitmask) |= (1 << (${bms_id} - 1));
+              // Remember that we've seen this BMS online
+              id(${yambms_id}_var_bms_seen_online_bitmask) |= id(${yambms_id}_var_bms_online_bitmask);
+
               // +-----------------------------------------------+
               // | Combine once only                             |
               // +-----------------------------------------------+
@@ -193,6 +198,9 @@ interval:
 
               // Uncombined
               id(bms${bms_id}_combined) = false;
+
+              // Remove from bitmask
+              id(${yambms_id}_var_bms_online_bitmask) &= ~(1 << (${bms_id} - 1));
             }
 
             // Increment the counter for next BMS processing

--- a/packages/shunt/shunt_combine.yaml
+++ b/packages/shunt/shunt_combine.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.5.9
+# Updated : 2026.01.24
+# Version : 1.6.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # This YAML is free software: you can redistribute it and/or
@@ -15,11 +15,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+substitutions:
+  bms_ids: '{0}'
+
 globals:
   - id: shunt${shunt_id}_combined
     type: bool
     restore_value: no
     initial_value: "false"
+  - id: shunt${shunt_id}_bms_map
+    type: std::vector<uint8_t>
+    initial_value: '${bms_ids}'
+  - id: shunt${shunt_id}_bms_caused_uncombine
+    type: int
+    restore_value: no
+    initial_value: "0"
 
 # Combine once without conditions
 esphome:
@@ -36,6 +46,21 @@ switch:
     device_id: shunt_${shunt_id}
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
+    on_turn_on:
+      - lambda: |-
+          id(shunt${shunt_id}_bms_caused_uncombine) = 0;
+          id(shunt${shunt_id}_combine_state).publish_state("Enabled (switch)");
+    on_turn_off:
+      - lambda: |-
+          if (id(shunt${shunt_id}_bms_caused_uncombine))
+          {
+            std::string state_msg = "Disabled (BMS " + std::to_string(id(shunt${shunt_id}_bms_caused_uncombine)) + " offline)";
+            id(shunt${shunt_id}_combine_state).publish_state(state_msg.c_str());
+          }
+          else
+          {
+            id(shunt${shunt_id}_combine_state).publish_state("Disabled (switch)");
+          }
 
 binary_sensor:
   # Indicates whether the Shunt can be combined
@@ -44,6 +69,16 @@ binary_sensor:
     id: shunt${shunt_id}_can_be_combined
     device_id: shunt_${shunt_id}
     lambda: return (id(shunt${shunt_id}_switch_combine).state && id(shunt${shunt_id}_online_status).state);
+
+text_sensor:
+  # Show diagnostic state and reason for combine/uncombine
+  - platform: template
+    name: "State"
+    id: shunt${shunt_id}_combine_state
+    device_id: shunt_${shunt_id}
+    entity_category: diagnostic
+    update_interval: never
+    icon: mdi:state-machine
 
 interval:
   - interval: ${yambms_update_interval}
@@ -55,6 +90,34 @@ interval:
             // The Shunt can be combined ?
             if (id(shunt${shunt_id}_can_be_combined).state)
             {
+              // +-----------------------------------------------+
+              // | Check if all connected BMS are online         |
+              // +-----------------------------------------------+
+              int bms_offline = 0;
+              for (auto const& bms_id : id(shunt${shunt_id}_bms_map))
+              {
+                if (!bms_id) continue;
+
+                // Ignore BMS that we've not seen online yet
+                if ((id(${yambms_id}_var_bms_seen_online_bitmask) & (1 << (bms_id - 1))) == 0)
+                {
+                  continue;
+                }
+
+                // Check if BMS is online
+                if ((id(${yambms_id}_var_bms_online_bitmask) & (1 << (bms_id - 1))) == 0)
+                {
+                  bms_offline = bms_id;
+                  break;
+                }
+              }
+
+              if (bms_offline) {
+                ESP_LOGI("shunt_combine", "Shunt %d: BMS %d is offline, uncombining.", ${shunt_id}, bms_offline);
+                id(shunt${shunt_id}_bms_caused_uncombine) = bms_offline;
+                id(shunt${shunt_id}_switch_combine).turn_off();
+              }
+
               // +-----------------------------------------------+
               // | Combine not continuously                      |
               // +-----------------------------------------------+

--- a/packages/yambms/yambms_combine.yaml
+++ b/packages/yambms/yambms_combine.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.21
-# Version : 1.6.0
+# Updated : 2026.01.24
+# Version : 1.6.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -28,6 +28,14 @@ globals:
     restore_value: no
     initial_value: '1'
   - id: ${yambms_id}_var_to_combine_bms_counter
+    type: int
+    restore_value: no
+    initial_value: '0'
+  - id: ${yambms_id}_var_bms_online_bitmask
+    type: int
+    restore_value: no
+    initial_value: '0'
+  - id: ${yambms_id}_var_bms_seen_online_bitmask
     type: int
     restore_value: no
     initial_value: '0'


### PR DESCRIPTION
This PR adds the possibility to provide connected BMS IDs to a shunt.

If one or more BMS from this array are offline, the shunt is not used anymore (Combine = Disabled). This avoids returning a wrong SOC when not all batteries are online/available anymore.

The `bms_ids` variable is used provide an array of BMS IDs that are connected to a shunt.

This variable is optional. If not provided, the shunt works independently from the BMS online status like before.

Examples:
```
bms_ids: '{1}'
bms_ids: '{1, 2}'
bms_ids: '{4, 5, 6}'
```

Additionally a diagnostic text_sensor has been added to show the cause of the switch change, this hopefully avoids confusion why the switch was disabled automatically:

<img width="632" height="279" alt="image" src="https://github.com/user-attachments/assets/cb13cb6e-ef63-42af-a4bc-a454607d3082" />

If the switch is turned on:

<img width="642" height="261" alt="image" src="https://github.com/user-attachments/assets/4f2903e4-c745-47d3-82a4-479761b0084a" />

If the switch is turned off:

<img width="638" height="278" alt="image" src="https://github.com/user-attachments/assets/84868dc9-7808-425e-893f-3d2171ea1a0c" />
