### PR TITLE
Highlight JK BMS cell resistance min/max in dashboards

### DIFF
--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -535,7 +535,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -544,8 +544,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -565,7 +572,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -574,8 +581,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -747,7 +761,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -756,8 +770,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -777,7 +798,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -786,8 +807,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -823,214 +851,6 @@ views:
         column_span: 1
         cards:
           - type: heading
-            heading: BMS 3
-            heading_style: title
-            badges:
-              - type: entity
-                show_state: true
-                show_icon: true
-                entity: binary_sensor.jk_bms_3_status_online
-                color: state
-                name: Online
-                state_content: name
-              - type: entity
-                show_state: true
-                show_icon: true
-                entity: binary_sensor.jk_bms_3_can_be_combined
-                color: state
-                name: Combined
-                state_content: name
-          - type: grid
-            square: false
-            columns: 1
-            cards:
-              - type: markdown
-                content: >-
-                  <center>Time : <b><font color=red>{{
-                  states('sensor.jk_bms_3_total_runtime_formatted', rounded=True)
-                  | upper }}</font>
-            layout_options:
-              grid_columns: 2
-              grid_rows: 1
-          - type: grid
-            square: false
-            columns: 1
-            cards:
-              - type: markdown
-                content: >-
-                  <center>Error : <b><font color=red>{{
-                  states('sensor.jk_bms_3_errors', rounded=True)}}</font>
-            layout_options:
-              grid_columns: 2
-              grid_rows: 1
-          - type: grid
-            square: false
-            columns: 3
-            cards:
-              - type: markdown
-                content: >-
-                  <center>Charge : <b>{% if
-                  states('binary_sensor.jk_bms_3_status_charging', rounded=True) == 'on'
-                  %} <font color=#41CD52>{{
-                  states('binary_sensor.jk_bms_3_status_charging', rounded=True) | upper
-                  }}</font> {% else %} <font color=#3090C7>{{
-                  states('binary_sensor.jk_bms_3_status_charging', rounded=True) | upper
-                  }}</font> {% endif %}
-              - type: markdown
-                content: >-
-                  <center>Discharge : <b> {% if
-                  states('binary_sensor.jk_bms_3_status_discharging', rounded=True) ==
-                  'on' %} <font color=#41CD52>{{
-                  states('binary_sensor.jk_bms_3_status_discharging', rounded=True) |
-                  upper }}</font> {% else %} <font color=#3090C7>{{
-                  states('binary_sensor.jk_bms_3_status_discharging', rounded=True) |
-                  upper }}</font> {% endif %}
-              - type: markdown
-                content: >-
-                  <center>Balance : <b> {% if
-                  states('binary_sensor.jk_bms_3_equalizing', rounded=True) ==
-                  'on' %} <font color=#41CD52>{{
-                  states('binary_sensor.jk_bms_3_equalizing', rounded=True) |
-                  upper }}</font> {% else %} <font color=#3090C7>{{
-                  states('binary_sensor.jk_bms_3_equalizing', rounded=True) |
-                  upper }}</font> {% endif %}
-              - type: markdown
-                content: >-
-                  <center><b><font color=#41CD52 size=4>{{
-                  states('sensor.jk_bms_3_battery_voltage', rounded=True) }}
-                  V</font></b>
-              - type: markdown
-                content: >-
-                  <center><b><font color=#41CD52 size=4>{{
-                  states('sensor.jk_bms_3_battery_current', rounded=True) }} A</font></b>
-              - type: markdown
-                content: >-
-                  <center><b><font color=#41CD52 size=4>{{
-                  states('sensor.jk_bms_3_battery_power', rounded=True) }} W</font>
-          - type: grid
-            square: false
-            columns: 2
-            cards:
-              - type: markdown
-                content: >-
-                  <center><b><font size=4>SoC :&nbsp;&nbsp;<font
-                  color=#41CD52 size=4>{{
-                  states('sensor.jk_bms_3_battery_soc', rounded=True) }}
-                  %</font></font>
-              - type: markdown
-                content: >-
-                  <center><b><font size=4>SoH :&nbsp;&nbsp;<font
-                  color=#41CD52 size=4>{{
-                  states('sensor.jk_bms_3_battery_soh_valuation', rounded=True) }}
-                  %</font></font>
-              - type: markdown
-                content: >-
-                  <center> Battery Capacity :&nbsp;&nbsp;<font color=#41CD52>{{
-                  states('number.jk_bms_3_battery_capacity_total_setting', rounded=True)
-                  }} Ah</font><br> Cycle Capacity :&nbsp;&nbsp;<font
-                  color=#41CD52>{{
-                  states('sensor.jk_bms_3_total_charging_cycle_capacity', rounded=True)
-                  }} Ah</font><br> Ave. Cell Vol. :&nbsp;&nbsp;<font
-                  color=#41CD52>{{
-                  states('sensor.jk_bms_3_cell_average_voltage', rounded=True) }}
-                  V</font><br> Balance Cur. :&nbsp;&nbsp;<font color=#41CD52>{{
-                  states('sensor.jk_bms_3_balancing_current', rounded=True) }}
-                  A</font><br> Max temp. :&nbsp;&nbsp;<font color=#41CD52>{{
-                  states('sensor.jk_bms_3_max_temperature', rounded=True) }}
-                  °C</font>
-              - type: markdown
-                content: >-
-                  <center> Remain Capacity :&nbsp;&nbsp;<font color=#41CD52>{{
-                  states('sensor.jk_bms_3_battery_capacity_remaining', rounded=True) }}
-                  Ah</font><br> Cycle Count :&nbsp;&nbsp;<font color=#41CD52>{{
-                  states('sensor.jk_bms_3_charging_cycles', rounded=True)
-                  }}</font><br> Delta Cell Vol. :&nbsp;&nbsp;<font
-                  color=#41CD52>{{
-                  states('sensor.jk_bms_3_cell_delta_voltage', rounded=True) }}
-                  V</font><br> MOS temp. :&nbsp;&nbsp;<font color=#41CD52>{{
-                  states('sensor.jk_bms_3_temperature_powertube', rounded=True)
-                  }} °C</font><br> Min temp. :&nbsp;&nbsp;<font color=#41CD52>{{
-                  states('sensor.jk_bms_3_min_temperature', rounded=True) }}
-                  °C</font>
-          - type: grid
-            square: false
-            columns: 2
-            cards:
-              - type: markdown
-                content: >-
-                  
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
-                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
-                  {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
-                  <font color='{{ max_color }}'>
-                  {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
-                  <font color='{{ min_color }}'>
-                  {% else %} <font> {% endif %}
-                  
-                  {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
-                  <br>
-                  
-                  {% endmacro %}
-                  
-                  <center>
-                  
-                  {{ cell_v(lead_zero=1, num=1, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=1, num=2, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=1, num=3, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=1, num=4, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=1, num=5, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=1, num=6, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=1, num=7, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=1, num=8, entity='.jk_bms_3') }}                  
-                  
-                  </center>
-              - type: markdown
-                content: >-
-                  
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
-                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
-                  {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
-                  <font color='{{ max_color }}'>
-                  {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
-                  <font color='{{ min_color }}'>
-                  {% else %} <font> {% endif %}
-                  
-                  {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
-                  <br>
-                  
-                  {% endmacro %}
-                  
-                  <center>
-                  
-                  {{ cell_v(lead_zero=1, num=9, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=0, num=10, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=0, num=11, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=0, num=12, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=0, num=13, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=0, num=14, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=0, num=15, entity='.jk_bms_3') }}
-                  {{ cell_v(lead_zero=0, num=16, entity='.jk_bms_3') }}              
-                  
-                  </center>
-          - type: entity-filter
-            entities:
-              - entity: switch.jk_bms_3_charging
-                name: Charge switch
-              - entity: switch.jk_bms_3_discharging
-                name: Discharge switch
-              - entity: switch.jk_bms_3_balancing
-                name: Balance switch
-              - entity: switch.jk_bms_3_enable_bluetooth_connection
-                name: Bluetooth
-              - entity: number.jk_bms_3_charging_cycles_offset
-                name: Charging Cycles Offset
-            conditions:
-              - condition: state
-                state_not: unavailable
   - title: Shunt
     type: sections
     max_columns: 3

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -535,7 +535,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -544,8 +544,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -565,7 +572,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -574,8 +581,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -747,7 +761,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -756,8 +770,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -777,7 +798,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -786,8 +807,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -959,7 +987,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -968,8 +996,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -989,7 +1024,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -998,8 +1033,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1171,7 +1213,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1180,8 +1222,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1201,7 +1250,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1210,8 +1259,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1383,7 +1439,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1392,8 +1448,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1413,7 +1476,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1422,8 +1485,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1595,7 +1665,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1604,8 +1674,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1625,7 +1702,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1634,8 +1711,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1807,7 +1891,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1816,8 +1900,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -1837,7 +1928,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1846,8 +1937,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -534,7 +534,7 @@ views:
               - type: markdown
                 content: >-
 
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -543,8 +543,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -564,7 +571,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -573,8 +580,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -745,7 +759,7 @@ views:
             cards:
               - type: markdown
                 content: >-
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -754,8 +768,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -773,7 +794,7 @@ views:
                   </center>
               - type: markdown
                 content: >-
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -782,8 +803,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -953,7 +981,7 @@ views:
             cards:
               - type: markdown
                 content: >-
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -962,8 +990,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}
@@ -981,7 +1016,7 @@ views:
                   </center>
               - type: markdown
                 content: >-
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_max_voltage_cell'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -990,8 +1025,15 @@ views:
                   {% else %} <font> {% endif %}
                   
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
                   
                   {% endmacro %}


### PR DESCRIPTION
## Summary
- highlight max/min cell resistance values (red/green) in JK BMS dashboards
- keep existing voltage coloring unchanged

## Files touched
- HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
- HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
- HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml