### PR TITLE
Add Freenove S3 board MCP2515 defaults and clean substitutions

### DIFF
--- a/packages/board/board_ESP32-S3_freenove_esp32_s3_wroom.yaml
+++ b/packages/board/board_ESP32-S3_freenove_esp32_s3_wroom.yaml
@@ -1,0 +1,88 @@
+# Updated : 2026.01.24
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+substitutions:
+  board_chip: "ESP32-S3"
+  board_name: "Freenove"
+  # Interfaces GPIOs
+  # uart_esp_1
+  tx_pin_1: '17'
+  rx_pin_1: '18'
+  # uart_esp_2
+  tx_pin_2: '15'
+  rx_pin_2: '16'
+  # uart_esp_3
+  tx_pin_3: '13'
+  rx_pin_3: '14'
+  # canbus_esp32_can
+  tx_pin_4: '38'
+  rx_pin_4: '39'
+  # canbus_mcp2515
+  # talk_pin
+  talk_pin: '8' # ESP32: 4, ESP32-S3: 8, ESP32-C3: 10
+
+  # canbus_mcp2515 (contiguous pins in board order: CS, SCK, MOSI, MISO)
+  # Adjust to the default SPI GPIOs if your wiring follows that order.
+  mcp2515_cs_pin: '9'   # CS
+  spi_clk_pin: '10'     # SCK
+  spi_mosi_pin: '11'    # MOSI
+  spi_miso_pin: '12'    # MISO
+
+
+packages:
+  device_base: !include ../base/device_base.yaml
+  device_base_wifi: !include ../base/device_base_wifi.yaml
+  board_rgb_led: !include board_options_rgb_led_status.yaml
+
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 8MB # ajust according to your ESP32-S3 version
+  cpu_frequency: 240MHz
+  framework:
+    type: esp-idf
+
+esphome:
+  platformio_options:
+    board_build.flash_mode: dio # use Dual IO (dio) instead of Quad IO (qio) to prevent boot loop after flashing
+
+wifi:
+  id: my_network
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  domain: !secret domain
+  reboot_timeout: 0s
+
+logger:
+  baud_rate: 0 # frees the 3rd UART and avoids some bugs like "WK2168 with canbus" or "BLE client with RS485 modbus"
+  hardware_uart: UART0 # UART0 / USB_SERIAL_JTAG
+
+light:
+  # https://esphome.io/components/light/esp32_rmt_led_strip
+  # ESP Light used to see the inverter heartbeat
+  # Internal : only specifying an id without a name will implicitly set this to true.
+  - platform: esp32_rmt_led_strip
+    id: esp_light
+    # name: ${name} ESP32 Light
+    rgb_order: GRB
+    pin: 48
+    num_leds: 1
+    # rmt_channel: 0
+    chipset: ws2812
+    entity_category: config
+    default_transition_length: 0ms

--- a/packages/board/board_ESP32-S3_freenove_esp32_s3_wroom.yaml
+++ b/packages/board/board_ESP32-S3_freenove_esp32_s3_wroom.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.01.24
+# Updated : 2026.01.30
 # Version : 1.1.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -34,16 +34,14 @@ substitutions:
   tx_pin_4: '38'
   rx_pin_4: '39'
   # canbus_mcp2515
-  # talk_pin
-  talk_pin: '8' # ESP32: 4, ESP32-S3: 8, ESP32-C3: 10
-
-  # canbus_mcp2515 (contiguous pins in board order: CS, SCK, MOSI, MISO)
-  # Adjust to the default SPI GPIOs if your wiring follows that order.
   mcp2515_cs_pin: '9'   # CS
   spi_clk_pin: '10'     # SCK
   spi_mosi_pin: '11'    # MOSI
   spi_miso_pin: '12'    # MISO
-
+  # talk_pin
+  talk_pin: '8' # ESP32: 4, ESP32-S3: 8, ESP32-C3: 10
+  # Requirement: RGB flag to show functionality is available
+  board_has_rgb: "true"
 
 packages:
   device_base: !include ../base/device_base.yaml
@@ -52,7 +50,7 @@ packages:
 
 esp32:
   board: esp32-s3-devkitc-1
-  flash_size: 8MB # ajust according to your ESP32-S3 version
+  flash_size: 8MB # adjust according to your ESP32-S3 version
   cpu_frequency: 240MHz
   framework:
     type: esp-idf

--- a/packages/board/board_options_itf_canbus_mcp2515.yaml
+++ b/packages/board/board_options_itf_canbus_mcp2515.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.09.12
-# Version : 1.1.4
+# Updated : 2026.01.24
+# Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -22,6 +22,7 @@
 substitutions:
   mcp2515_canbus_id: '2'
   mcp2515_canbus_bitrate: '500kbps'
+  canbus_clock: '8MHz'
 
 spi:
   - id: mcp2515_spi
@@ -37,3 +38,4 @@ canbus:
     cs_pin: ${mcp2515_cs_pin}
     can_id: ${mcp2515_canbus_id}
     bit_rate: ${mcp2515_canbus_bitrate}
+    clock: ${canbus_clock} # Default MCP2515 clock is 8MHz; many boards use 16MHz.

--- a/packages/board/board_options_itf_canbus_mcp2515.yaml
+++ b/packages/board/board_options_itf_canbus_mcp2515.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.01.24
+# Updated : 2026.01.30
 # Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -22,7 +22,7 @@
 substitutions:
   mcp2515_canbus_id: '2'
   mcp2515_canbus_bitrate: '500kbps'
-  canbus_clock: '8MHz'
+  mcp2515_clock: '8MHz'
 
 spi:
   - id: mcp2515_spi
@@ -38,4 +38,4 @@ canbus:
     cs_pin: ${mcp2515_cs_pin}
     can_id: ${mcp2515_canbus_id}
     bit_rate: ${mcp2515_canbus_bitrate}
-    clock: ${canbus_clock} # Default MCP2515 clock is 8MHz; many boards use 16MHz.
+    clock: ${mcp2515_clock} # Default MCP2515 clock is 8MHz; many boards use 16MHz


### PR DESCRIPTION
## Summary
- add default "canbus_clock" substitution for MCP2515 to avoid invalid example builds
- clean up and align the Freenove ESP32-S3 board MCP2515 substitutions
- update board metadata (date/version, board_name)

## Notes
- MCP2515 clock defaults to 8MHz; users can override to 16MHz when their board uses a 16MHz crystal
- MCP2515 pins are kept contiguous and in board order to match common flat cables