### PR TITLE
Merge PACE Sensor Fixes

### DIFF
--- a/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
@@ -1038,7 +1038,8 @@ number:
     address: 65
     register_type: holding
     value_type: U_WORD
-    multiply: 0.001
+    lambda: "return x * 0.001f;"
+    write_lambda: "return x * 1000.0f;"
     min_value: 0.0
     max_value: 65.535
     step: 0.001
@@ -1164,7 +1165,8 @@ number:
     address: 73
     register_type: holding
     value_type: U_WORD
-    multiply: 0.001
+    lambda: "return x * 0.001f;"
+    write_lambda: "return x * 1000.0f;"
     min_value: 0.0
     max_value: 65.535
     step: 0.001
@@ -1698,7 +1700,8 @@ number:
     address: 105
     register_type: holding
     value_type: U_WORD
-    multiply: 0.001
+    lambda: "return x * 0.001f;"
+    write_lambda: "return x * 1000.0f;"
     min_value: 0.0
     max_value: 65.535
     step: 0.001


### PR DESCRIPTION
These are some fixes to issues I found while testing the new RS485 PACE configurations.

Most of them are due to the PACE BMS reporting the values in mV rather than V.

* Add PACE-specific BMS configuration and battery SOC handling
* Refactor Battery SoC and Capacity Remaining calculations to use direct values from PACE BMS
* Refactor PACE BMS configuration to include new balancer file and update voltage handling for SOC calculations
* Fixed online sensor showing as unavailable