### PR TITLE
Component Fault Registry & Advanced LED Control

### DIFF
--- a/YamBMS_LP_PVbrain2.yaml
+++ b/YamBMS_LP_PVbrain2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -141,6 +141,11 @@ substitutions:
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
   # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
+  # +--------------------------------------+
   # | UART expander WK2168                 |
   # +--------------------------------------+
   uart0_baudrate: '2400'    # uart_id : uart_${uart_hub_bus}_0          WKS           {RJ45-UART0}
@@ -162,7 +167,13 @@ substitutions:
 
 packages:
 
-  device_board: !include packages/board/board_ESP32-S3_DevKitC-1_PVbrain2.yaml
+  device_board: 
+    file: packages/board/board_ESP32-S3_DevKitC-1_PVbrain2.yaml
+
+  #   vars:
+  #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+  #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
   # +------------------------------------------------------------------------------+
   # | >>> Board Options
@@ -244,10 +255,10 @@ packages:
   canbus1: !include
     file: packages/yambms/yambms_canbus.yaml # yambms_canbus_web_server.yaml
     vars:
-      canbus_id: 'canbus1'
+      canbus_id: '1' # Must be a number
       canbus_name: 'CANBUS 1'
       canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
-      light_id: 'esp_light'
+      canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
       # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
       canbus_link_timer: '5s'
@@ -261,13 +272,12 @@ packages:
   # rs485_pylon: !include
   #   file: packages/yambms/yambms_rs485_pylon.yaml # yambms_rs485_pylon_web_server.yaml
   #   vars:
-  #     rs485_id: 'rs485_1'
+  #     rs485_id: '1' # Must be a number
   #     rs485_name: 'RS485 1'
   #     rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #     rs485_uart_baud_rate: '9600'
   #     rs485_update_timeout: '5s'
-  #     light_id: 'esp_light'
-
+  #     rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
   # +------------------------------------------------------------------------------+

--- a/YamBMS_LP_PVbrain2.yaml
+++ b/YamBMS_LP_PVbrain2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -167,7 +167,7 @@ substitutions:
 
 packages:
 
-  device_board: 
+  device_board: !include
     file: packages/board/board_ESP32-S3_DevKitC-1_PVbrain2.yaml
 
   #   vars:

--- a/YamBMS_Local_Packages_example.yaml
+++ b/YamBMS_Local_Packages_example.yaml
@@ -163,6 +163,7 @@ packages:
   # This list is incomplete, other board.yaml are available in the board folder
 
   device_board: !include 
+  
     file: 'packages/board/board_ESP32_Generic.yaml'
   # file: 'packages/board/board_ESP32_Atom-Lite.yaml'
   # file: 'packages/board/board_ESP32_DevKit-V1.yaml'
@@ -173,9 +174,12 @@ packages:
   # file: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
   # file: 'packages/board/board_ESP32-C3_FlipC3.yaml'
   # file: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+  # file: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+  # file: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
   # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
   # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
   # file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+  # file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
   # file: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
   # file: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
   # file: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -187,26 +191,18 @@ packages:
   #   server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
   #   network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-  # device_board: !include
-  #   file: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+  # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+  # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
   #   vars:
   #     display_auto_next_page_interval: '5s'
-  #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-  #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-  #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-  # # LilyGo T-Connect Pro - Board
-  # device_board: !include
-  #   file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-  #   vars:
-  #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-  #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-  # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-  # device_dispay: !include
-  #   file: 'packages/board/board_options_display_480x222.yaml'
-  #   vars:
-  #     display_auto_next_page_interval: '5s'
-
+  #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees  
 
 
   # +------------------------------------------------------------------------------+

--- a/YamBMS_Local_Packages_example.yaml
+++ b/YamBMS_Local_Packages_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,7 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
-
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 # +--------------------------------------+
@@ -158,25 +162,30 @@ packages:
 
   # This list is incomplete, other board.yaml are available in the board folder
 
-  device_board: !include 'packages/board/board_ESP32_Generic.yaml'
-  # device_board: !include 'packages/board/board_ESP32_Atom-Lite.yaml'
-  # device_board: !include 'packages/board/board_ESP32_DevKit-V1.yaml'
-  # device_board: !include 'packages/board/board_ESP32_EVB.yaml'
-  # device_board: !include 'packages/board/board_ESP32_iBMS_CAN_RS485_V3.3.yaml'
-  # device_board: !include 'packages/board/board_ESP32_LilyGo-T-CAN485.yaml'
-  # device_board: !include 'packages/board/board_ESP32-C3_DevKitM-1.yaml'
-  # device_board: !include 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
-  # device_board: !include 'packages/board/board_ESP32-C3_FlipC3.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_WS-ETH.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_XIAO.yaml'
-  # device_board: !include 'packages/board/board_ESP32-S3_YBoard.yaml'
+  device_board: !include 
+    file: 'packages/board/board_ESP32_Generic.yaml'
+  # file: 'packages/board/board_ESP32_Atom-Lite.yaml'
+  # file: 'packages/board/board_ESP32_DevKit-V1.yaml'
+  # file: 'packages/board/board_ESP32_EVB.yaml'
+  # file: 'packages/board/board_ESP32_iBMS_CAN_RS485_V3.3.yaml'
+  # file: 'packages/board/board_ESP32_LilyGo-T-CAN485.yaml'
+  # file: 'packages/board/board_ESP32-C3_DevKitM-1.yaml'
+  # file: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
+  # file: 'packages/board/board_ESP32-C3_FlipC3.yaml'
+  # file: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+  # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
+  # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
+  # file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+  # file: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
+  # file: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
+  # file: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
+  # file: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
+  # file: 'packages/board/board_ESP32-S3_XIAO.yaml'
+  # file: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+  # vars:
+  #   server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+  #   network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
   # device_board: !include
   #   file: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
@@ -271,10 +280,10 @@ packages:
   canbus1: !include
     file: packages/yambms/yambms_canbus.yaml # yambms_canbus_web_server.yaml
     vars:
-      canbus_id: 'canbus1'
+      canbus_id: '1' # Must be a number
       canbus_name: 'CANBUS 1'
       canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
-      light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+      canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
       # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
       canbus_link_timer: '5s'
@@ -288,12 +297,12 @@ packages:
   # rs485_pylon: !include
   #   file: packages/yambms/yambms_rs485_pylon.yaml # yambms_rs485_pylon_web_server.yaml
   #   vars:
-  #     rs485_id: 'rs485_1'
+  #     rs485_id: '1' # Must be a number
   #     rs485_name: 'RS485 1'
   #     rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #     rs485_uart_baud_rate: '9600'
   #     rs485_update_timeout: '5s'
-  #     light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #     rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_Local_Packages_example.yaml
+++ b/YamBMS_Local_Packages_example.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.04
+# Updated : 2026.02.05
 # Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -162,34 +162,33 @@ packages:
 
   # This list is incomplete, other board.yaml are available in the board folder
 
-  device_board: !include 
-  
+  board: !include
     file: 'packages/board/board_ESP32_Generic.yaml'
-  # file: 'packages/board/board_ESP32_Atom-Lite.yaml'
-  # file: 'packages/board/board_ESP32_DevKit-V1.yaml'
-  # file: 'packages/board/board_ESP32_EVB.yaml'
-  # file: 'packages/board/board_ESP32_iBMS_CAN_RS485_V3.3.yaml'
-  # file: 'packages/board/board_ESP32_LilyGo-T-CAN485.yaml'
-  # file: 'packages/board/board_ESP32-C3_DevKitM-1.yaml'
-  # file: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
-  # file: 'packages/board/board_ESP32-C3_FlipC3.yaml'
-  # file: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
-  # file: 'packages/board/board_ESP32-S3_AtomS3.yaml'
-  # file: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
-  # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
-  # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
-  # file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
-  # file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-  # file: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
-  # file: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
-  # file: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
-  # file: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
-  # file: 'packages/board/board_ESP32-S3_XIAO.yaml'
-  # file: 'packages/board/board_ESP32-S3_YBoard.yaml'
+    # file: 'packages/board/board_ESP32_Atom-Lite.yaml'
+    # file: 'packages/board/board_ESP32_DevKit-V1.yaml'
+    # file: 'packages/board/board_ESP32_EVB.yaml'
+    # file: 'packages/board/board_ESP32_iBMS_CAN_RS485_V3.3.yaml'
+    # file: 'packages/board/board_ESP32_LilyGo-T-CAN485.yaml'
+    # file: 'packages/board/board_ESP32-C3_DevKitM-1.yaml'
+    # file: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
+    # file: 'packages/board/board_ESP32-C3_FlipC3.yaml'
+    # file: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+    # file: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+    # file: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+    # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
+    # file: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
+    # file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+    # file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+    # file: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
+    # file: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
+    # file: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
+    # file: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
+    # file: 'packages/board/board_ESP32-S3_XIAO.yaml'
+    # file: 'packages/board/board_ESP32-S3_YBoard.yaml'
 
-  # vars:
-  #   server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-  #   network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+    # vars:
+    #   server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+    #   network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
   # +------------------------------------------------------------------------------+
   # | >>> Board Display
@@ -197,12 +196,13 @@ packages:
   # | >>> Importing the display also activates PSRAM
   # +------------------------------------------------------------------------------+
 
-  # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
-  # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
-      
+  # board_display: !include
+  #   file: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+  #   file: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
   #   vars:
   #     display_auto_next_page_interval: '5s'
   #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees  
+
 
 
   # +------------------------------------------------------------------------------+

--- a/YamBMS_Local_Packages_example.yaml
+++ b/YamBMS_Local_Packages_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -192,9 +192,15 @@ packages:
   #   vars:
   #     display_auto_next_page_interval: '5s'
   #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+  #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+  #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
   # # LilyGo T-Connect Pro - Board
-  # device_board: !include 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+  # device_board: !include
+  #   file: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+  #   vars:
+  #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+  #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
   # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
   # device_dispay: !include
   #   file: 'packages/board/board_options_display_480x222.yaml'

--- a/YamBMS_RP_BMS_BASEN_RS485.yaml
+++ b/YamBMS_RP_BMS_BASEN_RS485.yaml
@@ -174,9 +174,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -188,22 +191,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_BASEN_RS485.yaml
+++ b/YamBMS_RP_BMS_BASEN_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,8 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
-
-
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 # +--------------------------------------+
 # | Packages                             |
@@ -180,6 +183,10 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -268,18 +275,21 @@ packages:
           basen_uart_id: 'uart_esp_1'
           basen_uart_baud_rate: '9600'
           basen_controller_id: "basen_controller_1"
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Basen module 1
       - path: packages/bms/bms_combine_BASEN_RS485_full.yaml
         vars:
           bms_id: '1' # must be a number
           bms_name: 'BASEN-BMS 1'
           bms_address: '0x01'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Basen module 2
       - path: packages/bms/bms_combine_BASEN_RS485_full.yaml
         vars:
           bms_id: '2' # must be a number
           bms_name: 'BASEN-BMS 2'
           bms_address: '0x02'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -302,17 +312,17 @@ packages:
 
   canbus:
     url: https://github.com/Sleeper85/esphome-yambms
-    ref: main
-    refresh: 60min
+    ref: dev
+    refresh: 0s
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -323,17 +333,17 @@ packages:
 
   # rs485_pylon:
   #   url: https://github.com/Sleeper85/esphome-yambms
-  #   ref: main
-  #   refresh: 60min
+  #   ref: dev
+  #   refresh: 0s
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_BASEN_RS485.yaml
+++ b/YamBMS_RP_BMS_BASEN_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -192,9 +192,14 @@ packages:
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:
@@ -312,7 +317,7 @@ packages:
 
   canbus:
     url: https://github.com/Sleeper85/esphome-yambms
-    ref: dev
+    ref: main
     refresh: 0s
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml

--- a/YamBMS_RP_BMS_DEYE_CAN.yaml
+++ b/YamBMS_RP_BMS_DEYE_CAN.yaml
@@ -175,9 +175,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -189,22 +192,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_DEYE_CAN.yaml
+++ b/YamBMS_RP_BMS_DEYE_CAN.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,7 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
-
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 # +--------------------------------------+
@@ -181,6 +185,10 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
 
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
@@ -192,6 +200,7 @@ packages:
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
+
 
 
 
@@ -279,6 +288,7 @@ packages:
           bms_name: 'DEYE-BMS 1'
           deye_id: '1'
           deye_module_id: '0' # Modules are numbered with 0-9
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Deye module 2
       - path: 'packages/bms/bms_combine_DEYE_CAN_module_full.yaml'
         vars:
@@ -289,6 +299,7 @@ packages:
           bms_id: '2' # must be a number
           bms_name: 'DEYE-BMS 2'
           deye_module_id: '1' # Modules are numbered with 0-9
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -316,12 +327,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -337,12 +348,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_DEYE_CAN.yaml
+++ b/YamBMS_RP_BMS_DEYE_CAN.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -193,9 +193,14 @@ packages:
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:
@@ -329,7 +334,7 @@ packages:
         vars:
           canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_node_id: 'canbus_inverter_1'
           canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
           # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
           # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356

--- a/YamBMS_RP_BMS_EG4_RS485.yaml
+++ b/YamBMS_RP_BMS_EG4_RS485.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_EG4_RS485.yaml
+++ b/YamBMS_RP_BMS_EG4_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -274,18 +284,21 @@ packages:
           bms_name: 'EG4-BMS 1'
           ## BMS address must start at 2 with EG4 LLV2, ID 1 is a special case and has different output.
           bms_address: 2 # BMS 1 modbus address
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_EG4_LLV2_RS485_bms_full.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'EG4-BMS 2'
           bms_address: 3 # BMS 2 modbus address
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_EG4_LLV2_RS485_bms_full.yaml'
         vars:
-          bms_id: '2' # must be a number
+          bms_id: '3' # must be a number
           bms_name: 'EG4-BMS 3'
           bms_address: 4 # BMS 3 modbus address
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -313,12 +326,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -334,12 +347,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_EG4_RS485.yaml
+++ b/YamBMS_RP_BMS_EG4_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_JBD.yaml
+++ b/YamBMS_RP_BMS_JBD.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_JBD.yaml
+++ b/YamBMS_RP_BMS_JBD.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -280,6 +290,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JBD_BLE_full.yaml'
         vars:
@@ -297,6 +308,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -324,12 +336,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -345,12 +357,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_JBD.yaml
+++ b/YamBMS_RP_BMS_JBD.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_JK-B_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_JK-B_RS485_Modbus.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_JK-B_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_JK-B_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -279,48 +289,56 @@ packages:
           bms_id: '1' # must be a number
           bms_name: 'JK-BMS 1'
           bms_address: '0x01' # BMS 1 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'JK-BMS 2'
           bms_address: '0x02' # BMS 2 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '3' # must be a number
           bms_name: 'JK-BMS 3'
           bms_address: '0x03' # BMS 3 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 4
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '4' # must be a number
           bms_name: 'JK-BMS 4'
           bms_address: '0x04' # BMS 4 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 5
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '5' # must be a number
           bms_name: 'JK-BMS 5'
           bms_address: '0x05' # BMS 5 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 6
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '6' # must be a number
           bms_name: 'JK-BMS 6'
           bms_address: '0x06' # BMS 6 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 7
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '7' # must be a number
           bms_name: 'JK-BMS 7'
           bms_address: '0x07' # BMS 7 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 8
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '8' # must be a number
           bms_name: 'JK-BMS 8'
           bms_address: '0x08' # BMS 8 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -348,12 +366,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -369,12 +387,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_JK-B_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_JK-B_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_JK-PB_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_JK-PB_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 # +--------------------------------------+
@@ -179,6 +184,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -278,48 +288,56 @@ packages:
           bms_id: '1' # must be a number
           bms_name: 'JK-BMS 1'
           bms_address: '0x01' # BMS 1 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'JK-BMS 2'
           bms_address: '0x02' # BMS 2 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '3' # must be a number
           bms_name: 'JK-BMS 3'
           bms_address: '0x03' # BMS 3 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 4
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '4' # must be a number
           bms_name: 'JK-BMS 4'
           bms_address: '0x04' # BMS 4 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 5
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '5' # must be a number
           bms_name: 'JK-BMS 5'
           bms_address: '0x05' # BMS 5 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 6
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '6' # must be a number
           bms_name: 'JK-BMS 6'
           bms_address: '0x06' # BMS 6 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 7
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '7' # must be a number
           bms_name: 'JK-BMS 7'
           bms_address: '0x07' # BMS 7 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 8
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '8' # must be a number
           bms_name: 'JK-BMS 8'
           bms_address: '0x08' # BMS 8 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -347,12 +365,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -368,12 +386,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_JK-PB_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_JK-PB_RS485_Modbus.yaml
@@ -175,9 +175,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -189,22 +192,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_JK-PB_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_JK-PB_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -189,14 +189,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_JK_BLE.yaml
+++ b/YamBMS_RP_BMS_JK_BLE.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_JK_BLE.yaml
+++ b/YamBMS_RP_BMS_JK_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -272,6 +282,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_BLE_standard.yaml'
         vars:
@@ -282,6 +293,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -309,12 +321,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -330,12 +342,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_JK_BLE.yaml
+++ b/YamBMS_RP_BMS_JK_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_JK_UART_4G-GPS.yaml
+++ b/YamBMS_RP_BMS_JK_UART_4G-GPS.yaml
@@ -175,9 +175,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -189,22 +192,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_JK_UART_4G-GPS.yaml
+++ b/YamBMS_RP_BMS_JK_UART_4G-GPS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 # +--------------------------------------+
@@ -179,6 +184,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -270,6 +280,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_UART_4G-GPS_full.yaml'
         vars:
@@ -279,6 +290,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -306,12 +318,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -327,12 +339,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_JK_UART_4G-GPS.yaml
+++ b/YamBMS_RP_BMS_JK_UART_4G-GPS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -189,14 +189,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_PACE_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_PACE_RS485_Modbus.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_PACE_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_PACE_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -272,11 +282,13 @@ packages:
         vars:
           bms_id: '1' # BMS id and modbus address
           bms_name: 'PACE-BMS 1'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_PACE_RS485_bms_full.yaml'
         vars:
           bms_id: '2' # BMS id and modbus address
           bms_name: 'PACE-BMS 2'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -304,13 +316,13 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
-          canbus_link_timer: '6s'
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
+          canbus_link_timer: '5s'
 
 
 
@@ -325,12 +337,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_PACE_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_PACE_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_SEPLOS_V1_V2_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_SEPLOS_V1_V2_RS485_Modbus.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_SEPLOS_V1_V2_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_SEPLOS_V1_V2_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -283,6 +293,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_SEPLOS_V1_V2_RS485_bms_full.yaml'
         vars:
@@ -298,6 +309,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_SEPLOS_V1_V2_RS485_bms_full.yaml'
         vars:
@@ -313,6 +325,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -340,12 +353,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -361,12 +374,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_SEPLOS_V1_V2_RS485_Modbus.yaml
+++ b/YamBMS_RP_BMS_SEPLOS_V1_V2_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_BMS_SEPLOS_V3_RS485_Modbus_sniffer.yaml
+++ b/YamBMS_RP_BMS_SEPLOS_V3_RS485_Modbus_sniffer.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_BMS_SEPLOS_V3_RS485_Modbus_sniffer.yaml
+++ b/YamBMS_RP_BMS_SEPLOS_V3_RS485_Modbus_sniffer.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -281,6 +291,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_SEPLOS_V3_RS485_sniffer_bms_full.yaml'
         vars:
@@ -293,6 +304,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_SEPLOS_V3_RS485_sniffer_bms_full.yaml'
         vars:
@@ -305,6 +317,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -332,12 +345,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -353,12 +366,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_BMS_SEPLOS_V3_RS485_Modbus_sniffer.yaml
+++ b/YamBMS_RP_BMS_SEPLOS_V3_RS485_Modbus_sniffer.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_Balancer.yaml
+++ b/YamBMS_RP_Balancer.yaml
@@ -174,9 +174,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -188,22 +191,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_Balancer.yaml
+++ b/YamBMS_RP_Balancer.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -192,9 +192,14 @@ packages:
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_Balancer.yaml
+++ b/YamBMS_RP_Balancer.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,7 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
-
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 # +--------------------------------------+
 # | Packages                             |
@@ -179,6 +183,10 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -273,12 +281,14 @@ packages:
           bms_id: '1' # must be a number
           bms_name: 'BASEN-BMS 1'
           bms_address: '0x01'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Basen module 2
       - path: 'packages/bms/bms_combine_BASEN_RS485_full.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'BASEN-BMS 2'
           bms_address: '0x02'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       
       # Balancer 1 linked to BMS 1
       - path: 'packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml'
@@ -286,12 +296,14 @@ packages:
           bms_id: '1' # must match the BMS ID
           balancer_name: 'Balancer 1'
           balancer_ble_mac_address: 11:22:33:44:55:66
+          balancer_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Balancer 2 linked to BMS 2
       - path: 'packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml'
         vars:
           bms_id: '2' # must match the BMS ID
           balancer_name: 'Balancer 2'
           balancer_ble_mac_address: 11:22:33:44:55:67
+          balancer_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'nullptr' to disable
 
 
 
@@ -319,12 +331,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -340,12 +352,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_DEMO.yaml
+++ b/YamBMS_RP_DEMO.yaml
@@ -176,9 +176,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -190,22 +193,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_RP_DEMO.yaml
+++ b/YamBMS_RP_DEMO.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -190,14 +190,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_RP_DEMO.yaml
+++ b/YamBMS_RP_DEMO.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -180,6 +185,11 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -296,6 +306,7 @@ packages:
           bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
           bms_charging_cycles: '178' # charging cycles number  Used to calculate the SoH
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_FAKE.yaml'
         vars:
@@ -321,6 +332,7 @@ packages:
           bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
           bms_charging_cycles: '226' # charging cycles number  Used to calculate the SoH
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_FAKE.yaml'
         vars:
@@ -346,6 +358,7 @@ packages:
           bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
           bms_charging_cycles: '194' # charging cycles number  Used to calculate the SoH
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 
@@ -373,12 +386,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -394,12 +407,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_Ethernet_board.yaml
+++ b/YamBMS_RP_Ethernet_board.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/YamBMS_RP_Ethernet_board.yaml
+++ b/YamBMS_RP_Ethernet_board.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,6 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -164,6 +169,11 @@ packages:
       - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32_EVB.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
 
 
@@ -255,12 +265,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -276,12 +286,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_PVbrain2.yaml
+++ b/YamBMS_RP_PVbrain2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/YamBMS_RP_PVbrain2.yaml
+++ b/YamBMS_RP_PVbrain2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -141,6 +141,12 @@ substitutions:
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
   # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
+
+  # +--------------------------------------+
   # | UART expander WK2168                 |
   # +--------------------------------------+
   uart0_baudrate: '2400'    # uart_id : uart_${uart_hub_bus}_0          WKS           {RJ45-UART0}
@@ -168,6 +174,11 @@ packages:
     refresh: 60min
     files:
       - path: 'packages/board/board_ESP32-S3_DevKitC-1_PVbrain2.yaml'
+
+    #   vars:
+    #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+    #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
 
 
 
@@ -265,12 +276,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -286,12 +297,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
 

--- a/YamBMS_RP_PVbrain2.yaml
+++ b/YamBMS_RP_PVbrain2.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.04
+# Updated : 2026.02.05
 # Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -174,11 +174,9 @@ packages:
     refresh: 60min
     files:
       - path: 'packages/board/board_ESP32-S3_DevKitC-1_PVbrain2.yaml'
-
-    #   vars:
-    #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-    #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
+        # vars:
+        #   server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+        #   network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
 
 

--- a/YamBMS_RP_RPi_Pico_Shunts_modbus_server.yaml
+++ b/YamBMS_RP_RPi_Pico_Shunts_modbus_server.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.04
+# Updated : 2026.02.05
 # Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -63,10 +63,9 @@ packages:
     files:
       # board
       - path: packages/board/board_RP2040_RPi_Pico.yaml
-
-    #   vars:
-    #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-    #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+        # vars:
+        #   server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+        #   network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # uart
       - path: packages/board/board_options_itf_uart_1.yaml

--- a/YamBMS_RP_RPi_Pico_Shunts_modbus_server.yaml
+++ b/YamBMS_RP_RPi_Pico_Shunts_modbus_server.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.14
-# Version : 1.6.0
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -41,6 +41,11 @@ substitutions:
   # | Shunt Settings                       |
   # +--------------------------------------+
   shunt_update_interval: '5s'  # frequency at which Shunt data is refreshed
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 
@@ -58,6 +63,11 @@ packages:
     files:
       # board
       - path: packages/board/board_RP2040_RPi_Pico.yaml
+
+    #   vars:
+    #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+    #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+
       # uart
       - path: packages/board/board_options_itf_uart_1.yaml
       - path: packages/board/board_options_itf_uart_2.yaml
@@ -77,27 +87,32 @@ packages:
           shunt_id: '1'
           shunt_name: 'Shunt 1'
           shunt_uart_id: 'uart_2'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # shunt2
       - path: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
         vars:
           shunt_id: '2'
           shunt_name: 'Shunt 2'
           shunt_uart_id: 'uart_3'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # shunt3
       - path: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
         vars:
           shunt_id: '3'
           shunt_name: 'Shunt 3'
           shunt_uart_id: 'uart_4'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # shunt4
       - path: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
         vars:
           shunt_id: '4'
           shunt_name: 'Shunt 4'
           shunt_uart_id: 'uart_5'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # shunt5
       - path: packages/shunt/shunt_modbus_Victron_SmartShunt_UART_minimal.yaml
         vars:
           shunt_id: '5'
           shunt_name: 'Shunt 5'
           shunt_uart_id: 'uart_6'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/YamBMS_RP_RPi_Pico_Shunts_modbus_server.yaml
+++ b/YamBMS_RP_RPi_Pico_Shunts_modbus_server.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/YamBMS_Remote_Packages_example.yaml
+++ b/YamBMS_Remote_Packages_example.yaml
@@ -175,9 +175,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -189,22 +192,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_Remote_Packages_example.yaml
+++ b/YamBMS_Remote_Packages_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -193,9 +193,14 @@ packages:
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/YamBMS_Remote_Packages_example.yaml
+++ b/YamBMS_Remote_Packages_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,7 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
-
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 
 # +--------------------------------------+
@@ -180,6 +184,10 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -283,12 +291,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -304,13 +312,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
   # +------------------------------------------------------------------------------+

--- a/YamBMS_Remote_Packages_example_dev_branch.yaml
+++ b/YamBMS_Remote_Packages_example_dev_branch.yaml
@@ -174,9 +174,12 @@ packages:
       # - path: 'packages/board/board_ESP32-C3_ETH01-EVO.yaml'
       # - path: 'packages/board/board_ESP32-C3_FlipC3.yaml'
       # - path: 'packages/board/board_ESP32-S3_AtomS3-Lite.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml'
+      # - path: 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-38.yaml'
       # - path: 'packages/board/board_ESP32-S3_DevKitC-1_LED-48.yaml'
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect.yaml'
+      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-ETH.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-RS485-CAN.yaml'
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml'
@@ -188,22 +191,18 @@ packages:
       #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
-      # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
+  # +------------------------------------------------------------------------------+
+  # | >>> Board Display
+  # | >>> Uncomment the display that corresponds to your board
+  # | >>> Importing the display also activates PSRAM
+  # +------------------------------------------------------------------------------+
+
+      # - path: 'packages/board/board_options_display_128x128.yaml' # AtomS3 / AtomS3R display
+      # - path: 'packages/board/board_options_display_480x222.yaml' # LilyGo T-Connect Pro display
+      
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-
-      # # LilyGo T-Connect Pro - Board
-      # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
-      #   vars:
-      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
-      # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
-      # - path: 'packages/board/board_options_display_480x222.yaml'
-      #   vars:
-      #     display_auto_next_page_interval: '5s'
 
 
 

--- a/YamBMS_Remote_Packages_example_dev_branch.yaml
+++ b/YamBMS_Remote_Packages_example_dev_branch.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.29
-# Version : 1.6.1
+# Updated : 2026.02.03
+# Version : 1.6.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -140,7 +140,11 @@ substitutions:
   # | BMS Settings                         |
   # +--------------------------------------+
   bms_update_interval: '3s'    # frequency at which BMS data is refreshed, going below '3s' can cause problems
-
+  # +--------------------------------------+
+  # | Health & LED Assignment Logs         |
+  # +--------------------------------------+
+  enable_led_logging: 'false'     # Set to true to see if an led is assigned to a component correctly, logged every 60 seconds
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
 # +--------------------------------------+
 # | Packages                             |
@@ -179,6 +183,10 @@ packages:
       # - path: 'packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml'
       # - path: 'packages/board/board_ESP32-S3_XIAO.yaml'
       # - path: 'packages/board/board_ESP32-S3_YBoard.yaml'
+
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # - path: 'packages/board/board_ESP32-S3_AtomS3.yaml' # 'packages/board/board_ESP32-S3_AtomS3R.yaml'
       #   vars:
@@ -282,12 +290,12 @@ packages:
     files:
       - path: 'packages/yambms/yambms_canbus.yaml' # yambms_canbus_web_server.yaml
         vars:
-          canbus_id: 'canbus1'
+          canbus_id: '1' # Must be a number
           canbus_name: 'CANBUS 1'
-          canbus_node_id: 'canbus_inverter_1'
-          light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
-          # The CANBUS link will be considered down if no response from the inverter (0x305 frame) for 5s
-          # The Deye inverter sends the ACK 0x305 only when it receives the 0x356 frame.
+          canbus_node_id: 'canbus_inverter_1' # CAN bus node to which your inverter is connected
+          canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
+          # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
+          # The Deye inverter sends the ACK (can_id 0x305) only when it receives the can_id 0x356
           canbus_link_timer: '5s'
 
 
@@ -303,12 +311,12 @@ packages:
   #   files:
   #     - path: 'packages/yambms/yambms_rs485_pylon.yaml' # yambms_rs485_pylon_web_server.yaml
   #       vars:
-  #         rs485_id: 'rs485_1'
+  #         rs485_id: '1' # Must be a number
   #         rs485_name: 'RS485 1'
   #         rs485_uart_id: 'uart_esp_3' # UART interface to which your inverter is connected
   #         rs485_uart_baud_rate: '9600'
   #         rs485_update_timeout: '5s'
-  #         light_id: 'esp_light' # led used to show status. Default = esp_light, comment out or set to 'none' to disable
+  #         rs485_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
 
   # +------------------------------------------------------------------------------+

--- a/YamBMS_Remote_Packages_example_dev_branch.yaml
+++ b/YamBMS_Remote_Packages_example_dev_branch.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.6.2
+# Updated : 2026.02.04
+# Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -192,9 +192,14 @@ packages:
       #   vars:
       #     display_auto_next_page_interval: '5s'
       #     display_rotation: '0' # 0/90/180/270 rotation angle in degrees
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
 
       # # LilyGo T-Connect Pro - Board
       # - path: 'packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml'
+      #   vars:
+      #     server_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
+      #     network_status_led_id: 'virtual_status_light' # led used to show status. Default = esp_light, set specific led or set to 'virtual_status_light' to disable
       # # LilyGo T-Connect Pro - Display - Importing the display also activates PSRAM
       # - path: 'packages/board/board_options_display_480x222.yaml'
       #   vars:

--- a/documents/README/YamBMS_behavior.md
+++ b/documents/README/YamBMS_behavior.md
@@ -115,8 +115,8 @@ To make counting easier, long codes are broken into groups of 4:
 | :--: | :--- | :--- |
 | **1** | **API / MQTT** | API or MQTT communication failure. |
 | **2** | **BMS** | Battery Management System communication failure. |
-| **3** | **INV CAN** | Inverter CAN-BUS communication failure. |
-| **4** | **INV RS485** | Inverter Modbus/RS485 communication failure. |
+| **3** | **INV CAN** | Inverter CAN bus communication failure. |
+| **4** | **INV RS485** | Inverter RS485 bus communication failure. |
 | **5** | **SHUNT** | Shunt communication failure. |
 | **6** | **BALANCER** | Balancer communication failure. |
 | **7** | **NETWORK** | No wifi or ethernet connection. |
@@ -199,10 +199,10 @@ This `5s` delay can be modified in the configuration when importing the canbus p
   canbus1: !include
     file: packages/yambms/yambms_canbus.yaml
     vars:
-      canbus_id: 'canbus1'
+      canbus_id: '1' # Must be a number
       canbus_name: 'CANBUS 1'
       canbus_node_id: 'canbus_node1'
-      canbus_light_id: 'esp_light'
+      canbus_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # The CANBUS link will be considered down if no response from the inverter (ID 0x305) for 5s
       canbus_link_timer: '5s'
 ```

--- a/examples/multi-node/LP_example_multi-node_YamBMS_modbus_server_1.yaml
+++ b/examples/multi-node/LP_example_multi-node_YamBMS_modbus_server_1.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.02
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -41,6 +41,7 @@ packages:
       shunt_id: '1' # must be a number
       shunt_name: 'Shunt 1'
       shunt_uart_id: 'uart_esp_2'
+      shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms1: !include
     file: packages/bms/bms_modbus_JK_UART_4G-GPS_full.yaml
@@ -51,3 +52,4 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/multi-node/LP_example_multi-node_YamBMS_modbus_server_2.yaml
+++ b/examples/multi-node/LP_example_multi-node_YamBMS_modbus_server_2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.02
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -45,6 +45,7 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_modbus_JK_BLE_standard.yaml
@@ -56,3 +57,4 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/multi-node/LP_example_multi-node_YamBMS_modbus_server_3.yaml
+++ b/examples/multi-node/LP_example_multi-node_YamBMS_modbus_server_3.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.14
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -42,6 +42,7 @@ packages:
       bms_id: '2' # must match BMS ID
       balancer_name: 'NEEY 1'
       balancer_ble_mac_address: 11:22:33:44:55:66
+      balancer_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   # Balancer for BMS 3
   balancer3: !include
@@ -50,3 +51,4 @@ packages:
       bms_id: '3' # must be a number
       balancer_name: 'NEEY 2'
       balancer_ble_mac_address: 11:22:33:44:55:67
+      balancer_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/multi-node/RP_example_multi-node_YamBMS_modbus_server_1.yaml
+++ b/examples/multi-node/RP_example_multi-node_YamBMS_modbus_server_1.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.02
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -45,6 +45,7 @@ packages:
           shunt_id: '1' # must be a number
           shunt_name: 'Shunt 1'
           shunt_uart_id: 'uart_esp_2'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 1
       - path: 'packages/bms/bms_modbus_JK_UART_4G-GPS_full.yaml'
         vars:
@@ -54,3 +55,4 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/multi-node/RP_example_multi-node_YamBMS_modbus_server_2.yaml
+++ b/examples/multi-node/RP_example_multi-node_YamBMS_modbus_server_2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.02
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -49,6 +49,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_modbus_JK_BLE_standard.yaml'
         vars:
@@ -59,3 +60,4 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/multi-node/RP_example_multi-node_YamBMS_modbus_server_3.yaml
+++ b/examples/multi-node/RP_example_multi-node_YamBMS_modbus_server_3.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.14
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -45,9 +45,11 @@ packages:
           bms_id: '2' # must match BMS ID
           balancer_name: 'NEEY 1'
           balancer_ble_mac_address: 11:22:33:44:55:66
+          balancer_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Balancer for BMS 3
       - path: 'packages/balancer/balancer_modbus_JK_NEEY_BLE.yaml'
         vars:
           bms_id: '3' # must be a number
           balancer_name: 'NEEY 2'
           balancer_ble_mac_address: 11:22:33:44:55:67
+          balancer_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_BASEN_RS485.yaml
+++ b/examples/single-node/LP_BMS_example_BASEN_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -40,6 +40,7 @@ packages:
       bms_id: '1' # must be a number
       bms_name: 'BASEN-BMS 1'
       bms_address: '0x01'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   # Basen module 2
   bms2: !include
@@ -48,3 +49,4 @@ packages:
       bms_id: '2' # must be a number
       bms_name: 'BASEN-BMS 2'
       bms_address: '0x02'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_DEMO_Shunt_and_BMS.yaml
+++ b/examples/single-node/LP_BMS_example_DEMO_Shunt_and_BMS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.15
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -35,6 +35,7 @@ packages:
       shunt_current: '17.5' # A
       shunt_power: '924' # W
       shunt_soc: '50' # %
+      shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms1: !include
     file: packages/bms/bms_combine_FAKE.yaml
@@ -61,6 +62,7 @@ packages:
       bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
       bms_charging_cycles: '178' # charging cycles number  Used to calculate the SoH
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_FAKE.yaml
@@ -87,6 +89,7 @@ packages:
       bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
       bms_charging_cycles: '226' # charging cycles number  Used to calculate the SoH
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_FAKE.yaml
@@ -113,3 +116,4 @@ packages:
       bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
       bms_charging_cycles: '194' # charging cycles number  Used to calculate the SoH
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_DEYE_CAN.yaml
+++ b/examples/single-node/LP_BMS_example_DEYE_CAN.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -45,6 +45,7 @@ packages:
       bms_name: 'DEYE-BMS 1'
       deye_id: '1'
       deye_module_id: '0' # Modules are numbered with 0-9
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   # Deye module 2
   bms2: !include
@@ -57,3 +58,4 @@ packages:
       bms_id: '2' # must be a number
       bms_name: 'DEYE-BMS 2'
       deye_module_id: '1' # Modules are numbered with 0-9
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_EG4_LLV2_RS485_Modbus.yaml
+++ b/examples/single-node/LP_BMS_example_EG4_LLV2_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -38,6 +38,7 @@ packages:
       bms_name: 'EG4-BMS 1'
       ## BMS address must start at 2 with EG4 LLV2, ID 1 is a special case and has different output.
       bms_address: 2 # BMS 1 modbus address
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
   
   bms2: !include
     file: packages/bms/bms_combine_EG4_LLV2_RS485_bms_full.yaml
@@ -45,6 +46,7 @@ packages:
       bms_id: '2' # must be a number
       bms_name: 'EG4-BMS 2'
       bms_address: 3 # BMS 2 modbus address
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_EG4_LLV2_RS485_bms_full.yaml
@@ -52,3 +54,4 @@ packages:
       bms_id: '3' # must be a number
       bms_name: 'EG4-BMS 3'
       bms_address: 4 # BMS 3 modbus address
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_JBD_UART_BLE.yaml
+++ b/examples/single-node/LP_BMS_example_JBD_UART_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -43,6 +43,7 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_JBD_BLE_full.yaml
@@ -61,3 +62,4 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_JK-B_RS485_Modbus_mode2.yaml
+++ b/examples/single-node/LP_BMS_example_JK-B_RS485_Modbus_mode2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -49,6 +49,7 @@ packages:
       bms_id: '1' # must be a number
       bms_name: 'JK-BMS 1'
       bms_address: '0x01' # BMS 1 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -56,6 +57,7 @@ packages:
       bms_id: '2' # must be a number
       bms_name: 'JK-BMS 2'
       bms_address: '0x02' # BMS 2 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -63,6 +65,7 @@ packages:
       bms_id: '3' # must be a number
       bms_name: 'JK-BMS 3'
       bms_address: '0x03' # BMS 3 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms4: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -70,6 +73,7 @@ packages:
       bms_id: '4' # must be a number
       bms_name: 'JK-BMS 4'
       bms_address: '0x04' # BMS 4 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms5: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -77,6 +81,7 @@ packages:
       bms_id: '5' # must be a number
       bms_name: 'JK-BMS 5'
       bms_address: '0x05' # BMS 5 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms6: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -84,6 +89,7 @@ packages:
       bms_id: '6' # must be a number
       bms_name: 'JK-BMS 6'
       bms_address: '0x06' # BMS 6 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms7: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -91,6 +97,7 @@ packages:
       bms_id: '7' # must be a number
       bms_name: 'JK-BMS 7'
       bms_address: '0x07' # BMS 7 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms8: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -98,3 +105,4 @@ packages:
       bms_id: '8' # must be a number
       bms_name: 'JK-BMS 8'
       bms_address: '0x08' # BMS 8 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_JK-PB_RS485_Modbus_mode1.yaml
+++ b/examples/single-node/LP_BMS_example_JK-PB_RS485_Modbus_mode1.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -49,6 +49,7 @@ packages:
       bms_id: '1' # must be a number
       bms_name: 'JK-BMS 1'
       bms_address: '0x00' # BMS 1 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
   
   bms2: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
@@ -56,6 +57,7 @@ packages:
       bms_id: '2' # must be a number
       bms_name: 'JK-BMS 2'
       bms_address: '0x01' # BMS 2 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
@@ -63,6 +65,7 @@ packages:
       bms_id: '3' # must be a number
       bms_name: 'JK-BMS 3'
       bms_address: '0x02' # BMS 3 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms4: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
@@ -70,6 +73,7 @@ packages:
       bms_id: '4' # must be a number
       bms_name: 'JK-BMS 4'
       bms_address: '0x03' # BMS 4 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
   
   bms5: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
@@ -77,6 +81,7 @@ packages:
       bms_id: '5' # must be a number
       bms_name: 'JK-BMS 5'
       bms_address: '0x04' # BMS 5 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms6: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
@@ -84,6 +89,7 @@ packages:
       bms_id: '6' # must be a number
       bms_name: 'JK-BMS 6'
       bms_address: '0x05' # BMS 6 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms7: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
@@ -91,3 +97,4 @@ packages:
       bms_id: '7' # must be a number
       bms_name: 'JK-BMS 7'
       bms_address: '0x06' # BMS 7 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_JK-PB_RS485_Modbus_mode2.yaml
+++ b/examples/single-node/LP_BMS_example_JK-PB_RS485_Modbus_mode2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -49,6 +49,7 @@ packages:
       bms_id: '1' # must be a number
       bms_name: 'JK-BMS 1'
       bms_address: '0x01' # BMS 1 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -56,6 +57,7 @@ packages:
       bms_id: '2' # must be a number
       bms_name: 'JK-BMS 2'
       bms_address: '0x02' # BMS 2 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -63,6 +65,7 @@ packages:
       bms_id: '3' # must be a number
       bms_name: 'JK-BMS 3'
       bms_address: '0x03' # BMS 3 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms4: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -70,6 +73,7 @@ packages:
       bms_id: '4' # must be a number
       bms_name: 'JK-BMS 4'
       bms_address: '0x04' # BMS 4 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms5: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -77,6 +81,7 @@ packages:
       bms_id: '5' # must be a number
       bms_name: 'JK-BMS 5'
       bms_address: '0x05' # BMS 5 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms6: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -84,6 +89,7 @@ packages:
       bms_id: '6' # must be a number
       bms_name: 'JK-BMS 6'
       bms_address: '0x06' # BMS 6 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms7: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -91,6 +97,7 @@ packages:
       bms_id: '7' # must be a number
       bms_name: 'JK-BMS 7'
       bms_address: '0x07' # BMS 7 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms8: !include
     file: packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -98,3 +105,4 @@ packages:
       bms_id: '8' # must be a number
       bms_name: 'JK-BMS 8'
       bms_address: '0x08' # BMS 8 DIP switch
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_JK_BLE.yaml
+++ b/examples/single-node/LP_BMS_example_JK_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -35,6 +35,7 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_JK_BLE_standard.yaml
@@ -46,3 +47,4 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_JK_UART_4G-GPS.yaml
+++ b/examples/single-node/LP_BMS_example_JK_UART_4G-GPS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -34,6 +34,7 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_JK_UART_4G-GPS_full.yaml
@@ -44,3 +45,4 @@ packages:
       # Maximum cell charging cycles is used to calculate the battey SoH.
       # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
       bms_cell_max_cycles: '6000.0'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_PACE_RS485.yaml
+++ b/examples/single-node/LP_BMS_example_PACE_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -36,15 +36,18 @@ packages:
     vars:
       bms_id: '1' # BMS id and modbus address
       bms_name: 'PACE-BMS 1'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
   
   bms2: !include
     file: packages/bms/bms_combine_PACE_RS485_bms_full.yaml
     vars:
       bms_id: '2' # BMS id and modbus address
       bms_name: 'PACE-BMS 2'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_PACE_RS485_bms_full.yaml
     vars:
       bms_id: '3' # BMS id and modbus address
       bms_name: 'PACE-BMS 3'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_SEPLOS_V1_V2_RS485.yaml
+++ b/examples/single-node/LP_BMS_example_SEPLOS_V1_V2_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -46,6 +46,7 @@ packages:
       bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
       bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_SEPLOS_V1_V2_RS485_bms_full.yaml
@@ -62,6 +63,7 @@ packages:
       bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
       bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_SEPLOS_V1_V2_RS485_bms_full.yaml
@@ -78,3 +80,4 @@ packages:
       bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
       bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_BMS_example_SEPLOS_V3_RS485_sniffer.yaml
+++ b/examples/single-node/LP_BMS_example_SEPLOS_V3_RS485_sniffer.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -45,6 +45,7 @@ packages:
       bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
       bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms2: !include
     file: packages/bms/bms_combine_SEPLOS_V3_RS485_sniffer_bms_full.yaml
@@ -58,6 +59,7 @@ packages:
       bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
       bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms3: !include
     file: packages/bms/bms_combine_SEPLOS_V3_RS485_sniffer_bms_full.yaml
@@ -71,3 +73,4 @@ packages:
       bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
       bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
       bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/LP_Shunt_example.yaml
+++ b/examples/single-node/LP_Shunt_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.25
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -29,6 +29,7 @@
       shunt_id: '1' # must be a number
       shunt_name: 'Shunt 1'
       shunt_uart_id: 'uart_esp_1'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Optional: BMS IDs connected to this shunt
       # If provided, the shunt will only be used when all listed BMS are online
       # If not provided, the shunt will be used independently of the BMS online status
@@ -40,6 +41,7 @@
       shunt_id: '1' # must be a number
       shunt_name: 'Shunt 1'
       shunt_uart_id: 'uart_esp_1'
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Optional: BMS IDs connected to this shunt
       # If provided, the shunt will only be used when all listed BMS are online
       # If not provided, the shunt will be used independently of the BMS online status
@@ -52,6 +54,7 @@
       shunt_name: 'Shunt 1'
       shunt_mac_address: '60:A4:23:91:8F:55' # Your MAC address
       shunt_encryption_key: '0df4d0395b7d1a876c0c33ecb9e70dcd' # Your encryption key
+      bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Optional: BMS IDs connected to this shunt
       # If provided, the shunt will only be used when all listed BMS are online
       # If not provided, the shunt will be used independently of the BMS online status

--- a/examples/single-node/RP_BMS_example_BASEN_RS485.yaml
+++ b/examples/single-node/RP_BMS_example_BASEN_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -42,9 +42,11 @@ packages:
           bms_id: '1' # must be a number
           bms_name: 'BASEN-BMS 1'
           bms_address: '0x01'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Basen module 2
       - path: 'packages/bms/bms_combine_BASEN_RS485_full.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'BASEN-BMS 2'
           bms_address: '0x02'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_DEMO_Shunt_and_BMS.yaml
+++ b/examples/single-node/RP_BMS_example_DEMO_Shunt_and_BMS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.15
-# Version : 1.1.2
+# Updated : 2026.02.01
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -38,6 +38,7 @@
           shunt_current: '17.5' # A
           shunt_power: '924' # W
           shunt_soc: '50' # %
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
 
   bms:
     url: https://github.com/Sleeper85/esphome-yambms
@@ -69,6 +70,7 @@
           bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
           bms_charging_cycles: '178' # charging cycles number  Used to calculate the SoH
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_FAKE.yaml'
         vars:
@@ -94,6 +96,7 @@
           bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
           bms_charging_cycles: '226' # charging cycles number  Used to calculate the SoH
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_FAKE.yaml'
         vars:
@@ -119,3 +122,4 @@
           bms_cell_uvp: '2.800' # V                            Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V             Used by 'Auto CVL' functions
           bms_charging_cycles: '194' # charging cycles number  Used to calculate the SoH
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_DEYE_CAN.yaml
+++ b/examples/single-node/RP_BMS_example_DEYE_CAN.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -47,6 +47,7 @@ packages:
           bms_name: 'DEYE-BMS 1'
           deye_id: '1'
           deye_module_id: '0' # Modules are numbered with 0-9
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # Deye module 2
       - path: 'packages/bms/bms_combine_DEYE_CAN_module_full.yaml'
         vars:
@@ -57,3 +58,4 @@ packages:
           bms_id: '2' # must be a number
           bms_name: 'DEYE-BMS 2'
           deye_module_id: '1' # Modules are numbered with 0-9
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_EG4_LLV2_RS485_Modbus.yaml
+++ b/examples/single-node/RP_BMS_example_EG4_LLV2_RS485_Modbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -42,15 +42,18 @@ packages:
           bms_name: 'EG4-BMS 1'
           ## BMS address must start at 2 with EG4 LLV2, ID 1 is a special case and has different output.
           bms_address: 2 # BMS 1 modbus address
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_EG4_LLV2_RS485_bms_full.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'EG4-BMS 2'
           bms_address: 3 # BMS 2 modbus address
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_EG4_LLV2_RS485_bms_full.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'EG4-BMS 3'
           bms_address: 4 # BMS 3 modbus address
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_JBD_UART_BLE.yaml
+++ b/examples/single-node/RP_BMS_example_JBD_UART_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -48,6 +48,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JBD_BLE_full.yaml'
         vars:
@@ -65,3 +66,4 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_JK-B_RS485_Modbus_mode2.yaml
+++ b/examples/single-node/RP_BMS_example_JK-B_RS485_Modbus_mode2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -50,45 +50,53 @@ packages:
           bms_id: '1' # must be a number
           bms_name: 'JK-BMS 1'
           bms_address: '0x01' # BMS 1 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'JK-BMS 2'
           bms_address: '0x02' # BMS 2 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '3' # must be a number
           bms_name: 'JK-BMS 3'
           bms_address: '0x03' # BMS 3 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 4
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '4' # must be a number
           bms_name: 'JK-BMS 4'
           bms_address: '0x04' # BMS 4 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 5
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '5' # must be a number
           bms_name: 'JK-BMS 5'
           bms_address: '0x05' # BMS 5 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 6
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '6' # must be a number
           bms_name: 'JK-BMS 6'
           bms_address: '0x06' # BMS 6 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 7
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '7' # must be a number
           bms_name: 'JK-BMS 7'
           bms_address: '0x07' # BMS 7 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 8
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml'
         vars:
           bms_id: '8' # must be a number
           bms_name: 'JK-BMS 8'
           bms_address: '0x08' # BMS 8 ( JK app `Device Addr.` setting )
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_JK-PB_RS485_Modbus_mode2.yaml
+++ b/examples/single-node/RP_BMS_example_JK-PB_RS485_Modbus_mode2.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -50,45 +50,53 @@ packages:
           bms_id: '1' # must be a number
           bms_name: 'JK-BMS 1'
           bms_address: '0x01' # BMS 1 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '2' # must be a number
           bms_name: 'JK-BMS 2'
           bms_address: '0x02' # BMS 2 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '3' # must be a number
           bms_name: 'JK-BMS 3'
           bms_address: '0x03' # BMS 3 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 4
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '4' # must be a number
           bms_name: 'JK-BMS 4'
           bms_address: '0x04' # BMS 4 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 5
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '5' # must be a number
           bms_name: 'JK-BMS 5'
           bms_address: '0x05' # BMS 5 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 6
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '6' # must be a number
           bms_name: 'JK-BMS 6'
           bms_address: '0x06' # BMS 6 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 7
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '7' # must be a number
           bms_name: 'JK-BMS 7'
           bms_address: '0x07' # BMS 7 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 8
       - path: 'packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml'
         vars:
           bms_id: '8' # must be a number
           bms_name: 'JK-BMS 8'
           bms_address: '0x08' # BMS 8 DIP switch
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_JK_BLE.yaml
+++ b/examples/single-node/RP_BMS_example_JK_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -40,6 +40,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_BLE_standard.yaml'
         vars:
@@ -50,3 +51,4 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_JK_UART_4G-GPS.yaml
+++ b/examples/single-node/RP_BMS_example_JK_UART_4G-GPS.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.07.27
-# Version : 1.1.1
+# Updated : 2026.02.03
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -39,6 +39,7 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_JK_UART_4G-GPS_full.yaml'
         vars:
@@ -48,3 +49,4 @@ packages:
           # Maximum cell charging cycles is used to calculate the battey SoH.
           # MB31=8000.0, LF280K v3=8000.0, LF280K v2=6000.0, LF280=3000.0 (decimal is required)
           bms_cell_max_cycles: '6000.0'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_PACE_RS485.yaml
+++ b/examples/single-node/RP_BMS_example_PACE_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -40,13 +40,16 @@ packages:
         vars:
           bms_id: '1' # BMS id and modbus address
           bms_name: 'PACE-BMS 1'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_PACE_RS485_bms_full.yaml'
         vars:
           bms_id: '2' # BMS id and modbus address
           bms_name: 'PACE-BMS 2'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_PACE_RS485_bms_full.yaml'
         vars:
           bms_id: '3' # BMS id and modbus address
           bms_name: 'PACE-BMS 3'
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_SEPLOS_V1_V2_RS485.yaml
+++ b/examples/single-node/RP_BMS_example_SEPLOS_V1_V2_RS485.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.3
+# Updated : 2026.02.03
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -50,6 +50,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_SEPLOS_V1_V2_RS485_bms_full.yaml'
         vars:
@@ -65,6 +66,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_SEPLOS_V1_V2_RS485_bms_full.yaml'
         vars:
@@ -80,3 +82,4 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_BMS_example_SEPLOS_V3_RS485_sniffer.yaml
+++ b/examples/single-node/RP_BMS_example_SEPLOS_V3_RS485_sniffer.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -49,6 +49,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 2
       - path: 'packages/bms/bms_combine_SEPLOS_V3_RS485_sniffer_bms_full.yaml'
         vars:
@@ -61,6 +62,7 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
       # BMS 3
       - path: 'packages/bms/bms_combine_SEPLOS_V3_RS485_sniffer_bms_full.yaml'
         vars:
@@ -73,3 +75,4 @@ packages:
           bms_cell_ovp: '3.650' # V. Used by 'Auto CCL' functions
           bms_cell_uvp: '2.800' # V. Used by 'Auto DCL' functions and to calculate maximum discharge voltage
           bms_balance_trigger_voltage: '0.010' # V. Used by 'Auto CVL' functions
+          bms_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable

--- a/examples/single-node/RP_Shunt_example.yaml
+++ b/examples/single-node/RP_Shunt_example.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.25
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -35,6 +35,7 @@
           shunt_id: '1' # must be a number
           shunt_name: 'Shunt 1'
           shunt_uart_id: 'uart_esp_1'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
           # Optional: BMS IDs connected to this shunt
           # If provided, the shunt will only be used when all listed BMS are online
           # If not provided, the shunt will be used independently of the BMS online status
@@ -52,6 +53,7 @@
           shunt_id: '1' # must be a number
           shunt_name: 'Shunt 1'
           shunt_uart_id: 'uart_esp_1'
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
           # Optional: BMS IDs connected to this shunt
           # If provided, the shunt will only be used when all listed BMS are online
           # If not provided, the shunt will be used independently of the BMS online status
@@ -70,6 +72,7 @@
           shunt_name: 'Shunt 1'
           shunt_mac_address: '60:A4:23:91:8F:55' # Your MAC address
           shunt_encryption_key: '0df4d0395b7d1a876c0c33ecb9e70dcd' # Your encryption key
+          shunt_status_led_id: 'esp_light' # led used to show status. Default = esp_light, comment out to disable
           # Optional: BMS IDs connected to this shunt
           # If provided, the shunt will only be used when all listed BMS are online
           # If not provided, the shunt will be used independently of the BMS online status

--- a/packages/balancer/balancer_base.yaml
+++ b/packages/balancer/balancer_base.yaml
@@ -1,0 +1,22 @@
+# Updated : 2026.02.04
+# Version : 1.0.0
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+packages:
+  sub_device: !include balancer_base_sub_device.yaml
+  led_assign: !include balancer_base_led_assign.yaml

--- a/packages/balancer/balancer_base_led_assign.yaml
+++ b/packages/balancer/balancer_base_led_assign.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.2.9
+# Updated : 2026.02.01
+# Version : 1.0.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,10 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
-packages:
-  balancer: !include bms_base_balancer.yaml
-  battery_soc: !include bms_base_battery_soc.yaml
-  charging_cycles: !include bms_base_charging_cycles.yaml
-  daily_energy: !include bms_base_daily_energy.yaml
-  sub_device: !include bms_base_sub_device.yaml
-  led_assign: !include bms_base_led_assign.yaml
+substitutions:
+  # The ID of the LED on your board used for this component
+  balancer_status_led_id: "virtual_status_light"
+
+esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_BALANCER}, 1, id(${balancer_status_led_id}));

--- a/packages/balancer/balancer_modbus_client.yaml
+++ b/packages/balancer/balancer_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.04
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,12 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+packages:
+  balancer_base: !include balancer_base.yaml
+
 substitutions:
   balancer_model: "YamBMS"
   balancer_protocol: "Modbus"
-
-packages:
-  sub_device: !include balancer_base_sub_device.yaml
 
 # +--------------------------------------+
 # | Component settings                   |

--- a/packages/balancer/balancer_modbus_client.yaml
+++ b/packages/balancer/balancer_modbus_client.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.04
+# Updated : 2026.02.05
 # Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -17,12 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
-packages:
-  balancer_base: !include balancer_base.yaml
-
 substitutions:
   balancer_model: "YamBMS"
   balancer_protocol: "Modbus"
+
+packages:
+  balancer_base: !include balancer_base.yaml
 
 # +--------------------------------------+
 # | Component settings                   |

--- a/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -23,6 +23,7 @@ substitutions:
 
 packages:
   sub_device: !include balancer_base_sub_device.yaml
+  fault_updater: !include balancer_base_led_assign.yaml
 
 ota:
   on_begin:
@@ -66,9 +67,11 @@ binary_sensor:
       id: balancer${bms_id}_online_status
       device_id: balancer_${bms_id}
       name: "online status"
-      on_state:
-        then:
-          - lambda: id(bms${bms_id}_var_ext_balancer_online) = x;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_BALANCER}, ${bms_id}, !x);
     balancing:
       id: balancer${bms_id}_equalizing
       device_id: balancer_${bms_id}

--- a/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
@@ -17,13 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+packages:
+  balancer_base: !include balancer_base.yaml
+
 substitutions:
   balancer_model: "JK NEEY"
   balancer_protocol: "BLE"
-
-packages:
-  sub_device: !include balancer_base_sub_device.yaml
-  fault_updater: !include balancer_base_led_assign.yaml
 
 ota:
   on_begin:

--- a/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.04
+# Updated : 2026.02.05
 # Version : 1.1.3
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
@@ -17,12 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
-packages:
-  balancer_base: !include balancer_base.yaml
-
 substitutions:
   balancer_model: "JK NEEY"
   balancer_protocol: "BLE"
+
+packages:
+  balancer_base: !include balancer_base.yaml
 
 ota:
   on_begin:

--- a/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.03
+# Updated : 2026.02.04
 # Version : 1.1.3
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
@@ -67,11 +67,12 @@ binary_sensor:
       id: balancer${bms_id}_online_status
       device_id: balancer_${bms_id}
       name: "online status"
-    on_state:
-      then:
-        - lambda: |-
-            // Pass the current state to the update function
-            id(global_update_fault)(${CAT_BALANCER}, ${bms_id}, !x);
+      on_state:
+        then:
+          - lambda: id(bms${bms_id}_var_ext_balancer_online) = x;
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BALANCER}, ${bms_id}, !x);
     balancing:
       id: balancer${bms_id}_equalizing
       device_id: balancer_${bms_id}

--- a/packages/base/device_base.yaml
+++ b/packages/base/device_base.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.2.3
+# Updated : 2026.02.01
+# Version : 1.2.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -20,6 +20,21 @@
 packages:
   device_base_esphome: !include device_base_esphome.yaml
   sub_device: !include device_base_sub_device.yaml
+  fault_registry: !include device_base_fault_registry.yaml
+
+substitutions:
+  # The ID of the LED on your board used for this component
+  board_status_led_id: "esp_light"
+  # ID for this component instance for fault registry
+  board_fault_device_id: "1"
+
+esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_SYSTEM}, ${board_fault_device_id}, id(${board_status_led_id}));
 
 time:
   # https://esphome.io/components/time/homeassistant
@@ -48,6 +63,12 @@ binary_sensor:
     id: esp32_online_status
     device_id: ${board_id}
     entity_category: diagnostic
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_SYSTEM}, ${board_fault_device_id}, !x);
+
   # Inverter communication status (CANBUS / RS485)
   - platform: template
     name: Inverter communication status

--- a/packages/base/device_base_ethernet.yaml
+++ b/packages/base/device_base_ethernet.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.2.3
+# Updated : 2026.02.01
+# Version : 1.2.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,6 +17,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+substitutions:
+  # The ID of the LED on your board used for this component
+  network_status_led_id: "esp_light"
+  # ID for this component instance for fault registry
+  network_device_id: "1"
+
+esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_NETWORK}, ${network_device_id}, id(${network_status_led_id}));
+
 text_sensor:
   # https://esphome.io/components/text_sensor/ethernet_info.html
   - platform: ethernet_info
@@ -32,3 +46,13 @@ text_sensor:
       name: MAC address
       id: esp32_mac_address
       device_id: ${board_id}
+
+interval:
+  - interval: 5s
+    then:
+      - lambda: |-
+          // network::is_connected() can be used for wifi or ethernet.
+          // It returns true if Ethernet or WiFi has a valid Link + IP.
+          bool x = network::is_connected();
+
+          id(global_update_fault)(${CAT_NETWORK}, ${network_device_id}, !x);

--- a/packages/base/device_base_fault_registry.yaml
+++ b/packages/base/device_base_fault_registry.yaml
@@ -142,7 +142,7 @@ interval:
 
             std::string cat_name;
             switch(cat) {
-                case 0: cat_name = "SYSTEM     "; break;
+                case 0: cat_name = "API / MQTT "; break;
                 case 1: cat_name = "BMS        "; break;
                 case 2: cat_name = "CAN->INV   "; break;
                 case 3: cat_name = "RS485->INV "; break;

--- a/packages/base/device_base_fault_registry.yaml
+++ b/packages/base/device_base_fault_registry.yaml
@@ -27,7 +27,6 @@ substitutions:
   CAT_SHUNT:       "4"
   CAT_BALANCER:    "5"
   CAT_NETWORK:     "6"
-  CAT_AUX_1:       "7"
 
   enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
 
@@ -35,9 +34,10 @@ globals:
 
   # Tracks True/False fault status for every component instance
   # Structure: [Component Category (0-15)] -> [Specific Instance ID (0-N)]
+  # 0 = Healthy, 1 = Fault, 2 = Unregistered
   - id: global_instance_faults
-    type: std::vector<std::vector<bool>>
-    initial_value: std::vector<std::vector<bool>>(16) 
+    type: std::vector<std::vector<uint8_t>>
+    initial_value: std::vector<std::vector<uint8_t>>(16)
     restore_value: false
 
   # Component Fault Bitmask: A 16-bit summary of the component instance health.
@@ -57,11 +57,12 @@ globals:
         std::string json = "[";
         for (int cat = 0; cat < 16; cat++) {
           auto &faults = id(global_instance_faults)[cat];
-          if (cat > 0) json += ","; 
+          if (cat > 0) json += ",";
           json += "[";
           for (size_t i = 0; i < faults.size(); i++) {
-            if (i > 0) json += ","; 
-            json += (faults[i] ? "1" : "0");
+            if (i > 0) json += ",";
+            // 0 = Healthy, 1= Fault, 2 = Unregistered
+            json += to_string(faults[i]);
           }
           json += "]";
         }
@@ -78,50 +79,49 @@ globals:
       [](int category, int instance, bool is_failing) {
         int computer_instance = instance - 1;
 
-        // Checks
         if (category < 0 || category >= 16 || computer_instance < 0) return;
 
         auto &faults = id(global_instance_faults)[category];
-        
-        // Auto-Resize Vector if needed
+
+        // Resize with default value '2' (Unregistered).
         if (computer_instance >= faults.size()) {
-           faults.resize(computer_instance + 1, false);
+          faults.resize(computer_instance + 1, 2); 
         }
 
-        // Update only if state changed
-        if (faults[computer_instance] != is_failing) {
-           
-           // Update the specific instance in the list
-           faults[computer_instance] = is_failing;
-           
-           // Trigger the sensor update
-           id(global_update_health_sensor)();
-           
-           // Update the Master Mask ---
-           // Re-scan this category to see if it is now Clean or Faulted
-           bool cat_has_fault = false;
-           for(bool f : faults) {
-              if(f) { 
-                cat_has_fault = true; 
-                break; 
-              }
-           }
+        // Convert input boolean to integer
+        // Input false (Healthy) -> 0
+        // Input true (Fault)    -> 1
+        uint8_t new_state = is_failing ? 1 : 0;
 
-           // Update the specific bit in the global mask
-           if(cat_has_fault) {
-               id(global_system_fault_mask) |= (1 << category); // Set Bit to 1
-           } else {
-               id(global_system_fault_mask) &= ~(1 << category); // Clear Bit to 0
-           }
-        } 
+        // Update only if state changed
+        if (faults[computer_instance] != new_state) {
+          
+          faults[computer_instance] = new_state;
+          id(global_update_health_sensor)();
+
+          // Update Master Mask
+          // State 2 (unregistered) is ignored
+          bool cat_has_fault = false;
+          for(uint8_t f : faults) {
+            if(f == 1) { 
+              cat_has_fault = true;
+              break;
+            }
+          }
+
+          if(cat_has_fault) {
+            id(global_system_fault_mask) |= (1 << category);
+          } else {
+            id(global_system_fault_mask) &= ~(1 << category);
+          }
+        }
       }
 
-interval:        
-  # System Health Report in logs, enabled via enable_health_logging substitution
+interval:
   - interval: 60s
     then:
       - lambda: |-
-          // If the substitution is false, stop
+          // Check if logging is enabled
           if (!${enable_health_logging}) return;
 
           ESP_LOGI("health_rpt", "┌──────────────────────────────┐");
@@ -130,51 +130,70 @@ interval:
 
           // Log Master Bitmask
           uint16_t mask = id(global_system_fault_mask);
-          ESP_LOGI("health_rpt", "Global Fault Mask: %d (Binary: " BYTE_TO_BINARY_PATTERN " " BYTE_TO_BINARY_PATTERN ")", 
-                   mask, BYTE_TO_BINARY(mask>>8), BYTE_TO_BINARY(mask));
+          std::string binary_mask = std::bitset<16>(mask).to_string();
+          ESP_LOGI("health_rpt", "Global Fault Mask: %d (Binary: %s)", mask, binary_mask.c_str());
+
+          bool system_clean = true;
 
           // Iterate through all 16 Categories
-          bool system_clean = true;
-          
           for (int cat = 0; cat < 16; cat++) {
             auto &faults = id(global_instance_faults)[cat];
             if (faults.empty()) continue;
 
+            // Define Category Names
             std::string cat_name;
             switch(cat) {
-                case 0: cat_name = "API / MQTT "; break;
-                case 1: cat_name = "BMS        "; break;
-                case 2: cat_name = "CAN->INV   "; break;
-                case 3: cat_name = "RS485->INV "; break;
-                case 4: cat_name = "SHUNT      "; break;
-                case 5: cat_name = "BALANCER   "; break;
-                case 6: cat_name = "NETWORK    "; break;
-                case 7: cat_name = "AUX 1      "; break;
-                default: cat_name = "CAT_" + to_string(cat) + "     "; break;
+              case 0: cat_name = "API / MQTT "; break;
+              case 1: cat_name = "BMS        "; break;
+              case 2: cat_name = "CAN->INV   "; break;
+              case 3: cat_name = "RS485->INV "; break;
+              case 4: cat_name = "SHUNT      "; break;
+              case 5: cat_name = "BALANCER   "; break;
+              case 6: cat_name = "NETWORK    "; break;
+              default: cat_name = "CAT_" + to_string(cat) + "     "; break;
             }
 
             std::string status_line = "";
             bool cat_has_fault = false;
+            bool cat_has_real_devices = false; 
 
+            // Determine status
             for (size_t i = 0; i < faults.size(); i++) {
-                if (faults[i]) {
-                    status_line += "[FAIL] ";
-                    cat_has_fault = true;
-                    system_clean = false;
-                } else {
-                    status_line += "[ OK ] ";
-                }
+              uint8_t state = faults[i];
+
+              if (state == 0) {
+                // Healthy
+                status_line += "[ OK ] ";
+                cat_has_real_devices = true;
+              } 
+              else if (state == 1) {
+                // Fault
+                status_line += "[FAIL] ";
+                cat_has_fault = true;
+                cat_has_real_devices = true;
+                system_clean = false;
+              } 
+              else {
+                // Unregistered devices
+                status_line += "[ -- ] "; 
+              }
             }
 
-            if (cat_has_fault) {
+            // Log the component if instances exist
+            if (cat_has_real_devices) {
+              if (cat_has_fault) {
+                // Set to WARN if fault
                 ESP_LOGW("health_rpt", ">> %s: %s", cat_name.c_str(), status_line.c_str());
-            } else {
+              } else {
+                // Set to INFO if healthy
                 ESP_LOGI("health_rpt", "   %s: %s", cat_name.c_str(), status_line.c_str());
+              }
             }
           }
 
+          // Footer
           if (system_clean) {
-             ESP_LOGI("health_rpt", ">> ALL SYSTEMS NORMAL");
+            ESP_LOGI("health_rpt", ">> ALL SYSTEMS NORMAL");
           }
           ESP_LOGI("health_rpt", "--------------------------------");
 

--- a/packages/base/device_base_fault_registry.yaml
+++ b/packages/base/device_base_fault_registry.yaml
@@ -1,0 +1,186 @@
+# Updated : 2026.02.01
+# Version : 1.0.0
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+substitutions:
+  # --- CATEGORY DICTIONARY ---
+  # Use these human-readable names in component yaml substitutions, up to 16 categories
+  CAT_SYSTEM:      "0"
+  CAT_BMS:         "1"
+  CAT_INV_CAN_BUS: "2"
+  CAT_INV_RS485:   "3"
+  CAT_SHUNT:       "4"
+  CAT_BALANCER:    "5"
+  CAT_NETWORK:     "6"
+  CAT_AUX_1:       "7"
+
+  enable_health_logging: 'false'  # Set to true to see if component health for all component instances, logged every 60 seconds
+
+globals:
+
+  # Tracks True/False fault status for every component instance
+  # Structure: [Component Category (0-15)] -> [Specific Instance ID (0-N)]
+  - id: global_instance_faults
+    type: std::vector<std::vector<bool>>
+    initial_value: std::vector<std::vector<bool>>(16) 
+    restore_value: false
+
+  # Component Fault Bitmask: A 16-bit summary of the component instance health.
+  # If Bit 4 is "1", it means "At least one instance in Category 4 is failing."
+  - id: global_system_fault_mask
+    type: uint16_t
+    initial_value: '0'
+    restore_value: false
+
+  # -------------------------------------------------------
+  # Global Function: Update Fault Sensor
+  # -------------------------------------------------------
+  - id: global_update_health_sensor
+    type: "std::function<void()>"
+    initial_value: |-
+      []() {
+        std::string json = "[";
+        for (int cat = 0; cat < 16; cat++) {
+          auto &faults = id(global_instance_faults)[cat];
+          if (cat > 0) json += ","; 
+          json += "[";
+          for (size_t i = 0; i < faults.size(); i++) {
+            if (i > 0) json += ","; 
+            json += (faults[i] ? "1" : "0");
+          }
+          json += "]";
+        }
+        json += "]";
+        id(sys_fault_data).publish_state(json);
+      }
+
+# ---------------------------------------------------------
+  # Global Function: Update Fault Status
+  # ---------------------------------------------------------
+  - id: global_update_fault
+    type: std::function<void(int, int, bool)>
+    initial_value: |-
+      [](int category, int instance, bool is_failing) {
+        int computer_instance = instance - 1;
+
+        // Checks
+        if (category < 0 || category >= 16 || computer_instance < 0) return;
+
+        auto &faults = id(global_instance_faults)[category];
+        
+        // Auto-Resize Vector if needed
+        if (computer_instance >= faults.size()) {
+           faults.resize(computer_instance + 1, false);
+        }
+
+        // Update only if state changed
+        if (faults[computer_instance] != is_failing) {
+           
+           // Update the specific instance in the list
+           faults[computer_instance] = is_failing;
+           
+           // Trigger the sensor update
+           id(global_update_health_sensor)();
+           
+           // Update the Master Mask ---
+           // Re-scan this category to see if it is now Clean or Faulted
+           bool cat_has_fault = false;
+           for(bool f : faults) {
+              if(f) { 
+                cat_has_fault = true; 
+                break; 
+              }
+           }
+
+           // Update the specific bit in the global mask
+           if(cat_has_fault) {
+               id(global_system_fault_mask) |= (1 << category); // Set Bit to 1
+           } else {
+               id(global_system_fault_mask) &= ~(1 << category); // Clear Bit to 0
+           }
+        } 
+      }
+
+interval:        
+  # System Health Report in logs, enabled via enable_health_logging substitution
+  - interval: 60s
+    then:
+      - lambda: |-
+          // If the substitution is false, stop
+          if (!${enable_health_logging}) return;
+
+          ESP_LOGI("health_rpt", "┌──────────────────────────────┐");
+          ESP_LOGI("health_rpt", "│     SYSTEM HEALTH REPORT     │");
+          ESP_LOGI("health_rpt", "└──────────────────────────────┘");
+
+          // Log Master Bitmask
+          uint16_t mask = id(global_system_fault_mask);
+          ESP_LOGI("health_rpt", "Global Fault Mask: %d (Binary: " BYTE_TO_BINARY_PATTERN " " BYTE_TO_BINARY_PATTERN ")", 
+                   mask, BYTE_TO_BINARY(mask>>8), BYTE_TO_BINARY(mask));
+
+          // Iterate through all 16 Categories
+          bool system_clean = true;
+          
+          for (int cat = 0; cat < 16; cat++) {
+            auto &faults = id(global_instance_faults)[cat];
+            if (faults.empty()) continue;
+
+            std::string cat_name;
+            switch(cat) {
+                case 0: cat_name = "SYSTEM     "; break;
+                case 1: cat_name = "BMS        "; break;
+                case 2: cat_name = "CAN->INV   "; break;
+                case 3: cat_name = "RS485->INV "; break;
+                case 4: cat_name = "SHUNT      "; break;
+                case 5: cat_name = "BALANCER   "; break;
+                case 6: cat_name = "NETWORK    "; break;
+                case 7: cat_name = "AUX 1      "; break;
+                default: cat_name = "CAT_" + to_string(cat) + "     "; break;
+            }
+
+            std::string status_line = "";
+            bool cat_has_fault = false;
+
+            for (size_t i = 0; i < faults.size(); i++) {
+                if (faults[i]) {
+                    status_line += "[FAIL] ";
+                    cat_has_fault = true;
+                    system_clean = false;
+                } else {
+                    status_line += "[ OK ] ";
+                }
+            }
+
+            if (cat_has_fault) {
+                ESP_LOGW("health_rpt", ">> %s: %s", cat_name.c_str(), status_line.c_str());
+            } else {
+                ESP_LOGI("health_rpt", "   %s: %s", cat_name.c_str(), status_line.c_str());
+            }
+          }
+
+          if (system_clean) {
+             ESP_LOGI("health_rpt", ">> ALL SYSTEMS NORMAL");
+          }
+          ESP_LOGI("health_rpt", "--------------------------------");
+
+text_sensor:
+  # JSON sensor representing system fault data, use with markdown card in Home Assistant
+  - platform: template
+    name: "System Fault Data"
+    id: sys_fault_data
+    entity_category: diagnostic

--- a/packages/base/device_base_wifi.yaml
+++ b/packages/base/device_base_wifi.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.2.3
+# Updated : 2026.02.01
+# Version : 1.2.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -16,6 +16,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+substitutions:
+  # The ID of the LED on your board used for this component
+  network_status_led_id: "esp_light"
+  # ID for this component instance for fault registry
+  network_fault_device_id: "1"
+
+esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_NETWORK}, ${network_fault_device_id}, id(${network_status_led_id}));
 
 sensor:
   # https://esphome.io/components/sensor/wifi_signal
@@ -67,3 +81,13 @@ text_sensor:
       name: DNS address
       id: esp32_dns_address
       device_id: ${board_id}
+
+interval:
+  - interval: 5s
+    then:
+      - lambda: |-
+          // network::is_connected() can be used for wifi or ethernet.
+          // It returns true if Ethernet or WiFi has a valid Link + IP.
+          bool x = network::is_connected();
+
+          id(global_update_fault)(${CAT_NETWORK}, ${network_fault_device_id}, !x);

--- a/packages/bms/bms_base_led_assign.yaml
+++ b/packages/bms/bms_base_led_assign.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.2.9
+# Updated : 2026.02.01
+# Version : 1.0.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,10 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
-packages:
-  balancer: !include bms_base_balancer.yaml
-  battery_soc: !include bms_base_battery_soc.yaml
-  charging_cycles: !include bms_base_charging_cycles.yaml
-  daily_energy: !include bms_base_daily_energy.yaml
-  sub_device: !include bms_base_sub_device.yaml
-  led_assign: !include bms_base_led_assign.yaml
+substitutions:
+  # The ID of the LED on your board used for this component
+  bms_status_led_id: "virtual_status_light"
+
+esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_BMS}, ${bms_id}, id(${bms_status_led_id}));

--- a/packages/bms/bms_combine.yaml
+++ b/packages/bms/bms_combine.yaml
@@ -28,9 +28,10 @@ globals:
 # Combine once without conditions
 esphome:
   on_boot:
-    then:
-      # Shunt counter (total)
-      - lambda: id(${yambms_id}_var_bms_counter) += 1;
+    - priority: 600
+      then:
+        # Shunt counter (total)
+        - lambda: id(${yambms_id}_var_bms_counter) += 1;
 
 binary_sensor:
   # Indicates whether the BMS can be combined

--- a/packages/bms/bms_sensors_BASEN_RS485_full.yaml
+++ b/packages/bms/bms_sensors_BASEN_RS485_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.27
-# Version : 1.1.10
+# Updated : 2026.02.01
+# Version : 1.1.11
 # GitHub  : https://github.com/GHswitt/esphome-basen
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -42,6 +42,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "status online"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
     alarm:
       id: bms${bms_id}_alarm
       device_id: bms_${bms_id}

--- a/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.8
+# Updated : 2026.02.01
+# Version : 1.1.9
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -28,7 +28,7 @@ packages:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${canbus_id}
+  - id: !extend ${ext_canbus_id}
     on_frame:
     - can_id: 0x11${deye_module_id}
       then:
@@ -156,6 +156,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
   # Equalizing
   - platform: template

--- a/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.9
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
@@ -28,7 +28,7 @@ packages:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${ext_canbus_id}
+  - id: !extend ${canbus_id}
     on_frame:
     - can_id: 0x11${deye_module_id}
       then:
@@ -151,16 +151,16 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: "status online"
-    lambda: |-
-      if (id(bms${bms_id}_total_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
+    lambda: |-
+      if (id(bms${bms_id}_total_voltage).state > 0)
+        return true;
+      else
+        return false;
 
   # Equalizing
   - platform: template

--- a/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.8
+# Updated : 2026.02.01
+# Version : 1.1.9
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -28,7 +28,7 @@ packages:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${canbus_id}
+  - id: !extend ${ext_canbus_id}
     on_frame:
     - can_id: 0x11${deye_module_id}
       then:
@@ -103,6 +103,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
   # Equalizing
   - platform: template

--- a/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.9
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
@@ -28,7 +28,7 @@ packages:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${ext_canbus_id}
+  - id: !extend ${canbus_id}
     on_frame:
     - can_id: 0x11${deye_module_id}
       then:
@@ -98,16 +98,16 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: "status online"
-    lambda: |-
-      if (id(bms${bms_id}_total_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
+    lambda: |-
+      if (id(bms${bms_id}_total_voltage).state > 0)
+        return true;
+      else
+        return false;
 
   # Equalizing
   - platform: template

--- a/packages/bms/bms_sensors_DEYE_CAN_top_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_top_full.yaml
@@ -36,7 +36,7 @@ globals:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${canbus_id}
+  - id: !extend ${ext_canbus_id}
     on_frame:
     - can_id: 0x351
       then:
@@ -52,7 +52,7 @@ canbus:
 
             if (!id(deye${deye_id}_send_flag)) {
               std::vector<uint8_t> data{0x01};
-              id(${canbus_id})->send_data(0x18A2FF80, true, data);
+              id(${ext_canbus_id})->send_data(0x18A2FF80, true, data);
               id(deye${deye_id}_send_flag) = true;
             }
 

--- a/packages/bms/bms_sensors_DEYE_CAN_top_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_top_full.yaml
@@ -36,7 +36,7 @@ globals:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${ext_canbus_id}
+  - id: !extend ${canbus_id}
     on_frame:
     - can_id: 0x351
       then:
@@ -52,7 +52,7 @@ canbus:
 
             if (!id(deye${deye_id}_send_flag)) {
               std::vector<uint8_t> data{0x01};
-              id(${ext_canbus_id})->send_data(0x18A2FF80, true, data);
+              id(${canbus_id})->send_data(0x18A2FF80, true, data);
               id(deye${deye_id}_send_flag) = true;
             }
 

--- a/packages/bms/bms_sensors_DEYE_CAN_top_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_top_minimal.yaml
@@ -30,7 +30,7 @@ globals:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${canbus_id}
+  - id: !extend ${ext_canbus_id}
     on_frame:
     - can_id: 0x351
       then:
@@ -46,7 +46,7 @@ canbus:
 
             if (!id(deye${deye_id}_send_flag)) {
               std::vector<uint8_t> data{0x01};
-              id(${canbus_id})->send_data(0x18A2FF80, true, data);
+              id(${ext_canbus_id})->send_data(0x18A2FF80, true, data);
               id(deye${deye_id}_send_flag) = true;
             }
 

--- a/packages/bms/bms_sensors_DEYE_CAN_top_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_top_minimal.yaml
@@ -30,7 +30,7 @@ globals:
 # +-----------------------------------------------+
 
 canbus:
-  - id: !extend ${ext_canbus_id}
+  - id: !extend ${canbus_id}
     on_frame:
     - can_id: 0x351
       then:
@@ -46,7 +46,7 @@ canbus:
 
             if (!id(deye${deye_id}_send_flag)) {
               std::vector<uint8_t> data{0x01};
-              id(${ext_canbus_id})->send_data(0x18A2FF80, true, data);
+              id(${canbus_id})->send_data(0x18A2FF80, true, data);
               id(deye${deye_id}_send_flag) = true;
             }
 

--- a/packages/bms/bms_sensors_EG4_LLV2_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_EG4_LLV2_RS485_bms_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 2.0.1
+# Updated : 2026.02.01
+# Version : 2.0.2
 # GitHub  : https://github.com/RAR/esphome-eg4-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -48,6 +48,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "online status"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
     heating:
       device_id: bms_${bms_id}
       name: "heating"

--- a/packages/bms/bms_sensors_FAKE.yaml
+++ b/packages/bms/bms_sensors_FAKE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.14
-# Version : 1.2.3
+# Updated : 2026.02.03
+# Version : 1.2.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -21,6 +21,7 @@ packages:
   balancer: !include bms_base_balancer.yaml
   bms_battery_soc: !include bms_base_battery_soc.yaml
   sub_device: !include bms_base_sub_device.yaml
+  led_assign: !include bms_base_led_assign.yaml
   # bms_temperature_sensor: !include bms_temperature_sensor_4.yaml
 
 number:
@@ -130,6 +131,11 @@ binary_sensor:
     device_id: bms_${bms_id}
     name: "online status"
     lambda: return id(bms${bms_id}_online_status_switch).state;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
   # charging_allowed
   - platform: template
     id: bms${bms_id}_charging_allowed

--- a/packages/bms/bms_sensors_FAKE.yaml
+++ b/packages/bms/bms_sensors_FAKE.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.03
+# Updated : 2026.02.04
 # Version : 1.2.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -130,12 +130,12 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: "online status"
-    lambda: return id(bms${bms_id}_online_status_switch).state;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
+    lambda: return id(bms${bms_id}_online_status_switch).state;
   # charging_allowed
   - platform: template
     id: bms${bms_id}_charging_allowed

--- a/packages/bms/bms_sensors_JBD_BLE_full.yaml
+++ b/packages/bms/bms_sensors_JBD_BLE_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.2.0
+# Updated : 2026.02.01
+# Version : 1.2.1
 # GitHub  : https://github.com/syssi/esphome-jdb-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -80,6 +80,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "online status"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
 switch:
   - platform: jbd_bms_ble

--- a/packages/bms/bms_sensors_JBD_UART_full.yaml
+++ b/packages/bms/bms_sensors_JBD_UART_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.2.0
+# Updated : 2026.02.01
+# Version : 1.2.1
 # GitHub  : https://github.com/syssi/esphome-jdb-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -71,6 +71,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "online status"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
 switch:
   - platform: jbd_bms

--- a/packages/bms/bms_sensors_JK_BLE_standard.yaml
+++ b/packages/bms/bms_sensors_JK_BLE_standard.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.3.3
+# Updated : 2026.02.01
+# Version : 1.3.4
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -86,6 +86,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "online status"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
 switch:
   - platform: jk_bms_ble

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.9
+# Updated : 2026.02.01
+# Version : 1.1.10
 # GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -86,6 +86,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "status online"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
     status_heating:
       device_id: bms_${bms_id}
       name: "status heating"

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_bms_full.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_bms_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.3.3
+# Updated : 2026.02.01
+# Version : 1.3.4
 # GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -110,6 +110,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "status online"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
     status_heating:
       device_id: bms_${bms_id}
       name: "status heating"

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.3.4
+# Updated : 2026.02.01
+# Version : 1.3.5
 # GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -110,6 +110,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "status online"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
     status_heating:
       device_id: bms_${bms_id}
       name: "status heating"

--- a/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
+++ b/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.3.4
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
@@ -78,16 +78,16 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: "online status"
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
     lambda: |-
       if (id(bms${bms_id}_total_voltage).state > 0)
         return true;
       else
         return false;
-      on_state:
-        then:
-          - lambda: |-
-              // Pass the current state to the update function
-              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
 switch:
   - platform: jk_bms

--- a/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
+++ b/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.3.3
+# Updated : 2026.02.01
+# Version : 1.3.4
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -83,6 +83,11 @@ binary_sensor:
         return true;
       else
         return false;
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
 switch:
   - platform: jk_bms

--- a/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.7
 # GitHub  : https://github.com/syssi/esphome-pace-bms
 
@@ -79,14 +79,15 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: "online status"
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
     lambda: |-
       // Consider online if we have valid total_voltage reading (> 0V indicates communication)
       return id(bms${bms_id}_total_voltage).has_state() && id(bms${bms_id}_total_voltage).state > 0;
-      on_state:
-        then:
-          - lambda: |-
-              // Pass the current state to the update function
-              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
+
 
   #  11  Status/Fault flag                     2 byte   R  uint16  Hex See ^3
   #      Bit 8: Status: Charging operation

--- a/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.19
-# Version : 1.1.6
+# Updated : 2026.02.01
+# Version : 1.1.7
 # GitHub  : https://github.com/syssi/esphome-pace-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -82,6 +82,11 @@ binary_sensor:
     lambda: |-
       // Consider online if we have valid total_voltage reading (> 0V indicates communication)
       return id(bms${bms_id}_total_voltage).has_state() && id(bms${bms_id}_total_voltage).state > 0;
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
 
   #  11  Status/Fault flag                     2 byte   R  uint16  Hex See ^3
   #      Bit 8: Status: Charging operation

--- a/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
@@ -88,7 +88,6 @@ binary_sensor:
       // Consider online if we have valid total_voltage reading (> 0V indicates communication)
       return id(bms${bms_id}_total_voltage).has_state() && id(bms${bms_id}_total_voltage).state > 0;
 
-
   #  11  Status/Fault flag                     2 byte   R  uint16  Hex See ^3
   #      Bit 8: Status: Charging operation
   - platform: modbus_controller

--- a/packages/bms/bms_sensors_SEPLOS_V1_V2_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_SEPLOS_V1_V2_RS485_bms_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.2.1
+# Updated : 2026.02.01
+# Version : 1.2.2
 # GitHub  : https://github.com/syssi/esphome-seplos-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -48,6 +48,11 @@ binary_sensor:
       id: bms${bms_id}_online_status
       device_id: bms_${bms_id}
       name: "online status"
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
   # Required sensors cannot be retrieved from BMS
   # equalizing
   - platform: template

--- a/packages/bms/bms_sensors_SEPLOS_V3_RS485_sniffer_bms_full.yaml
+++ b/packages/bms/bms_sensors_SEPLOS_V3_RS485_sniffer_bms_full.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.5
 # GitHub  : https://github.com/syssi/esphome-seplos-bms
 
@@ -34,16 +34,16 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: ${bms_prefix} Online status
-    lambda: |-
-      if (id(bms${bms_id}_total_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
+    lambda: |-
+      if (id(bms${bms_id}_total_voltage).state > 0)
+        return true;
+      else
+        return false;
   # equalizing
   - platform: template
     id: bms${bms_id}_bms_equalizing

--- a/packages/bms/bms_sensors_SEPLOS_V3_RS485_sniffer_bms_full.yaml
+++ b/packages/bms/bms_sensors_SEPLOS_V3_RS485_sniffer_bms_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.23
-# Version : 1.1.4
+# Updated : 2026.02.01
+# Version : 1.1.5
 # GitHub  : https://github.com/syssi/esphome-seplos-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -39,6 +39,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
   # equalizing
   - platform: template
     id: bms${bms_id}_bms_equalizing

--- a/packages/board/board_ESP32-S3_AtomS3R.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3R.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.3.5
+# Updated : 2026.02.01
+# Version : 1.3.6
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -64,9 +64,10 @@ esphome:
     board_build.flash_mode: dio             # use Dual IO (dio) instead of Quad IO (qio) to prevent boot loop after flashing
     board_upload.maximum_ram_size: 524288   # total size of the internal RAM in bits, it's the same for all ESP32-S3 ( 512KB )
   on_boot:
-    then:
-      - output.turn_on:
-           id: white
+    - priority: 600
+      then:
+        - output.turn_on:
+            id: white
 
 external_components:
   # Backlight

--- a/packages/board/board_options_led_control.yaml
+++ b/packages/board/board_options_led_control.yaml
@@ -33,24 +33,20 @@ globals:
   # Global Function: Update LED assignment
   # ---------------------------------------------------------
   - id: global_register_led
-    type: std::function<void(int, int, light::LightState*)>
+    type: std::function<void(int, int, esphome::light::LightState*)>
     initial_value: |-
-      [](int category, int instance, light::LightState* led) {
-
-        if (led == &id(virtual_status_light)) {
-            led = nullptr; 
-        }
-
+      [](int category, int instance, esphome::light::LightState* led) {
         int computer_instance = instance - 1;
         if (category < 0 || category >= 16 || computer_instance < 0) return;
-
         auto &leds = id(global_led_registry)[category];
-        auto &faults = id(global_instance_faults)[category];
 
-        if (leds.size() <= computer_instance) {
-          leds.resize(computer_instance + 1, nullptr);
-          faults.resize(computer_instance + 1, false);
+        // Resize if needed
+        if (computer_instance >= leds.size()) {
+          // Fill new empty slots with nullptr
+          leds.resize(computer_instance + 1, nullptr); 
         }
+
+        // Store the pointer
         leds[computer_instance] = led;
       }
 
@@ -119,8 +115,9 @@ interval:
               int max_active_category = -1;
               for (int cat = 0; cat < 16; cat++) {
                   auto &faults = id(global_instance_faults)[cat];
-                  for (bool f : faults) {
-                      if (f) {
+                  // Only state 1 is a fault
+                  for (uint8_t f : faults) {
+                      if (f == 1) { 
                           if (cat > max_active_category) max_active_category = cat;
                           break; // Found a fault in this category, move to next
                       }
@@ -162,6 +159,7 @@ interval:
              auto &leds_in_cat = id(global_led_registry)[cat];
              for (size_t inst = 0; inst < leds_in_cat.size(); inst++) {
                  auto *led = leds_in_cat[inst];
+                 // SAFETY CHECK: Ignore nullptr slots created by vector resizing
                  if (led != nullptr) assignments[led].push_back({cat, (int)inst});
              }
           }
@@ -181,8 +179,10 @@ interval:
                   int cat = pair.first;
                   int inst = pair.second;
                   auto &cat_faults = id(global_instance_faults)[cat];
-                  // Check if this specific instance index is flagged as true
-                  if (inst < cat_faults.size() && cat_faults[inst]) {
+                  
+                  // TRI-STATE UPDATE: Check if index exists AND value is explicitly '1' (Fail)
+                  // '0' (OK) and '2' (Ghost) are ignored.
+                  if (inst < cat_faults.size() && cat_faults[inst] == 1) {
                       active_fault_categories.push_back(cat);
                   }
               }
@@ -322,7 +322,6 @@ interval:
                 case 4: cat_name = "SHUNT      "; break;
                 case 5: cat_name = "BALANCER   "; break;
                 case 6: cat_name = "NETWORK    "; break;
-                case 7: cat_name = "AUX 1      "; break;
                 default: cat_name = "CAT_" + to_string(cat) + "     "; break;
             }
 
@@ -330,11 +329,19 @@ interval:
             std::string status_line = "";
             
             for (size_t i = 0; i < leds.size(); i++) {
-                // Check if the pointer is valid
-                if (leds[i] != nullptr) {
+                // Check for unregistered component instances
+                // These are slots created only to resize the vector
+                if (leds[i] == nullptr) {
+                    status_line += "[ -- ] ";
+                } 
+                // Determine if a placeholder LED is assigned
+                else if (leds[i] == id(virtual_status_light)) {
+                    status_line += "[NONE] ";
+                } 
+                // Physical LED assigned
+                // These are active hardware lights responding to faults
+                else {
                     status_line += "[LINK] ";
-                } else {
-                    status_line += "[NULL] ";
                 }
             }
 

--- a/packages/board/board_options_led_control.yaml
+++ b/packages/board/board_options_led_control.yaml
@@ -29,6 +29,12 @@ globals:
     type: std::vector<std::vector<esphome::light::LightState*>>
     initial_value: 'std::vector<std::vector<esphome::light::LightState*>>(16)'
 
+  # Set true when a component registers (or re-registers) an LED.
+  - id: global_led_registry_updated
+    type: bool
+    restore_value: false
+    initial_value: 'true'
+
   # ---------------------------------------------------------
   # Global Function: Update LED assignment
   # ---------------------------------------------------------
@@ -40,6 +46,8 @@ globals:
         if (category < 0 || category >= 16 || computer_instance < 0) return;
         auto &leds = id(global_led_registry)[category];
 
+        // Mark cached LED assignments updated (rebuilt by the 50ms LED loop)
+        id(global_led_registry_updated) = true;
         // Resize if needed
         if (computer_instance >= leds.size()) {
           // Fill new empty slots with nullptr
@@ -73,220 +81,300 @@ interval:
           // -----------------------------------------------------------------------
           // Define the timing characteristics of the annunciator signal.
           const uint32_t HEADER_MS = 1000;        // Duration of the initial Blue/Green sync pulse
-          const uint32_t PRE_PIP_GAP_MS = 500;    // Silence between Header and first Red Pip
-          const uint32_t PIP_DURATION_MS = 300;   // Total time per pip (150ms ON / 150ms OFF)
-          const uint32_t GROUP_GAP_MS = 500;      // Extended pause inserted after every 4th pip
+          const uint32_t PRE_BLINK_GAP_MS = 500;  // Silence between Header and first Red Blink
+          const uint32_t BLINK_DURATION_MS = 300; // Total time per blink (150ms ON / 150ms OFF)
+          const uint32_t GROUP_GAP_MS = 500;      // Extended pause inserted after every 4th blink
           const uint32_t END_PADDING_MS = 1000;   // Minimum silence at end of cycle before restart
-          
+
           // -----------------------------------------------------------------------
           // STATE MANAGEMENT
           // -----------------------------------------------------------------------
           // Tracks the current fault index for LEDs with multiple assigned faults
+          
           struct LedStateContext {
-              size_t fault_index;     // Index in the local list of active faults
-              int last_cycle_id;      // Used to detect when a new global cycle begins
+            size_t fault_index; // Index in the local list of active faults
+            int last_cycle_id;  // Used to detect when a new global cycle begins
+
+            // Render cache
+            bool last_valid;
+            bool last_state;
+            float last_r;
+            float last_g;
+            float last_b;
+            float last_bri;
           };
 
-          // Persistent storage for LED states (Key: LightState pointer)
+          // Persistent storage for LED states
           static std::map<esphome::light::LightState*, LedStateContext> states;
-          
+
+          // Cached LED assignments (rebuilt only when global_led_registry_updated is set)
+          static std::map<esphome::light::LightState*, std::vector<std::pair<int, int>>> assignments;
+
           // Global timing variables
           static uint32_t cycle_start_ms = 0;
           static uint32_t current_cycle_duration = 2000; // Default to 2s (Healthy state)
           static int global_cycle_count = 0;             // Increments every full loop
 
           // -----------------------------------------------------------------------
-          // STEP 1: DYNAMIC TIMING CALCULATION
+          // REGISTRY MAPPING (PERFORMANCE OPTIMIZATION)
+          // -----------------------------------------------------------------------
+          // Invert the Category->LED registry to build a list of assignments per LED.
+          //
+          // Build only when global_register_led() marks the registry updated.
+          if (id(global_led_registry_updated)) {
+            assignments.clear();
+
+            for (int cat = 0; cat < 16; cat++) {
+              auto &leds_in_cat = id(global_led_registry)[cat];
+              for (size_t inst = 0; inst < leds_in_cat.size(); inst++) {
+                auto *led = leds_in_cat[inst];
+                // Ignore nullptr slots created by vector resizing
+                if (led != nullptr) assignments[led].push_back({cat, (int)inst});
+              }
+            }
+
+            id(global_led_registry_updated) = false;
+          }
+
+          // -----------------------------------------------------------------------
+          // DYNAMIC TIMING CALCULATION
           // -----------------------------------------------------------------------
           // The cycle duration is adaptive. It expands to fit the longest active
-          // fault code in the system, preventing long dead-air waits for short codes.
-          
+          // fault code in the system, preventing long waits for short codes.
+
           uint32_t now = millis();
           int32_t time_into_cycle = now - cycle_start_ms;
 
           // Check if the current cycle has completed
           if (time_into_cycle >= current_cycle_duration || time_into_cycle < 0) {
-              // Start new cycle
-              cycle_start_ms = now;
-              time_into_cycle = 0;
-              global_cycle_count++;
+            // Start new cycle
+            cycle_start_ms = now;
+            time_into_cycle = 0;
+            global_cycle_count++;
 
-              // Scan global registry to find the highest active Category ID
-              int max_active_category = -1;
-              for (int cat = 0; cat < 16; cat++) {
-                  auto &faults = id(global_instance_faults)[cat];
-                  // Only state 1 is a fault
-                  for (uint8_t f : faults) {
-                      if (f == 1) { 
-                          if (cat > max_active_category) max_active_category = cat;
-                          break; // Found a fault in this category, move to next
-                      }
-                  }
+            // Scan global registry to find the highest active Category ID
+            int max_active_category = -1;
+            for (int cat = 0; cat < 16; cat++) {
+              auto &faults = id(global_instance_faults)[cat];
+              // Only state 1 is a fault
+              for (uint8_t f : faults) {
+                if (f == 1) {
+                  if (cat > max_active_category) max_active_category = cat;
+                  break; // Found a fault in this category, move to next
+                }
               }
+            }
 
-              // Calculate required duration for the next cycle
-              if (max_active_category == -1) {
-                  // System Healthy: Default to 2s (1s ON, 1s OFF)
-                  current_cycle_duration = 2000;
-              } else {
-                  // System Faulted: Calculate exact time needed for the longest code
-                  int pips = max_active_category + 1;
-                  
-                  // Calculate total time for pips
-                  uint32_t total_pip_time = pips * PIP_DURATION_MS;
-                  
-                  // Calculate total time for group gaps (1 gap after every 4 pips)
-                  // Integer division ensures gap is only added for full groups of 4
-                  int gaps = (pips - 1) / 4;
-                  uint32_t total_gap_time = gaps * GROUP_GAP_MS;
+            // Calculate required duration for the next cycle
+            if (max_active_category == -1) {
+              // System Healthy: Default to 2s (1s ON, 1s OFF)
+              current_cycle_duration = 2000;
+            } else {
+              // System Faulted: Calculate exact time needed for the longest code
+              int blinks = max_active_category + 1;
 
-                  current_cycle_duration = HEADER_MS + PRE_PIP_GAP_MS + total_pip_time + total_gap_time + END_PADDING_MS;
-                  
-                  // Enforce minimum 2s to allow the Green/Blue header to finish properly
-                  if (current_cycle_duration < 2000) current_cycle_duration = 2000;
-              }
+              // Calculate total time for blinks
+              uint32_t total_blink_time = blinks * BLINK_DURATION_MS;
+
+              // Calculate total time for group gaps (1 gap after every 4 blinks)
+              // Integer division ensures gap is only added for full groups of 4
+              int gaps = (blinks - 1) / 4;
+              uint32_t total_gap_time = gaps * GROUP_GAP_MS;
+
+              current_cycle_duration = HEADER_MS + PRE_BLINK_GAP_MS + total_blink_time + total_gap_time + END_PADDING_MS;
+
+              // Enforce minimum 2s to allow the Green/Blue header to finish properly
+              if (current_cycle_duration < 2000) current_cycle_duration = 2000;
+            }
           }
 
           // -----------------------------------------------------------------------
-          // STEP 2: REGISTRY MAPPING
+          // RENDER
           // -----------------------------------------------------------------------
-          // Invert the Category->LED registry to build a list of assignments per LED.
-          // This allows each LED to know exactly which Categories/Instances it monitors.
-          
-          std::map<esphome::light::LightState*, std::vector<std::pair<int, int>>> assignments;
-          
-          for (int cat = 0; cat < 16; cat++) {
-             auto &leds_in_cat = id(global_led_registry)[cat];
-             for (size_t inst = 0; inst < leds_in_cat.size(); inst++) {
-                 auto *led = leds_in_cat[inst];
-                 // SAFETY CHECK: Ignore nullptr slots created by vector resizing
-                 if (led != nullptr) assignments[led].push_back({cat, (int)inst});
-             }
-          }
-
-          // -----------------------------------------------------------------------
-          // STEP 3: RENDER
-          // -----------------------------------------------------------------------
-          // "Spotlight Logic": The Healthy Green Pulse is only active during the Header phase.
-          // This ensures the rest of the cycle is dark, making Red Pips easier to count.
+          // The Health pulse is only active during the Header phase.
+          // This ensures the rest of the cycle is dark, making blinks easier to count.
           bool is_header_phase = (time_into_cycle < HEADER_MS);
 
-          for (auto const& [led, assigned_list] : assignments) {
-              
-              // Filter assigned items to find currently active faults
-              std::vector<int> active_fault_categories;
-              for (auto &pair : assigned_list) {
-                  int cat = pair.first;
-                  int inst = pair.second;
-                  auto &cat_faults = id(global_instance_faults)[cat];
-                  
-                  // TRI-STATE UPDATE: Check if index exists AND value is explicitly '1' (Fail)
-                  // '0' (OK) and '2' (Ghost) are ignored.
-                  if (inst < cat_faults.size() && cat_faults[inst] == 1) {
-                      active_fault_categories.push_back(cat);
-                  }
+          for (auto const &kv : assignments) {
+            auto *led = kv.first;
+            auto const &assigned_list = kv.second;
+
+            // Filter assigned items to find how many active faults exist
+            int active_fault_count = 0;
+            for (auto &pair : assigned_list) {
+              int cat = pair.first;
+              int inst = pair.second;
+              auto &cat_faults = id(global_instance_faults)[cat];
+
+              // Check if index exists AND value is explicitly '1' (Fail)
+              // '0' (OK) and '2' (Ghost) are ignored.
+              if (inst < (int)cat_faults.size() && cat_faults[inst] == 1) {
+                active_fault_count++;
               }
+            }
 
-              LedStateContext &ctx = states[led];
-              float bri = 0.5;
-              auto call = led->make_call();
+            LedStateContext &ctx = states[led];
 
-              // CASE A: UNASSIGNED LED
-              // Force off to prevent floating states
-              if (assigned_list.empty()) {
-                  call.set_state(false).perform();
-                  continue;
+            // Defaults to off
+            bool target_state = false;
+            float target_r = 0.0f;
+            float target_g = 0.0f;
+            float target_b = 0.0f;
+            float target_bri = 0.5f;
+
+            // UNASSIGNED LED
+            // Force off to prevent floating states
+            if (assigned_list.empty()) {
+              // Optimization: only call into the light stack if need to change something
+              if (!ctx.last_valid || ctx.last_state) {
+                auto call = led->make_call();
+                call.set_state(false);
+                call.perform();
+                ctx.last_valid = true;
+                ctx.last_state = false;
+                ctx.last_r = 0.0f;
+                ctx.last_g = 0.0f;
+                ctx.last_b = 0.0f;
+                ctx.last_bri = target_bri;
               }
+              continue;
+            }
 
-              // CASE B: HEALTHY LED
-              // No active faults found in assigned categories
-              if (active_fault_categories.empty()) {
-                  ctx.fault_index = 0; // Reset index for future faults
-                  
-                  if (is_header_phase) {
-                      // Pulse Green during the global sync header
-                      if (${board_has_rgb}) call.set_rgb(0.0, 1.0, 0.0);
-                      call.set_brightness(bri).set_state(true);
-                  } else {
-                      // Stay dark during the data phase to avoid visual noise
-                      call.set_state(false);
-                  }
-                  call.perform();
-                  continue;
+            // HEALTHY LED
+            // No active faults found in assigned categories
+            if (active_fault_count == 0) {
+              ctx.fault_index = 0; // Reset index for future faults
+
+              if (is_header_phase) {
+                // Pulse green during the global sync header
+                target_state = true;
+                target_g = 1.0f;
+              } else {
+                // Otherwise off
+                target_state = false;
               }
+            }
 
-              // CASE C: FAULTED LED
-              
-              // Handle Multi-Fault Rotation:
-              // If this LED has multiple faults, switch to the next one 
+            // FAULT LED
+            else {
+              // If this LED has multiple faults, switch to the next one
               // only when the global cycle restarts.
               if (ctx.last_cycle_id != global_cycle_count) {
-                  ctx.last_cycle_id = global_cycle_count;
-                  ctx.fault_index++;
-                  // Wrap around if index exceeds number of active faults
-                  if (ctx.fault_index >= active_fault_categories.size()) ctx.fault_index = 0;
+                ctx.last_cycle_id = global_cycle_count;
+                ctx.fault_index++;
+                // Wrap around based on number of active faults
+                if (ctx.fault_index >= (size_t)active_fault_count) ctx.fault_index = 0;
               }
 
-              // Retrieve the specific category to display for this cycle
-              int current_cat = active_fault_categories[ctx.fault_index];
-              int pips_needed = current_cat + 1; // Cat 0 = 1 pip
+              // Resolve which fault category to display for this cycle
+              size_t desired_idx = ctx.fault_index;
+              int current_cat = -1;
+              int seen = 0;
 
-              // --- RENDERING PHASES ---
-
-              // Phase 1: Blue Header (Syncs with Healthy Green)
-              if (time_into_cycle < HEADER_MS) {
-                  if (${board_has_rgb}) call.set_rgb(0.0, 0.0, 1.0);
-                  call.set_brightness(bri).set_state(true);
-                  call.perform();
-                  continue;
-              }
-
-              // Phase 2: Gap (Silence before pips start)
-              uint32_t start_pips = HEADER_MS + PRE_PIP_GAP_MS;
-              if (time_into_cycle < start_pips) {
-                  call.set_state(false).perform();
-                  continue;
-              }
-
-              // Phase 3: Grouped Pips
-              uint32_t t_pips = time_into_cycle - start_pips;
-              
-              // Calculate Time Block logic for grouping (4 pips + 1 gap)
-              // Block Duration = (4 * 300ms) + 500ms = 1700ms
-              const uint32_t BLOCK_DURATION = (4 * PIP_DURATION_MS) + GROUP_GAP_MS;
-              
-              int block_idx = t_pips / BLOCK_DURATION;
-              uint32_t t_within_block = t_pips % BLOCK_DURATION;
-              
-              // Calculate how many pips were displayed in previous full blocks
-              int pips_rendered_previously = block_idx * 4;
-              
-              // Check if we are in the "Blinking" part of the block or the "Gap" part
-              if (t_within_block < (4 * PIP_DURATION_MS)) {
-                  // Inside the blinking window
-                  int pip_in_block = t_within_block / PIP_DURATION_MS; // 0..3
-                  int actual_pip_number = pips_rendered_previously + pip_in_block + 1; // 1-based index
-                  
-                  if (actual_pip_number <= pips_needed) {
-                      // We are within the count for this fault code.
-                      // Toggle ON/OFF based on 50% duty cycle of PIP_DURATION_MS
-                      if ((t_within_block % PIP_DURATION_MS) < (PIP_DURATION_MS / 2)) {
-                           // LED ON (Red)
-                           if (${board_has_rgb}) call.set_rgb(1.0, 0.0, 0.0);
-                           call.set_brightness(bri).set_state(true);
-                      } else {
-                           // LED OFF (Inter-pip pause)
-                           call.set_state(false);
-                      }
-                  } else {
-                      // Count exceeded, stay dark
-                      call.set_state(false);
+              for (auto &pair : assigned_list) {
+                int cat = pair.first;
+                int inst = pair.second;
+                auto &cat_faults = id(global_instance_faults)[cat];
+                if (inst < (int)cat_faults.size() && cat_faults[inst] == 1) {
+                  if ((size_t)seen == desired_idx) {
+                    current_cat = cat;
+                    break;
                   }
-              } else {
-                  // We are in the Inter-Group Gap (the pause after 4 pips)
-                  call.set_state(false);
+                  seen++;
+                }
               }
-              call.perform();
+
+              // If faults disappeared mid-loop
+              if (current_cat >= 0) {
+                int blinks_needed = current_cat + 1; // Cat 0 = 1 blink
+
+                // --- RENDERING PHASES ---
+
+                // Blue Header
+                if (time_into_cycle < HEADER_MS) {
+                  target_state = true;
+                  target_b = 1.0f;
+                }
+
+                // Gap before blinks start
+                else {
+                  uint32_t start_blinks = HEADER_MS + PRE_BLINK_GAP_MS;
+                  if (time_into_cycle < start_blinks) {
+                    target_state = false;
+                  }
+
+                  // Blink code
+                  else {
+                    uint32_t t_blinks = time_into_cycle - start_blinks;
+
+                    // Calculate Time Block logic for grouping (4 blinks + 1 gap)
+                    // Block Duration = (4 * 300ms) + 500ms = 1700ms
+                    const uint32_t BLOCK_DURATION = (4 * BLINK_DURATION_MS) + GROUP_GAP_MS;
+
+                    int block_idx = t_blinks / BLOCK_DURATION;
+                    uint32_t t_within_block = t_blinks % BLOCK_DURATION;
+
+                    // Calculate how many blinks were displayed in previous full blocks
+                    int blinks_rendered_previously = block_idx * 4;
+
+                    // Check if in the blink code part of the block or the gap part
+                    if (t_within_block < (4 * BLINK_DURATION_MS)) {
+                      // Inside the blinking window
+                      int blink_in_block = t_within_block / BLINK_DURATION_MS; // 0..3
+                      int actual_blink_number = blinks_rendered_previously + blink_in_block + 1; // 1-based index
+
+                      if (actual_blink_number <= blinks_needed) {
+                        // Within the count for this fault code.
+                        if ((t_within_block % BLINK_DURATION_MS) < (BLINK_DURATION_MS / 2)) {
+                          // LED on
+                          target_state = true;
+                          target_r = 1.0f;
+                        } else {
+                          // LED off
+                          target_state = false;
+                        }
+                      } else {
+                        // Count exceeded, stay off
+                        target_state = false;
+                      }
+                    } else {
+                      // We are in the blink group gap
+                      target_state = false;
+                    }
+                  }
+                }
+              }
+            }
+
+            // -----------------------------------------------------------------------
+            // RENDER CACHE
+            // -----------------------------------------------------------------------
+            bool need_update = !ctx.last_valid || (ctx.last_state != target_state);
+            if (!need_update && target_state) {
+              // Only compare when on
+              if (ctx.last_bri != target_bri) need_update = true;
+              if (${board_has_rgb}) {
+                if (ctx.last_r != target_r || ctx.last_g != target_g || ctx.last_b != target_b) need_update = true;
+              }
+            }
+
+            if (!need_update) continue;
+
+            auto call = led->make_call();
+            call.set_state(target_state);
+            if (target_state) {
+              call.set_brightness(target_bri);
+              if (${board_has_rgb}) call.set_rgb(target_r, target_g, target_b);
+            }
+            call.perform();
+
+            // Update cache
+            ctx.last_valid = true;
+            ctx.last_state = target_state;
+            ctx.last_r = target_r;
+            ctx.last_g = target_g;
+            ctx.last_b = target_b;
+            ctx.last_bri = target_bri;
           }
 
 

--- a/packages/board/board_options_led_control.yaml
+++ b/packages/board/board_options_led_control.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.1.2
+# Updated : 2026.02.03
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,124 +17,331 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+
 substitutions:
-  # Placeholder light_id if no led is provided
-  light_id: "esp_light"
+  enable_led_logging: 'false'
+  global_status_led: "esp_light"
 
 globals:
-  - id: var_led_state
-    type: int
-    restore_value: no
-    initial_value: '0'
+  # 2D grid of physical LED pointers
+  # Structure: [Component Category (0-15)] -> [Specific Instance ID (0-N)]
+  - id: global_led_registry
+    type: std::vector<std::vector<esphome::light::LightState*>>
+    initial_value: 'std::vector<std::vector<esphome::light::LightState*>>(16)'
+
+  # ---------------------------------------------------------
+  # Global Function: Update LED assignment
+  # ---------------------------------------------------------
+  - id: global_register_led
+    type: std::function<void(int, int, light::LightState*)>
+    initial_value: |-
+      [](int category, int instance, light::LightState* led) {
+
+        if (led == &id(virtual_status_light)) {
+            led = nullptr; 
+        }
+
+        int computer_instance = instance - 1;
+        if (category < 0 || category >= 16 || computer_instance < 0) return;
+
+        auto &leds = id(global_led_registry)[category];
+        auto &faults = id(global_instance_faults)[category];
+
+        if (leds.size() <= computer_instance) {
+          leds.resize(computer_instance + 1, nullptr);
+          faults.resize(computer_instance + 1, false);
+        }
+        leds[computer_instance] = led;
+      }
+
+
+output:
+  - platform: template
+    id: virtual_output
+    type: binary
+    write_action: []
+
+# Fake light to act as a placeholder for LED control logic
+light:
+  - platform: binary
+    id: virtual_status_light
+    output: virtual_output
+
 
 interval:
-  - interval: 5s
-    then:
-      - lambda: |-
-          // Set LED state
-          auto& led_state = id(var_led_state);
-          const bool esp_ok = id(esp32_online_status).state;
-          const bool com_ok = id(inverter_com_status).state;
-          // 0 : critical | 1 : esp_ok only | 2 : com_ok only | 3 : all OK 
-          led_state = (esp_ok ? 1 : 0) + (com_ok ? 2 : 0);
-          ESP_LOGD("board", "LED state : %d", led_state);
-          
   - interval: 50ms
     then:
       - lambda: |-
-          // +============================================================
-          // | Status LED: 4 states, color + counted flashes
-          // |
-          // | state 0 = critical, red,     quad flash
-          // | state 1 = warning,  yellow,  triple flash
-          // | state 2 = info,     blue,    double flash
-          // | state 3 = healthy,  green,   single flash
-          // |
-          // | Timing (aligned to 50ms interval):
-          // | - ON_MS   = 150ms
-          // | - SLOT_MS = 300ms  (150ms ON + 150ms OFF)
-          // | - CYCLE   = 2000ms (includes a pause after the last pulse)
-          // |
-          // | Interval: 50ms
-          // +============================================================
-
-          // LED state
-          const auto state = id(var_led_state);
-
-          // If no light was specified then exit
-          esphome::light::LightState *light = ${light_id};
-          if (light == nullptr) return;
-
-          // Cache last output so only push changes at edges / state changes
-          static int  last_state = -999;   // -1 means "invalid/off"
-          static bool last_on = false;
-
-          // Restart flash cycle when the state changes (more readable)
-          static uint32_t base_ms = 0;
-
-          auto turn_off_once = [&]() {
-            if (last_state != -1 || last_on != false) {
-              auto call = light->make_call();
-              call.set_transition_length(0);
-              call.set_state(false);
-              call.perform();
-              last_state = -1;
-              last_on = false;
-            }
+          // -----------------------------------------------------------------------
+          // CONFIGURATION CONSTANTS
+          // -----------------------------------------------------------------------
+          // Define the timing characteristics of the annunciator signal.
+          const uint32_t HEADER_MS = 1000;        // Duration of the initial Blue/Green sync pulse
+          const uint32_t PRE_PIP_GAP_MS = 500;    // Silence between Header and first Red Pip
+          const uint32_t PIP_DURATION_MS = 300;   // Total time per pip (150ms ON / 150ms OFF)
+          const uint32_t GROUP_GAP_MS = 500;      // Extended pause inserted after every 4th pip
+          const uint32_t END_PADDING_MS = 1000;   // Minimum silence at end of cycle before restart
+          
+          // -----------------------------------------------------------------------
+          // STATE MANAGEMENT
+          // -----------------------------------------------------------------------
+          // Tracks the current fault index for LEDs with multiple assigned faults
+          struct LedStateContext {
+              size_t fault_index;     // Index in the local list of active faults
+              int last_cycle_id;      // Used to detect when a new global cycle begins
           };
 
-          // Input is an integer (0..3 expected)
-          // Invalid -> off (on transition)
-          if (state < 0 || state > 3) {
-            turn_off_once();
-            return;
+          // Persistent storage for LED states (Key: LightState pointer)
+          static std::map<esphome::light::LightState*, LedStateContext> states;
+          
+          // Global timing variables
+          static uint32_t cycle_start_ms = 0;
+          static uint32_t current_cycle_duration = 2000; // Default to 2s (Healthy state)
+          static int global_cycle_count = 0;             // Increments every full loop
+
+          // -----------------------------------------------------------------------
+          // STEP 1: DYNAMIC TIMING CALCULATION
+          // -----------------------------------------------------------------------
+          // The cycle duration is adaptive. It expands to fit the longest active
+          // fault code in the system, preventing long dead-air waits for short codes.
+          
+          uint32_t now = millis();
+          int32_t time_into_cycle = now - cycle_start_ms;
+
+          // Check if the current cycle has completed
+          if (time_into_cycle >= current_cycle_duration || time_into_cycle < 0) {
+              // Start new cycle
+              cycle_start_ms = now;
+              time_into_cycle = 0;
+              global_cycle_count++;
+
+              // Scan global registry to find the highest active Category ID
+              int max_active_category = -1;
+              for (int cat = 0; cat < 16; cat++) {
+                  auto &faults = id(global_instance_faults)[cat];
+                  for (bool f : faults) {
+                      if (f) {
+                          if (cat > max_active_category) max_active_category = cat;
+                          break; // Found a fault in this category, move to next
+                      }
+                  }
+              }
+
+              // Calculate required duration for the next cycle
+              if (max_active_category == -1) {
+                  // System Healthy: Default to 2s (1s ON, 1s OFF)
+                  current_cycle_duration = 2000;
+              } else {
+                  // System Faulted: Calculate exact time needed for the longest code
+                  int pips = max_active_category + 1;
+                  
+                  // Calculate total time for pips
+                  uint32_t total_pip_time = pips * PIP_DURATION_MS;
+                  
+                  // Calculate total time for group gaps (1 gap after every 4 pips)
+                  // Integer division ensures gap is only added for full groups of 4
+                  int gaps = (pips - 1) / 4;
+                  uint32_t total_gap_time = gaps * GROUP_GAP_MS;
+
+                  current_cycle_duration = HEADER_MS + PRE_PIP_GAP_MS + total_pip_time + total_gap_time + END_PADDING_MS;
+                  
+                  // Enforce minimum 2s to allow the Green/Blue header to finish properly
+                  if (current_cycle_duration < 2000) current_cycle_duration = 2000;
+              }
           }
 
-          // If state changed, restart cycle at t=0
-          if (state != last_state) {
-            base_ms = millis();
+          // -----------------------------------------------------------------------
+          // STEP 2: REGISTRY MAPPING
+          // -----------------------------------------------------------------------
+          // Invert the Category->LED registry to build a list of assignments per LED.
+          // This allows each LED to know exactly which Categories/Instances it monitors.
+          
+          std::map<esphome::light::LightState*, std::vector<std::pair<int, int>>> assignments;
+          
+          for (int cat = 0; cat < 16; cat++) {
+             auto &leds_in_cat = id(global_led_registry)[cat];
+             for (size_t inst = 0; inst < leds_in_cat.size(); inst++) {
+                 auto *led = leds_in_cat[inst];
+                 if (led != nullptr) assignments[led].push_back({cat, (int)inst});
+             }
           }
 
-          // --- flash timing constants (multiples of 50ms) ---
-          constexpr uint32_t CYCLE_MS = 2000;
-          constexpr uint32_t SLOT_MS  = 300;   // ON + gap
-          constexpr uint32_t ON_MS    = 150;
+          // -----------------------------------------------------------------------
+          // STEP 3: RENDER
+          // -----------------------------------------------------------------------
+          // "Spotlight Logic": The Healthy Green Pulse is only active during the Header phase.
+          // This ensures the rest of the cycle is dark, making Red Pips easier to count.
+          bool is_header_phase = (time_into_cycle < HEADER_MS);
 
-          const uint32_t t = (millis() - base_ms) % CYCLE_MS;
+          for (auto const& [led, assigned_list] : assignments) {
+              
+              // Filter assigned items to find currently active faults
+              std::vector<int> active_fault_categories;
+              for (auto &pair : assigned_list) {
+                  int cat = pair.first;
+                  int inst = pair.second;
+                  auto &cat_faults = id(global_instance_faults)[cat];
+                  // Check if this specific instance index is flagged as true
+                  if (inst < cat_faults.size() && cat_faults[inst]) {
+                      active_fault_categories.push_back(cat);
+                  }
+              }
 
-          // Pulse counts per state: 0->4, 1->3, 2->2, 3->1
-          constexpr uint8_t PULSES[4] = {4, 3, 2, 1};
-          const uint8_t pulses = PULSES[state];
+              LedStateContext &ctx = states[led];
+              float bri = 0.5;
+              auto call = led->make_call();
 
-          const uint32_t slot_index = t / SLOT_MS;
-          const uint32_t slot_pos   = t - (slot_index * SLOT_MS);
+              // CASE A: UNASSIGNED LED
+              // Force off to prevent floating states
+              if (assigned_list.empty()) {
+                  call.set_state(false).perform();
+                  continue;
+              }
 
-          const bool desired_on =
-              (slot_index < pulses) &&
-              (slot_pos < ON_MS);
+              // CASE B: HEALTHY LED
+              // No active faults found in assigned categories
+              if (active_fault_categories.empty()) {
+                  ctx.fault_index = 0; // Reset index for future faults
+                  
+                  if (is_header_phase) {
+                      // Pulse Green during the global sync header
+                      if (${board_has_rgb}) call.set_rgb(0.0, 1.0, 0.0);
+                      call.set_brightness(bri).set_state(true);
+                  } else {
+                      // Stay dark during the data phase to avoid visual noise
+                      call.set_state(false);
+                  }
+                  call.perform();
+                  continue;
+              }
 
-          // If nothing changes, do nothing
-          if (state == last_state && desired_on == last_on) return;
+              // CASE C: FAULTED LED
+              
+              // Handle Multi-Fault Rotation:
+              // If this LED has multiple faults, switch to the next one 
+              // only when the global cycle restarts.
+              if (ctx.last_cycle_id != global_cycle_count) {
+                  ctx.last_cycle_id = global_cycle_count;
+                  ctx.fault_index++;
+                  // Wrap around if index exceeds number of active faults
+                  if (ctx.fault_index >= active_fault_categories.size()) ctx.fault_index = 0;
+              }
 
-          auto call = light->make_call();
-          call.set_transition_length(0);
+              // Retrieve the specific category to display for this cycle
+              int current_cat = active_fault_categories[ctx.fault_index];
+              int pips_needed = current_cat + 1; // Cat 0 = 1 pip
 
-          // RGB mapping (set only when state changes)
-          const bool is_rgb = ${board_has_rgb};
-          if (is_rgb && state != last_state) {
-            call.set_brightness(0.5f);
+              // --- RENDERING PHASES ---
 
-            switch (state) {
-              case 0: call.set_rgb(1.0f, 0.0f, 0.0f);  break; // Red
-              case 1: call.set_rgb(1.0f, 1.0f, 0.0f);  break; // Yellow
-              case 2: call.set_rgb(0.0f, 0.0f, 1.0f);  break; // Blue
-              case 3: call.set_rgb(0.0f, 1.0f, 0.0f);  break; // Green
+              // Phase 1: Blue Header (Syncs with Healthy Green)
+              if (time_into_cycle < HEADER_MS) {
+                  if (${board_has_rgb}) call.set_rgb(0.0, 0.0, 1.0);
+                  call.set_brightness(bri).set_state(true);
+                  call.perform();
+                  continue;
+              }
+
+              // Phase 2: Gap (Silence before pips start)
+              uint32_t start_pips = HEADER_MS + PRE_PIP_GAP_MS;
+              if (time_into_cycle < start_pips) {
+                  call.set_state(false).perform();
+                  continue;
+              }
+
+              // Phase 3: Grouped Pips
+              uint32_t t_pips = time_into_cycle - start_pips;
+              
+              // Calculate Time Block logic for grouping (4 pips + 1 gap)
+              // Block Duration = (4 * 300ms) + 500ms = 1700ms
+              const uint32_t BLOCK_DURATION = (4 * PIP_DURATION_MS) + GROUP_GAP_MS;
+              
+              int block_idx = t_pips / BLOCK_DURATION;
+              uint32_t t_within_block = t_pips % BLOCK_DURATION;
+              
+              // Calculate how many pips were displayed in previous full blocks
+              int pips_rendered_previously = block_idx * 4;
+              
+              // Check if we are in the "Blinking" part of the block or the "Gap" part
+              if (t_within_block < (4 * PIP_DURATION_MS)) {
+                  // Inside the blinking window
+                  int pip_in_block = t_within_block / PIP_DURATION_MS; // 0..3
+                  int actual_pip_number = pips_rendered_previously + pip_in_block + 1; // 1-based index
+                  
+                  if (actual_pip_number <= pips_needed) {
+                      // We are within the count for this fault code.
+                      // Toggle ON/OFF based on 50% duty cycle of PIP_DURATION_MS
+                      if ((t_within_block % PIP_DURATION_MS) < (PIP_DURATION_MS / 2)) {
+                           // LED ON (Red)
+                           if (${board_has_rgb}) call.set_rgb(1.0, 0.0, 0.0);
+                           call.set_brightness(bri).set_state(true);
+                      } else {
+                           // LED OFF (Inter-pip pause)
+                           call.set_state(false);
+                      }
+                  } else {
+                      // Count exceeded, stay dark
+                      call.set_state(false);
+                  }
+              } else {
+                  // We are in the Inter-Group Gap (the pause after 4 pips)
+                  call.set_state(false);
+              }
+              call.perform();
+          }
+
+
+
+  # LED Assignment Report in logs, enabled via enable_led_logging substitution
+  - interval: 60s
+    then:
+      - lambda: |-
+          // If the substitution is false, stop
+          if (!${enable_led_logging}) return;
+
+          ESP_LOGI("led_rpt", "┌──────────────────────────────┐");
+          ESP_LOGI("led_rpt", "│    LED REGISTRY ASSIGNMENT   │");
+          ESP_LOGI("led_rpt", "└──────────────────────────────┘");
+
+          bool registry_empty = true;
+
+          for (int cat = 0; cat < 16; cat++) {
+            // Access the LED Registry
+            auto &leds = id(global_led_registry)[cat];
+            
+            // Skip empty categories
+            if (leds.empty()) continue;
+            registry_empty = false;
+
+            // Translate ID to Name
+            std::string cat_name;
+            switch(cat) {
+                case 0: cat_name = "API / MQTT "; break;
+                case 1: cat_name = "BMS        "; break;
+                case 2: cat_name = "CAN->INV   "; break;
+                case 3: cat_name = "RS485->INV "; break;
+                case 4: cat_name = "SHUNT      "; break;
+                case 5: cat_name = "BALANCER   "; break;
+                case 6: cat_name = "NETWORK    "; break;
+                case 7: cat_name = "AUX 1      "; break;
+                default: cat_name = "CAT_" + to_string(cat) + "     "; break;
             }
+
+            // Build the status string for this category's LEDs
+            std::string status_line = "";
+            
+            for (size_t i = 0; i < leds.size(); i++) {
+                // Check if the pointer is valid
+                if (leds[i] != nullptr) {
+                    status_line += "[LINK] ";
+                } else {
+                    status_line += "[NULL] ";
+                }
+            }
+
+            ESP_LOGI("led_rpt", "   %s: %s", cat_name.c_str(), status_line.c_str());
           }
 
-          // Apply flash (RGB + mono)
-          call.set_state(desired_on);
-          call.perform();
-
-          last_state = state;
-          last_on = desired_on;
+          if (registry_empty) {
+             ESP_LOGW("led_rpt", ">> WARNING: NO LEDS REGISTERED");
+          }
+          ESP_LOGI("led_rpt", "--------------------------------");

--- a/packages/shunt/shunt_base.yaml
+++ b/packages/shunt/shunt_base.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.5
+# Updated : 2026.02.03
+# Version : 1.1.6
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -19,6 +19,7 @@
 
 packages:
   shunt_base_minimal: !include shunt_base_minimal.yaml
+  led_assign: !include shunt_base_led_assign.yaml
 
 sensor:
   # Daily Charging Energy

--- a/packages/shunt/shunt_base_led_assign.yaml
+++ b/packages/shunt/shunt_base_led_assign.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.03
-# Version : 1.2.9
+# Version : 1.0.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,10 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
-packages:
-  balancer: !include bms_base_balancer.yaml
-  battery_soc: !include bms_base_battery_soc.yaml
-  charging_cycles: !include bms_base_charging_cycles.yaml
-  daily_energy: !include bms_base_daily_energy.yaml
-  sub_device: !include bms_base_sub_device.yaml
-  led_assign: !include bms_base_led_assign.yaml
+substitutions:
+  # The ID of the LED on your board used for this component
+  shunt_status_led_id: "virtual_status_light"
+
+esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_SHUNT}, ${shunt_id}, id(${shunt_status_led_id}));

--- a/packages/shunt/shunt_combine.yaml
+++ b/packages/shunt/shunt_combine.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.01.30
+# Updated : 2026.02.01
 # Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -34,9 +34,10 @@ globals:
 # Combine once without conditions
 esphome:
   on_boot:
-    then:
-      # Shunt counter (total)
-      - lambda: id(${yambms_id}_var_shunt_counter) += 1;
+    - priority: 600
+      then:
+        # Shunt counter (total)
+        - lambda: id(${yambms_id}_var_shunt_counter) += 1;
 
 switch:
   # Combine enable/disable Switch

--- a/packages/shunt/shunt_sensors_FAKE.yaml
+++ b/packages/shunt/shunt_sensors_FAKE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.6
+# Updated : 2026.02.01
+# Version : 1.1.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -32,6 +32,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 sensor:
   # total_voltage

--- a/packages/shunt/shunt_sensors_FAKE.yaml
+++ b/packages/shunt/shunt_sensors_FAKE.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -27,16 +27,16 @@ binary_sensor:
     id: shunt${shunt_id}_online_status
     device_id: shunt_${shunt_id}
     name: "Online status"
-    lambda: |-
-      if (id(shunt${shunt_id}_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
+    lambda: |-
+      if (id(shunt${shunt_id}_voltage).state > 0)
+        return true;
+      else
+        return false;
 
 sensor:
   # total_voltage

--- a/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
+++ b/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.7
 # GitHub  : https://github.com/Sleeper85/esphome-junctek_khf
 
@@ -44,16 +44,16 @@ binary_sensor:
     id: shunt${shunt_id}_online_status
     device_id: shunt_${shunt_id}
     name: "Online status"
-    lambda: |-
-      if (id(shunt${shunt_id}_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
+    lambda: |-
+      if (id(shunt${shunt_id}_voltage).state > 0)
+        return true;
+      else
+        return false;
 
 # Platform :
 # junctek_khf : version with the screen connected (UART and RS485)

--- a/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
+++ b/packages/shunt/shunt_sensors_Junctek_KHF_UART.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.6
+# Updated : 2026.02.01
+# Version : 1.1.7
 # GitHub  : https://github.com/Sleeper85/esphome-junctek_khf
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -49,6 +49,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 # Platform :
 # junctek_khf : version with the screen connected (UART and RS485)

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_BLE.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.5
+# Updated : 2026.02.01
+# Version : 1.1.6
 # GitHub  : https://github.com/Fabian-Schmidt/esphome-victron_ble
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -73,6 +73,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 text_sensor:
   - platform: victron_ble

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_BLE.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_BLE.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.6
 # GitHub  : https://github.com/Fabian-Schmidt/esphome-victron_ble
 
@@ -68,16 +68,16 @@ binary_sensor:
     id: shunt${shunt_id}_online_status
     device_id: shunt_${shunt_id}
     name: "Online Status"
-    lambda: |-
-      if (id(shunt${shunt_id}_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
+    lambda: |-
+      if (id(shunt${shunt_id}_voltage).state > 0)
+        return true;
+      else
+        return false;
 
 text_sensor:
   - platform: victron_ble

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.6
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
@@ -49,16 +49,16 @@ binary_sensor:
     id: shunt${shunt_id}_online_status
     device_id: shunt_${shunt_id}
     name: "Online Status"
-    lambda: |-
-      if (id(shunt${shunt_id}_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
+    lambda: |-
+      if (id(shunt${shunt_id}_voltage).state > 0)
+        return true;
+      else
+        return false;
 
 sensor:
   - platform: victron

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.5
+# Updated : 2026.02.01
+# Version : 1.1.6
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -54,6 +54,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 sensor:
   - platform: victron

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.01
+# Updated : 2026.02.04
 # Version : 1.1.5
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
@@ -43,16 +43,16 @@ binary_sensor:
     id: shunt${shunt_id}_online_status
     device_id: shunt_${shunt_id}
     name: "Online status"
-    lambda: |-
-      if (id(shunt${shunt_id}_voltage).state > 0)
-        return true;
-      else
-        return false;
     on_state:
       then:
         - lambda: |-
             // Pass the current state to the update function
             id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
+    lambda: |-
+      if (id(shunt${shunt_id}_voltage).state > 0)
+        return true;
+      else
+        return false;
 
 sensor:
   - platform: victron

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.4
+# Updated : 2026.02.01
+# Version : 1.1.5
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -48,6 +48,11 @@ binary_sensor:
         return true;
       else
         return false;
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 sensor:
   - platform: victron

--- a/packages/yambms/yambms_canbus.yaml
+++ b/packages/yambms/yambms_canbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.01
-# Version : 2.5.0
+# Updated : 2026.02.03
+# Version : 2.5.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,29 +17,50 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+substitutions:
+  # Extended CANBUS ID
+  ext_canbus_id: "canbus${canbus_id}"
+  # The ID of the LED on your board used for this component
+  canbus_status_led_id: "virtual_status_light"
+
 esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_INV_CAN_BUS}, ${canbus_id}, id(${canbus_status_led_id}));
+            // Force register fault as default, will be updated once CANBUS is working
+            // (true = fault)
+            id(global_update_fault)(${CAT_INV_CAN_BUS}, ${canbus_id}, true);          
+    - priority: -100.0
+      then:
+        - lambda: |-
+            // Initialise canbus status as off
+            id(${ext_canbus_id}_status).publish_state(false);
+            
   devices:
-    - id: canbus_${canbus_id}
+    - id: canbus_${ext_canbus_id}
       name: "${canbus_name}"
 
 globals:
-  - id: ${canbus_id}_send_canbus_data
+  - id: ${ext_canbus_id}_send_canbus_data
     type: bool
     restore_value: no
     initial_value: "false"
-  - id: ${canbus_id}_auto_bms_name
+  - id: ${ext_canbus_id}_auto_bms_name
     type: int
     restore_value: no
     initial_value: "0"
-  - id: ${canbus_id}_can_frame
+  - id: ${ext_canbus_id}_can_frame
     type: int
     restore_value: no
     initial_value: "0"
-  - id: ${canbus_id}_can_frame_index
+  - id: ${ext_canbus_id}_can_frame_index
     type: int
     restore_value: no
     initial_value: "-1"
-  - id: ${canbus_id}_inverter_ack_ms_previous
+  - id: ${ext_canbus_id}_inverter_ack_ms_previous
     type: uint32_t
     restore_value: no
     initial_value: "0"
@@ -47,8 +68,8 @@ globals:
 select:
   - platform: template
     name: "YamBMS name"
-    id: ${canbus_id}_bms_name
-    device_id: canbus_${canbus_id}
+    id: ${ext_canbus_id}_bms_name
+    device_id: canbus_${ext_canbus_id}
     options:
       - "Automatic"
       - "PYLON"
@@ -68,8 +89,8 @@ select:
           args: ["x.c_str()"]
   - platform: template
     name: "YamBMS protocol"
-    id: ${canbus_id}_protocol
-    device_id: canbus_${canbus_id}
+    id: ${ext_canbus_id}_protocol
+    device_id: canbus_${ext_canbus_id}
     options:
       - "Disabled"
       - "PYLON 1.2"
@@ -93,8 +114,8 @@ select:
 switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
-    id: ${canbus_id}_switch_inverter_heartbeat_monitoring
-    device_id: canbus_${canbus_id}
+    id: ${ext_canbus_id}_switch_inverter_heartbeat_monitoring
+    device_id: canbus_${ext_canbus_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
@@ -102,8 +123,8 @@ switch:
 sensor:
   # 0x305 Inverter ACK interval
   - platform: template
-    id: ${canbus_id}_inverter_heartbeat
-    device_id: canbus_${canbus_id}
+    id: ${ext_canbus_id}_inverter_heartbeat
+    device_id: canbus_${ext_canbus_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -113,22 +134,27 @@ sensor:
 
 binary_sensor:
   - platform: template
-    id: ${canbus_id}_status
-    device_id: canbus_${canbus_id}
+    id: ${ext_canbus_id}_status
+    device_id: canbus_${ext_canbus_id}
     name: "Status"
     entity_category: diagnostic
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_INV_CAN_BUS}, ${canbus_id}, !x);
 
 # +--------------------------------------+
 # | Scripts                              |
 # +--------------------------------------+
 script:
-  - id: ${canbus_id}_script_canbus_link_timer
+  - id: ${ext_canbus_id}_script_canbus_link_timer
     mode: restart
     then:
       - delay: ${canbus_link_timer}
       - lambda: |-
-          id(${canbus_id}_send_canbus_data) = false;                      // Stop sending CANBUS datas
-          id(${canbus_id}_status).publish_state(false);                   // Set CANBUS status to OFF
+          id(${ext_canbus_id}_send_canbus_data) = false;                  // Stop sending CANBUS datas
+          id(${ext_canbus_id}_status).publish_state(false);               // Set CANBUS status to OFF
           id(inverter_com_status).publish_state(false);                   // Set Inverter com. status to OFF
 
 # +--------------------------------------+
@@ -142,20 +168,20 @@ canbus:
       - can_id: 0x305
         then:
           - lambda: |-
-              id(${canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
+              id(${ext_canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
 
-              if (id(${canbus_id}_status).state == false) {
-                id(${canbus_id}_send_canbus_data) = true;                    // Sending CANBUS frames allowed
-                id(${canbus_id}_status).publish_state(true);                 // Set CANBUS status to ON
-                id(inverter_com_status).publish_state(true);                 // Set Inverter com. status to ON
+              if (id(${ext_canbus_id}_status).state == false) {
+                id(${ext_canbus_id}_send_canbus_data) = true;                    // Sending CANBUS frames allowed
+                id(${ext_canbus_id}_status).publish_state(true);                 // Set CANBUS status to ON
+                id(inverter_com_status).publish_state(true);                     // Set Inverter com. status to ON
               }
 
               // Inverter ACK interval
-              if (id(${canbus_id}_switch_inverter_heartbeat_monitoring).state) {
+              if (id(${ext_canbus_id}_switch_inverter_heartbeat_monitoring).state) {
                 uint32_t inverter_ack_ms_current = millis();
-                uint32_t inverter_ack_interval_ms = (inverter_ack_ms_current - id(${canbus_id}_inverter_ack_ms_previous));
-                id(${canbus_id}_inverter_ack_ms_previous) = inverter_ack_ms_current;
-                id(${canbus_id}_inverter_heartbeat).publish_state(inverter_ack_interval_ms);
+                uint32_t inverter_ack_interval_ms = (inverter_ack_ms_current - id(${ext_canbus_id}_inverter_ack_ms_previous));
+                id(${ext_canbus_id}_inverter_ack_ms_previous) = inverter_ack_ms_current;
+                id(${ext_canbus_id}_inverter_heartbeat).publish_state(inverter_ack_interval_ms);
                 ESP_LOGI("canbus", "received can_id: 0x305 ack_interval %d ms", inverter_ack_interval_ms);
               }
 
@@ -164,17 +190,17 @@ interval:
     then:
       - lambda: |-
           // Save CANBUS options
-          id(${yambms_id}_var_inverter_bms_name) = id(${canbus_id}_bms_name).current_option();
-          id(${yambms_id}_var_inverter_protocol) = id(${canbus_id}_protocol).current_option();
+          id(${yambms_id}_var_inverter_bms_name) = id(${ext_canbus_id}_bms_name).current_option();
+          id(${yambms_id}_var_inverter_protocol) = id(${ext_canbus_id}_protocol).current_option();
 
   - interval: 30s
     then:
       - lambda: |-
           // Test inverter 0x305 ACK
-          if (id(${canbus_id}_send_canbus_data) == false && id(${yambms_id}_var_initialized) == true)
+          if (id(${ext_canbus_id}_send_canbus_data) == false && id(${yambms_id}_var_initialized) == true)
           {
-            id(${canbus_id}_send_canbus_data) = true;                      // Sending CANBUS frames allowed
-            id(${canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
+            id(${ext_canbus_id}_send_canbus_data) = true;                      // Sending CANBUS frames allowed
+            id(${ext_canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
             ESP_LOGD("yambms_debug", "CAN bus starting...");
           }
 
@@ -183,59 +209,59 @@ interval:
       - if:
           condition:
             lambda: |-
-              if ((id(${canbus_id}_send_canbus_data) == true) &&
+              if ((id(${ext_canbus_id}_send_canbus_data) == true) &&
                   (id(${yambms_id}_var_initialized) == true) &&
                   (id(${yambms_id}_bms_combined).state > 0))
               {
-                int index = id(${canbus_id}_can_frame_index);
+                int index = id(${ext_canbus_id}_can_frame_index);
 
                 // PYLON 1.2 / LuxPower CAN frames
-                if ((id(${canbus_id}_protocol).active_index() == 1) | (id(${canbus_id}_protocol).active_index() == 5))
+                if ((id(${ext_canbus_id}_protocol).active_index() == 1) | (id(${ext_canbus_id}_protocol).active_index() == 5))
                 {
                     int can_frame[] = {1, 2, 3, 4, 5, 6};
                     int max_index = 5;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${canbus_id}_can_frame) = can_frame[index];
+                    id(${ext_canbus_id}_can_frame) = can_frame[index];
                 }
                 // PYLON V2 CAN frames
-                else if (id(${canbus_id}_protocol).active_index() == 2)
+                else if (id(${ext_canbus_id}_protocol).active_index() == 2)
                 {
                     int can_frame[] = {1, 2, 3, 4, 5, 6, 7, 12, 13, 14, 15, 16, 17, 19};
                     int max_index = 13;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${canbus_id}_can_frame) = can_frame[index];
+                    id(${ext_canbus_id}_can_frame) = can_frame[index];
                 }
                 // SMA CAN frames
-                else if (id(${canbus_id}_protocol).active_index() == 3)
+                else if (id(${ext_canbus_id}_protocol).active_index() == 3)
                 {
                     int can_frame[] = {1, 2, 3, 4, 7, 8};
                     int max_index = 5;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${canbus_id}_can_frame) = can_frame[index];
+                    id(${ext_canbus_id}_can_frame) = can_frame[index];
                 }
                 // Victron CAN frames
-                else if (id(${canbus_id}_protocol).active_index() == 4)
+                else if (id(${ext_canbus_id}_protocol).active_index() == 4)
                 {
                     int can_frame[] = {1, 2, 3, 4, 7, 8, 12, 13, 14, 15, 16, 17, 19, 22, 23};
                     int max_index = 14;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${canbus_id}_can_frame) = can_frame[index];
+                    id(${ext_canbus_id}_can_frame) = can_frame[index];
                 }
                 // Deye PCS CAN frames
-                else if (id(${canbus_id}_protocol).active_index() == 6)
+                else if (id(${ext_canbus_id}_protocol).active_index() == 6)
                 {
                     int can_frame[] = {1, 2, 3, 4, 6, 24, 25, 26, 27, 28};
                     int max_index = 9;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${canbus_id}_can_frame) = can_frame[index];
+                    id(${ext_canbus_id}_can_frame) = can_frame[index];
                 }
 
-                id(${canbus_id}_can_frame_index) = index;
+                id(${ext_canbus_id}_can_frame_index) = index;
                 return true;
               }
               else return false;
@@ -243,7 +269,7 @@ interval:
           then:
             - if: # 0x35E - Manufacturer name
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 1;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 1;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -251,39 +277,39 @@ interval:
                       data: !lambda |-
 
                         // Automatic BMS name selection
-                        if (id(${canbus_id}_bms_name).active_index() == 0)
+                        if (id(${ext_canbus_id}_bms_name).active_index() == 0)
                         {
-                          if (id(${canbus_id}_protocol).active_index() == 1) id(${canbus_id}_auto_bms_name) = 1;          // PYLON
-                          else if (id(${canbus_id}_protocol).active_index() == 2) id(${canbus_id}_auto_bms_name) = 1;     // PYLON V2
-                          else if (id(${canbus_id}_protocol).active_index() == 3) id(${canbus_id}_auto_bms_name) = 4;     // SMA
-                          else if (id(${canbus_id}_protocol).active_index() == 4) id(${canbus_id}_auto_bms_name) = 0;     // Victron
-                          else if (id(${canbus_id}_protocol).active_index() == 5) id(${canbus_id}_auto_bms_name) = 0;     // LuxPower
-                          else if (id(${canbus_id}_protocol).active_index() == 6) id(${canbus_id}_auto_bms_name) = 7;     // Deye PCS
+                          if (id(${ext_canbus_id}_protocol).active_index() == 1) id(${ext_canbus_id}_auto_bms_name) = 1;          // PYLON
+                          else if (id(${ext_canbus_id}_protocol).active_index() == 2) id(${ext_canbus_id}_auto_bms_name) = 1;     // PYLON V2
+                          else if (id(${ext_canbus_id}_protocol).active_index() == 3) id(${ext_canbus_id}_auto_bms_name) = 4;     // SMA
+                          else if (id(${ext_canbus_id}_protocol).active_index() == 4) id(${ext_canbus_id}_auto_bms_name) = 0;     // Victron
+                          else if (id(${ext_canbus_id}_protocol).active_index() == 5) id(${ext_canbus_id}_auto_bms_name) = 0;     // LuxPower
+                          else if (id(${ext_canbus_id}_protocol).active_index() == 6) id(${ext_canbus_id}_auto_bms_name) = 7;     // Deye PCS
                         }
-                        else id(${canbus_id}_auto_bms_name) = 0;  // YamBMS
+                        else id(${ext_canbus_id}_auto_bms_name) = 0;  // YamBMS
 
                         // Manual BMS name selection
-                        if ((id(${canbus_id}_bms_name).active_index() == 1) | (id(${canbus_id}_auto_bms_name) == 1))
+                        if ((id(${ext_canbus_id}_bms_name).active_index() == 1) | (id(${ext_canbus_id}_auto_bms_name) == 1))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : PYLON");
                           return {0x50, 0x59, 0x4C, 0x4F, 0x4E, 0x20, 0x20, 0x20}; // PYLON (recognized by Deye, add SOH info)
                         }
-                        else if ((id(${canbus_id}_bms_name).active_index() == 2) | (id(${canbus_id}_auto_bms_name) == 2))
+                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 2) | (id(${ext_canbus_id}_auto_bms_name) == 2))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : GOODWE");
                           return {0x47, 0x4F, 0x4F, 0x44, 0x57, 0x45, 0x20, 0x20}; // GOODWE
                         }
-                        else if ((id(${canbus_id}_bms_name).active_index() == 3) | (id(${canbus_id}_auto_bms_name) == 3))
+                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 3) | (id(${ext_canbus_id}_auto_bms_name) == 3))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SHEnergy");
                           return {0x53, 0x48, 0x45, 0x6E, 0x65, 0x72, 0x67, 0x79}; // SHEnergy (SEPLOS, recognized by Deye)
                         }
-                        else if ((id(${canbus_id}_bms_name).active_index() == 4) | (id(${canbus_id}_auto_bms_name) == 4))
+                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 4) | (id(${ext_canbus_id}_auto_bms_name) == 4))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SMA");
                           return {0x53, 0x4D, 0x41, 0x20, 0x20, 0x20, 0x20, 0x20}; // SMA
                         }
-                        else if ((id(${canbus_id}_bms_name).active_index() == 5) | (id(${canbus_id}_auto_bms_name) == 5))
+                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 5) | (id(${ext_canbus_id}_auto_bms_name) == 5))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : BYD");
                           return {0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00}; // BYD (recognized by Deye)
@@ -291,7 +317,7 @@ interval:
                         //
                         // YamBMS = 6 = DON'T USE !
                         //
-                        else if ((id(${canbus_id}_bms_name).active_index() == 7) | (id(${canbus_id}_auto_bms_name) == 7))
+                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 7) | (id(${ext_canbus_id}_auto_bms_name) == 7))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : Deye PCS infos");
                           // Byte [00:01]    : BMS name (ASCII) [DY]
@@ -309,7 +335,7 @@ interval:
 
             - if: # 0x351 - BMS instruction : Charge Volts, Charge Amps, Discharge Amps, Min voltage
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 2;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 2;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -336,7 +362,7 @@ interval:
 
             - if: # 0x355 - Actual State of Charge (SOC), State of Health (SOH), Remaining total capacity
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 3;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 3;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -362,7 +388,7 @@ interval:
                         // Byte [04:05] : Max Cell Voltage         (1 mV)
                         // Byte [06:07] : Min Cell voltage         (1 mV)
 
-                        if (id(${canbus_id}_protocol).active_index() == 5) {
+                        if (id(${ext_canbus_id}_protocol).active_index() == 5) {
                           int min_cell_voltage_i = id(${yambms_id}_min_cell_voltage).state * 1000.0;
                           int max_cell_voltage_i = id(${yambms_id}_max_cell_voltage).state * 1000.0;
                           can_mesg[4] = max_cell_voltage_i & 0xff;
@@ -376,7 +402,7 @@ interval:
 
             - if: # 0x356 - Actual Voltage / Current / Temperature / Cycles (Deye 0x305 ACK)
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 4;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 4;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -402,7 +428,7 @@ interval:
                         // Byte [04:05] : Max cell temperature     (0.1 °C)
                         // Byte [06:07] : Min cell temperature     (0.1 °C)
 
-                        if (id(${canbus_id}_protocol).active_index() == 5)
+                        if (id(${ext_canbus_id}_protocol).active_index() == 5)
                         {
                           // Added 0.1 °C safeguard to max temperature so that max and min values are never equal
                           can_mesg[4] = int16_t(id(${yambms_id}_max_temperature).state * 10 + 1) & 0xff;
@@ -416,7 +442,7 @@ interval:
 
             - if: # 0x359 - Protection Alarms, Warning and Flags ( PYLON / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 5;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 5;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -476,7 +502,7 @@ interval:
                         // LuxPower
                         // Byte [05:06] : Battery Capacity     (1 Ah)
 
-                        if (id(${canbus_id}_protocol).active_index() == 5) {
+                        if (id(${ext_canbus_id}_protocol).active_index() == 5) {
                           can_mesg[5] = uint16_t(id(${yambms_id}_battery_capacity).state) & 0xff;
                           can_mesg[6] = uint16_t(id(${yambms_id}_battery_capacity).state) >> 8 & 0xff;
                         }
@@ -486,7 +512,7 @@ interval:
 
             - if: # 0x35C - Request flag to Enable/Disable: Charge, Discharge ( PYLON / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 6;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 6;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -513,7 +539,7 @@ interval:
 
                         // LuxPower
                         // Byte [02:03] : Cycle count     (1 cycle)
-                        if (id(${canbus_id}_protocol).active_index() == 5) {
+                        if (id(${ext_canbus_id}_protocol).active_index() == 5) {
                           can_mesg[2] = uint16_t(id(${yambms_id}_charging_cycles).state) & 0xff;
                           can_mesg[3] = uint16_t(id(${yambms_id}_charging_cycles).state) >> 8 & 0xff;
                         }
@@ -523,7 +549,7 @@ interval:
 
             - if: # 0x35A - Protection Alarms and Warning ( SMA / Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 7;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 7;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -585,7 +611,7 @@ interval:
 
             - if: # 0x35F - Battery information ( SMA, Victron )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 8;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 8;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -608,7 +634,7 @@ interval:
 
             - if: # 0x70  - Actual Max Cell Temp, Min Cell Temp, Max Cell V, Min Cell V ( SEPLOS V1.0 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 10;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 10;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -639,7 +665,7 @@ interval:
 
             - if: # 0x371 - Actual Max Cell Temp ID, Min Cell Temp ID, Max Cell V ID, Min Cell ID ( SEPLOS V1.0 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 11;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 11;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -666,7 +692,7 @@ interval:
 
             - if: # 0x372 - Battery modules information ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 12;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 12;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -688,7 +714,7 @@ interval:
 
             - if: # 0x373 - Actual Min Cell V, Max Cell V, Min Cell Temp (Kelvin), Max Cell Temp (Kelvin) ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 13;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 13;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -719,7 +745,7 @@ interval:
 
             - if: # 0x374 - Min cell voltage ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 14;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 14;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -737,7 +763,7 @@ interval:
 
             - if: # 0x375 - Max cell voltage ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 15;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 15;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -755,7 +781,7 @@ interval:
 
             - if: # 0x376 - Min cell temperature ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 16;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 16;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -773,7 +799,7 @@ interval:
 
             - if: # 0x377 - Max cell temperature ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 17;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 17;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -791,7 +817,7 @@ interval:
 
             - if: # 0x379 - Battery Installed Capacity Ah for Victron, Sol-Ark, LuxPower ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 19;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 19;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -806,7 +832,7 @@ interval:
 
             - if: # 0x382 - Product identification [ASCII] ( Victron )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 22;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 22;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -817,7 +843,7 @@ interval:
 
             - if: # 0x360 - Force charge instruction ( Victron )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 23;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 23;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -833,7 +859,7 @@ interval:
 
             - if: # 0x359 - Protection and System errors ( Deye PCS )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 24;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 24;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -844,7 +870,7 @@ interval:
 
             - if: # 0x361 - Actual Max Cell Temp, Min Cell Temp, Max Cell V, Min Cell V ( Deye PCS )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 25;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 25;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -874,7 +900,7 @@ interval:
 
             - if: # 0x363 - Software and Hardware version ( Deye PCS )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 26;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 26;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -888,7 +914,7 @@ interval:
 
             - if: # 0x364 - Modules count infos ( Deye PCS )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 27;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 27;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -912,7 +938,7 @@ interval:
 
             - if: # 0x371 - BMS instruction : [ON-GRID] Charge Amps, Discharge Amps ( Deye PCS )
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 28;
+                  lambda: return id(${ext_canbus_id}_can_frame) == 28;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}

--- a/packages/yambms/yambms_canbus.yaml
+++ b/packages/yambms/yambms_canbus.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.04
+# Updated : 2026.02.05
 # Version : 2.5.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -38,7 +38,7 @@ esphome:
             id(canbus${canbus_id}_status).publish_state(false);
             
   devices:
-    - id: canbus${canbus_id}
+    - id: canbus_${canbus_id}
       name: "${canbus_name}"
 
 globals:
@@ -67,7 +67,7 @@ select:
   - platform: template
     name: "YamBMS name"
     id: canbus${canbus_id}_bms_name
-    device_id: canbus${canbus_id}
+    device_id: canbus_${canbus_id}
     options:
       - "Automatic"
       - "PYLON"
@@ -88,7 +88,7 @@ select:
   - platform: template
     name: "YamBMS protocol"
     id: canbus${canbus_id}_protocol
-    device_id: canbus${canbus_id}
+    device_id: canbus_${canbus_id}
     options:
       - "Disabled"
       - "PYLON 1.2"
@@ -113,7 +113,7 @@ switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
     id: canbus${canbus_id}_switch_inverter_heartbeat_monitoring
-    device_id: canbus${canbus_id}
+    device_id: canbus_${canbus_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
@@ -122,7 +122,7 @@ sensor:
   # 0x305 Inverter ACK interval
   - platform: template
     id: canbus${canbus_id}_inverter_heartbeat
-    device_id: canbus${canbus_id}
+    device_id: canbus_${canbus_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -133,7 +133,7 @@ sensor:
 binary_sensor:
   - platform: template
     id: canbus${canbus_id}_status
-    device_id: canbus${canbus_id}
+    device_id: canbus_${canbus_id}
     name: "Status"
     entity_category: diagnostic
     on_state:

--- a/packages/yambms/yambms_canbus.yaml
+++ b/packages/yambms/yambms_canbus.yaml
@@ -38,7 +38,7 @@ esphome:
             id(canbus${canbus_id}_status).publish_state(false);
             
   devices:
-    - id: canbus_canbus${canbus_id}
+    - id: canbus${canbus_id}
       name: "${canbus_name}"
 
 globals:
@@ -67,7 +67,7 @@ select:
   - platform: template
     name: "YamBMS name"
     id: canbus${canbus_id}_bms_name
-    device_id: canbus_canbus${canbus_id}
+    device_id: canbus${canbus_id}
     options:
       - "Automatic"
       - "PYLON"
@@ -88,7 +88,7 @@ select:
   - platform: template
     name: "YamBMS protocol"
     id: canbus${canbus_id}_protocol
-    device_id: canbus_canbus${canbus_id}
+    device_id: canbus${canbus_id}
     options:
       - "Disabled"
       - "PYLON 1.2"
@@ -113,7 +113,7 @@ switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
     id: canbus${canbus_id}_switch_inverter_heartbeat_monitoring
-    device_id: canbus_canbus${canbus_id}
+    device_id: canbus${canbus_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
@@ -122,7 +122,7 @@ sensor:
   # 0x305 Inverter ACK interval
   - platform: template
     id: canbus${canbus_id}_inverter_heartbeat
-    device_id: canbus_canbus${canbus_id}
+    device_id: canbus${canbus_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -133,7 +133,7 @@ sensor:
 binary_sensor:
   - platform: template
     id: canbus${canbus_id}_status
-    device_id: canbus_canbus${canbus_id}
+    device_id: canbus${canbus_id}
     name: "Status"
     entity_category: diagnostic
     on_state:

--- a/packages/yambms/yambms_canbus.yaml
+++ b/packages/yambms/yambms_canbus.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.03
+# Updated : 2026.02.04
 # Version : 2.5.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
@@ -18,8 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
 substitutions:
-  # Extended CANBUS ID
-  ext_canbus_id: "canbus${canbus_id}"
   # The ID of the LED on your board used for this component
   canbus_status_led_id: "virtual_status_light"
 
@@ -37,30 +35,30 @@ esphome:
       then:
         - lambda: |-
             // Initialise canbus status as off
-            id(${ext_canbus_id}_status).publish_state(false);
+            id(canbus${canbus_id}_status).publish_state(false);
             
   devices:
-    - id: canbus_${ext_canbus_id}
+    - id: canbus_canbus${canbus_id}
       name: "${canbus_name}"
 
 globals:
-  - id: ${ext_canbus_id}_send_canbus_data
+  - id: canbus${canbus_id}_send_canbus_data
     type: bool
     restore_value: no
     initial_value: "false"
-  - id: ${ext_canbus_id}_auto_bms_name
+  - id: canbus${canbus_id}_auto_bms_name
     type: int
     restore_value: no
     initial_value: "0"
-  - id: ${ext_canbus_id}_can_frame
+  - id: canbus${canbus_id}_can_frame
     type: int
     restore_value: no
     initial_value: "0"
-  - id: ${ext_canbus_id}_can_frame_index
+  - id: canbus${canbus_id}_can_frame_index
     type: int
     restore_value: no
     initial_value: "-1"
-  - id: ${ext_canbus_id}_inverter_ack_ms_previous
+  - id: canbus${canbus_id}_inverter_ack_ms_previous
     type: uint32_t
     restore_value: no
     initial_value: "0"
@@ -68,8 +66,8 @@ globals:
 select:
   - platform: template
     name: "YamBMS name"
-    id: ${ext_canbus_id}_bms_name
-    device_id: canbus_${ext_canbus_id}
+    id: canbus${canbus_id}_bms_name
+    device_id: canbus_canbus${canbus_id}
     options:
       - "Automatic"
       - "PYLON"
@@ -89,8 +87,8 @@ select:
           args: ["x.c_str()"]
   - platform: template
     name: "YamBMS protocol"
-    id: ${ext_canbus_id}_protocol
-    device_id: canbus_${ext_canbus_id}
+    id: canbus${canbus_id}_protocol
+    device_id: canbus_canbus${canbus_id}
     options:
       - "Disabled"
       - "PYLON 1.2"
@@ -114,8 +112,8 @@ select:
 switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
-    id: ${ext_canbus_id}_switch_inverter_heartbeat_monitoring
-    device_id: canbus_${ext_canbus_id}
+    id: canbus${canbus_id}_switch_inverter_heartbeat_monitoring
+    device_id: canbus_canbus${canbus_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
@@ -123,8 +121,8 @@ switch:
 sensor:
   # 0x305 Inverter ACK interval
   - platform: template
-    id: ${ext_canbus_id}_inverter_heartbeat
-    device_id: canbus_${ext_canbus_id}
+    id: canbus${canbus_id}_inverter_heartbeat
+    device_id: canbus_canbus${canbus_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -134,8 +132,8 @@ sensor:
 
 binary_sensor:
   - platform: template
-    id: ${ext_canbus_id}_status
-    device_id: canbus_${ext_canbus_id}
+    id: canbus${canbus_id}_status
+    device_id: canbus_canbus${canbus_id}
     name: "Status"
     entity_category: diagnostic
     on_state:
@@ -148,13 +146,13 @@ binary_sensor:
 # | Scripts                              |
 # +--------------------------------------+
 script:
-  - id: ${ext_canbus_id}_script_canbus_link_timer
+  - id: canbus${canbus_id}_script_canbus_link_timer
     mode: restart
     then:
       - delay: ${canbus_link_timer}
       - lambda: |-
-          id(${ext_canbus_id}_send_canbus_data) = false;                  // Stop sending CANBUS datas
-          id(${ext_canbus_id}_status).publish_state(false);               // Set CANBUS status to OFF
+          id(canbus${canbus_id}_send_canbus_data) = false;                  // Stop sending CANBUS datas
+          id(canbus${canbus_id}_status).publish_state(false);               // Set CANBUS status to OFF
           id(inverter_com_status).publish_state(false);                   // Set Inverter com. status to OFF
 
 # +--------------------------------------+
@@ -168,20 +166,20 @@ canbus:
       - can_id: 0x305
         then:
           - lambda: |-
-              id(${ext_canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
+              id(canbus${canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
 
-              if (id(${ext_canbus_id}_status).state == false) {
-                id(${ext_canbus_id}_send_canbus_data) = true;                    // Sending CANBUS frames allowed
-                id(${ext_canbus_id}_status).publish_state(true);                 // Set CANBUS status to ON
+              if (id(canbus${canbus_id}_status).state == false) {
+                id(canbus${canbus_id}_send_canbus_data) = true;                    // Sending CANBUS frames allowed
+                id(canbus${canbus_id}_status).publish_state(true);                 // Set CANBUS status to ON
                 id(inverter_com_status).publish_state(true);                     // Set Inverter com. status to ON
               }
 
               // Inverter ACK interval
-              if (id(${ext_canbus_id}_switch_inverter_heartbeat_monitoring).state) {
+              if (id(canbus${canbus_id}_switch_inverter_heartbeat_monitoring).state) {
                 uint32_t inverter_ack_ms_current = millis();
-                uint32_t inverter_ack_interval_ms = (inverter_ack_ms_current - id(${ext_canbus_id}_inverter_ack_ms_previous));
-                id(${ext_canbus_id}_inverter_ack_ms_previous) = inverter_ack_ms_current;
-                id(${ext_canbus_id}_inverter_heartbeat).publish_state(inverter_ack_interval_ms);
+                uint32_t inverter_ack_interval_ms = (inverter_ack_ms_current - id(canbus${canbus_id}_inverter_ack_ms_previous));
+                id(canbus${canbus_id}_inverter_ack_ms_previous) = inverter_ack_ms_current;
+                id(canbus${canbus_id}_inverter_heartbeat).publish_state(inverter_ack_interval_ms);
                 ESP_LOGI("canbus", "received can_id: 0x305 ack_interval %d ms", inverter_ack_interval_ms);
               }
 
@@ -190,17 +188,17 @@ interval:
     then:
       - lambda: |-
           // Save CANBUS options
-          id(${yambms_id}_var_inverter_bms_name) = id(${ext_canbus_id}_bms_name).current_option();
-          id(${yambms_id}_var_inverter_protocol) = id(${ext_canbus_id}_protocol).current_option();
+          id(${yambms_id}_var_inverter_bms_name) = id(canbus${canbus_id}_bms_name).current_option();
+          id(${yambms_id}_var_inverter_protocol) = id(canbus${canbus_id}_protocol).current_option();
 
   - interval: 30s
     then:
       - lambda: |-
           // Test inverter 0x305 ACK
-          if (id(${ext_canbus_id}_send_canbus_data) == false && id(${yambms_id}_var_initialized) == true)
+          if (id(canbus${canbus_id}_send_canbus_data) == false && id(${yambms_id}_var_initialized) == true)
           {
-            id(${ext_canbus_id}_send_canbus_data) = true;                      // Sending CANBUS frames allowed
-            id(${ext_canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
+            id(canbus${canbus_id}_send_canbus_data) = true;                      // Sending CANBUS frames allowed
+            id(canbus${canbus_id}_script_canbus_link_timer).execute();           // Restart CANBUS link timer
             ESP_LOGD("yambms_debug", "CAN bus starting...");
           }
 
@@ -209,59 +207,59 @@ interval:
       - if:
           condition:
             lambda: |-
-              if ((id(${ext_canbus_id}_send_canbus_data) == true) &&
+              if ((id(canbus${canbus_id}_send_canbus_data) == true) &&
                   (id(${yambms_id}_var_initialized) == true) &&
                   (id(${yambms_id}_bms_combined).state > 0))
               {
-                int index = id(${ext_canbus_id}_can_frame_index);
+                int index = id(canbus${canbus_id}_can_frame_index);
 
                 // PYLON 1.2 / LuxPower CAN frames
-                if ((id(${ext_canbus_id}_protocol).active_index() == 1) | (id(${ext_canbus_id}_protocol).active_index() == 5))
+                if ((id(canbus${canbus_id}_protocol).active_index() == 1) | (id(canbus${canbus_id}_protocol).active_index() == 5))
                 {
                     int can_frame[] = {1, 2, 3, 4, 5, 6};
                     int max_index = 5;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${ext_canbus_id}_can_frame) = can_frame[index];
+                    id(canbus${canbus_id}_can_frame) = can_frame[index];
                 }
                 // PYLON V2 CAN frames
-                else if (id(${ext_canbus_id}_protocol).active_index() == 2)
+                else if (id(canbus${canbus_id}_protocol).active_index() == 2)
                 {
                     int can_frame[] = {1, 2, 3, 4, 5, 6, 7, 12, 13, 14, 15, 16, 17, 19};
                     int max_index = 13;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${ext_canbus_id}_can_frame) = can_frame[index];
+                    id(canbus${canbus_id}_can_frame) = can_frame[index];
                 }
                 // SMA CAN frames
-                else if (id(${ext_canbus_id}_protocol).active_index() == 3)
+                else if (id(canbus${canbus_id}_protocol).active_index() == 3)
                 {
                     int can_frame[] = {1, 2, 3, 4, 7, 8};
                     int max_index = 5;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${ext_canbus_id}_can_frame) = can_frame[index];
+                    id(canbus${canbus_id}_can_frame) = can_frame[index];
                 }
                 // Victron CAN frames
-                else if (id(${ext_canbus_id}_protocol).active_index() == 4)
+                else if (id(canbus${canbus_id}_protocol).active_index() == 4)
                 {
                     int can_frame[] = {1, 2, 3, 4, 7, 8, 12, 13, 14, 15, 16, 17, 19, 22, 23};
                     int max_index = 14;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${ext_canbus_id}_can_frame) = can_frame[index];
+                    id(canbus${canbus_id}_can_frame) = can_frame[index];
                 }
                 // Deye PCS CAN frames
-                else if (id(${ext_canbus_id}_protocol).active_index() == 6)
+                else if (id(canbus${canbus_id}_protocol).active_index() == 6)
                 {
                     int can_frame[] = {1, 2, 3, 4, 6, 24, 25, 26, 27, 28};
                     int max_index = 9;
                     if (index >= max_index) index = 0;
                     else index++;
-                    id(${ext_canbus_id}_can_frame) = can_frame[index];
+                    id(canbus${canbus_id}_can_frame) = can_frame[index];
                 }
 
-                id(${ext_canbus_id}_can_frame_index) = index;
+                id(canbus${canbus_id}_can_frame_index) = index;
                 return true;
               }
               else return false;
@@ -269,7 +267,7 @@ interval:
           then:
             - if: # 0x35E - Manufacturer name
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 1;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 1;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -277,39 +275,39 @@ interval:
                       data: !lambda |-
 
                         // Automatic BMS name selection
-                        if (id(${ext_canbus_id}_bms_name).active_index() == 0)
+                        if (id(canbus${canbus_id}_bms_name).active_index() == 0)
                         {
-                          if (id(${ext_canbus_id}_protocol).active_index() == 1) id(${ext_canbus_id}_auto_bms_name) = 1;          // PYLON
-                          else if (id(${ext_canbus_id}_protocol).active_index() == 2) id(${ext_canbus_id}_auto_bms_name) = 1;     // PYLON V2
-                          else if (id(${ext_canbus_id}_protocol).active_index() == 3) id(${ext_canbus_id}_auto_bms_name) = 4;     // SMA
-                          else if (id(${ext_canbus_id}_protocol).active_index() == 4) id(${ext_canbus_id}_auto_bms_name) = 0;     // Victron
-                          else if (id(${ext_canbus_id}_protocol).active_index() == 5) id(${ext_canbus_id}_auto_bms_name) = 0;     // LuxPower
-                          else if (id(${ext_canbus_id}_protocol).active_index() == 6) id(${ext_canbus_id}_auto_bms_name) = 7;     // Deye PCS
+                          if (id(canbus${canbus_id}_protocol).active_index() == 1) id(canbus${canbus_id}_auto_bms_name) = 1;          // PYLON
+                          else if (id(canbus${canbus_id}_protocol).active_index() == 2) id(canbus${canbus_id}_auto_bms_name) = 1;     // PYLON V2
+                          else if (id(canbus${canbus_id}_protocol).active_index() == 3) id(canbus${canbus_id}_auto_bms_name) = 4;     // SMA
+                          else if (id(canbus${canbus_id}_protocol).active_index() == 4) id(canbus${canbus_id}_auto_bms_name) = 0;     // Victron
+                          else if (id(canbus${canbus_id}_protocol).active_index() == 5) id(canbus${canbus_id}_auto_bms_name) = 0;     // LuxPower
+                          else if (id(canbus${canbus_id}_protocol).active_index() == 6) id(canbus${canbus_id}_auto_bms_name) = 7;     // Deye PCS
                         }
-                        else id(${ext_canbus_id}_auto_bms_name) = 0;  // YamBMS
+                        else id(canbus${canbus_id}_auto_bms_name) = 0;  // YamBMS
 
                         // Manual BMS name selection
-                        if ((id(${ext_canbus_id}_bms_name).active_index() == 1) | (id(${ext_canbus_id}_auto_bms_name) == 1))
+                        if ((id(canbus${canbus_id}_bms_name).active_index() == 1) | (id(canbus${canbus_id}_auto_bms_name) == 1))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : PYLON");
                           return {0x50, 0x59, 0x4C, 0x4F, 0x4E, 0x20, 0x20, 0x20}; // PYLON (recognized by Deye, add SOH info)
                         }
-                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 2) | (id(${ext_canbus_id}_auto_bms_name) == 2))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 2) | (id(canbus${canbus_id}_auto_bms_name) == 2))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : GOODWE");
                           return {0x47, 0x4F, 0x4F, 0x44, 0x57, 0x45, 0x20, 0x20}; // GOODWE
                         }
-                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 3) | (id(${ext_canbus_id}_auto_bms_name) == 3))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 3) | (id(canbus${canbus_id}_auto_bms_name) == 3))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SHEnergy");
                           return {0x53, 0x48, 0x45, 0x6E, 0x65, 0x72, 0x67, 0x79}; // SHEnergy (SEPLOS, recognized by Deye)
                         }
-                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 4) | (id(${ext_canbus_id}_auto_bms_name) == 4))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 4) | (id(canbus${canbus_id}_auto_bms_name) == 4))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SMA");
                           return {0x53, 0x4D, 0x41, 0x20, 0x20, 0x20, 0x20, 0x20}; // SMA
                         }
-                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 5) | (id(${ext_canbus_id}_auto_bms_name) == 5))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 5) | (id(canbus${canbus_id}_auto_bms_name) == 5))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : BYD");
                           return {0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00}; // BYD (recognized by Deye)
@@ -317,7 +315,7 @@ interval:
                         //
                         // YamBMS = 6 = DON'T USE !
                         //
-                        else if ((id(${ext_canbus_id}_bms_name).active_index() == 7) | (id(${ext_canbus_id}_auto_bms_name) == 7))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 7) | (id(canbus${canbus_id}_auto_bms_name) == 7))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : Deye PCS infos");
                           // Byte [00:01]    : BMS name (ASCII) [DY]
@@ -335,7 +333,7 @@ interval:
 
             - if: # 0x351 - BMS instruction : Charge Volts, Charge Amps, Discharge Amps, Min voltage
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 2;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 2;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -362,7 +360,7 @@ interval:
 
             - if: # 0x355 - Actual State of Charge (SOC), State of Health (SOH), Remaining total capacity
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 3;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 3;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -388,7 +386,7 @@ interval:
                         // Byte [04:05] : Max Cell Voltage         (1 mV)
                         // Byte [06:07] : Min Cell voltage         (1 mV)
 
-                        if (id(${ext_canbus_id}_protocol).active_index() == 5) {
+                        if (id(canbus${canbus_id}_protocol).active_index() == 5) {
                           int min_cell_voltage_i = id(${yambms_id}_min_cell_voltage).state * 1000.0;
                           int max_cell_voltage_i = id(${yambms_id}_max_cell_voltage).state * 1000.0;
                           can_mesg[4] = max_cell_voltage_i & 0xff;
@@ -402,7 +400,7 @@ interval:
 
             - if: # 0x356 - Actual Voltage / Current / Temperature / Cycles (Deye 0x305 ACK)
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 4;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 4;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -428,7 +426,7 @@ interval:
                         // Byte [04:05] : Max cell temperature     (0.1 °C)
                         // Byte [06:07] : Min cell temperature     (0.1 °C)
 
-                        if (id(${ext_canbus_id}_protocol).active_index() == 5)
+                        if (id(canbus${canbus_id}_protocol).active_index() == 5)
                         {
                           // Added 0.1 °C safeguard to max temperature so that max and min values are never equal
                           can_mesg[4] = int16_t(id(${yambms_id}_max_temperature).state * 10 + 1) & 0xff;
@@ -442,7 +440,7 @@ interval:
 
             - if: # 0x359 - Protection Alarms, Warning and Flags ( PYLON / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 5;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 5;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -502,7 +500,7 @@ interval:
                         // LuxPower
                         // Byte [05:06] : Battery Capacity     (1 Ah)
 
-                        if (id(${ext_canbus_id}_protocol).active_index() == 5) {
+                        if (id(canbus${canbus_id}_protocol).active_index() == 5) {
                           can_mesg[5] = uint16_t(id(${yambms_id}_battery_capacity).state) & 0xff;
                           can_mesg[6] = uint16_t(id(${yambms_id}_battery_capacity).state) >> 8 & 0xff;
                         }
@@ -512,7 +510,7 @@ interval:
 
             - if: # 0x35C - Request flag to Enable/Disable: Charge, Discharge ( PYLON / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 6;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 6;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -539,7 +537,7 @@ interval:
 
                         // LuxPower
                         // Byte [02:03] : Cycle count     (1 cycle)
-                        if (id(${ext_canbus_id}_protocol).active_index() == 5) {
+                        if (id(canbus${canbus_id}_protocol).active_index() == 5) {
                           can_mesg[2] = uint16_t(id(${yambms_id}_charging_cycles).state) & 0xff;
                           can_mesg[3] = uint16_t(id(${yambms_id}_charging_cycles).state) >> 8 & 0xff;
                         }
@@ -549,7 +547,7 @@ interval:
 
             - if: # 0x35A - Protection Alarms and Warning ( SMA / Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 7;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 7;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -611,7 +609,7 @@ interval:
 
             - if: # 0x35F - Battery information ( SMA, Victron )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 8;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 8;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -634,7 +632,7 @@ interval:
 
             - if: # 0x70  - Actual Max Cell Temp, Min Cell Temp, Max Cell V, Min Cell V ( SEPLOS V1.0 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 10;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 10;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -665,7 +663,7 @@ interval:
 
             - if: # 0x371 - Actual Max Cell Temp ID, Min Cell Temp ID, Max Cell V ID, Min Cell ID ( SEPLOS V1.0 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 11;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 11;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -692,7 +690,7 @@ interval:
 
             - if: # 0x372 - Battery modules information ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 12;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 12;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -714,7 +712,7 @@ interval:
 
             - if: # 0x373 - Actual Min Cell V, Max Cell V, Min Cell Temp (Kelvin), Max Cell Temp (Kelvin) ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 13;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 13;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -745,7 +743,7 @@ interval:
 
             - if: # 0x374 - Min cell voltage ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 14;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 14;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -763,7 +761,7 @@ interval:
 
             - if: # 0x375 - Max cell voltage ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 15;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 15;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -781,7 +779,7 @@ interval:
 
             - if: # 0x376 - Min cell temperature ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 16;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 16;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -799,7 +797,7 @@ interval:
 
             - if: # 0x377 - Max cell temperature ID [ASCII] ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 17;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 17;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -817,7 +815,7 @@ interval:
 
             - if: # 0x379 - Battery Installed Capacity Ah for Victron, Sol-Ark, LuxPower ( Victron / PYLON V2 )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 19;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 19;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -832,7 +830,7 @@ interval:
 
             - if: # 0x382 - Product identification [ASCII] ( Victron )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 22;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 22;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -843,7 +841,7 @@ interval:
 
             - if: # 0x360 - Force charge instruction ( Victron )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 23;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 23;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -859,7 +857,7 @@ interval:
 
             - if: # 0x359 - Protection and System errors ( Deye PCS )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 24;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 24;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -870,7 +868,7 @@ interval:
 
             - if: # 0x361 - Actual Max Cell Temp, Min Cell Temp, Max Cell V, Min Cell V ( Deye PCS )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 25;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 25;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -900,7 +898,7 @@ interval:
 
             - if: # 0x363 - Software and Hardware version ( Deye PCS )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 26;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 26;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -914,7 +912,7 @@ interval:
 
             - if: # 0x364 - Modules count infos ( Deye PCS )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 27;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 27;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -938,7 +936,7 @@ interval:
 
             - if: # 0x371 - BMS instruction : [ON-GRID] Charge Amps, Discharge Amps ( Deye PCS )
                 condition:
-                  lambda: return id(${ext_canbus_id}_can_frame) == 28;
+                  lambda: return id(canbus${canbus_id}_can_frame) == 28;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}

--- a/packages/yambms/yambms_canbus_web_server.yaml
+++ b/packages/yambms/yambms_canbus_web_server.yaml
@@ -22,15 +22,15 @@ packages:
 
 select:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${canbus_id}_bms_name
+  - id: !extend ${ext_canbus_id}_bms_name
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
-  - id: !extend ${canbus_id}_protocol
+  - id: !extend ${ext_canbus_id}_protocol
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
 
 binary_sensor:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${canbus_id}_status
+  - id: !extend ${ext_canbus_id}_status
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol

--- a/packages/yambms/yambms_canbus_web_server.yaml
+++ b/packages/yambms/yambms_canbus_web_server.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.11
-# Version : 1.1.1
+# Updated : 2026.02.04
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -22,15 +22,15 @@ packages:
 
 select:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${ext_canbus_id}_bms_name
+  - id: !extend ${canbus_id}_bms_name
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
-  - id: !extend ${ext_canbus_id}_protocol
+  - id: !extend ${canbus_id}_protocol
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
 
 binary_sensor:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${ext_canbus_id}_status
+  - id: !extend ${canbus_id}_status
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol

--- a/packages/yambms/yambms_canbus_web_server.yaml
+++ b/packages/yambms/yambms_canbus_web_server.yaml
@@ -22,15 +22,15 @@ packages:
 
 select:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${canbus_id}_bms_name
+  - id: !extend canbus${canbus_id}_bms_name
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
-  - id: !extend ${canbus_id}_protocol
+  - id: !extend canbus${canbus_id}_protocol
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
 
 binary_sensor:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${canbus_id}_status
+  - id: !extend canbus${canbus_id}_status
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol

--- a/packages/yambms/yambms_core.yaml
+++ b/packages/yambms/yambms_core.yaml
@@ -302,45 +302,46 @@ globals:
 # Execute once
 esphome:
   on_boot:
-    then:
-      - lambda: |-
-          //
-          // Source : https://batteryuniversity.com/article/bu-216-summary-table-of-lithium-based-batteries
-          //
-          if (${yambms_battery_chemistry} == 1) // LFP
-          {
-            // LFP
-            id(${yambms_id}_var_cell_nominal_v) = 3.20;
-            id(${yambms_id}_var_cell_min_charge_v) = 3.37; // Fully charged at rest
-            id(${yambms_id}_var_cell_max_charge_v) = 3.65;
-            id(${yambms_id}_var_cell_max_discharge_v) = 3.00; // Not used
-          }
-          else if (${yambms_battery_chemistry} == 2) // Li-ion
-          {
-            // Li-ion
-            id(${yambms_id}_var_cell_nominal_v) = 3.60;
-            id(${yambms_id}_var_cell_min_charge_v) = 3.90;
-            id(${yambms_id}_var_cell_max_charge_v) = 4.20;
-            id(${yambms_id}_var_cell_max_discharge_v) = 3.20; // Not used
-          }
-          else if (${yambms_battery_chemistry} == 3) // LTO
-          {
-            // LTO
-            id(${yambms_id}_var_cell_nominal_v) = 2.40;
-            id(${yambms_id}_var_cell_min_charge_v) = 2.55; // Fully charged at rest
-            id(${yambms_id}_var_cell_max_charge_v) = 2.85;
-            id(${yambms_id}_var_cell_max_discharge_v) = 2.00; // Not used
-          }
-          int cell_count = ${yambms_cell_count};
-          // Bulk V.
-          id(${yambms_id}_bulk_voltage).traits.set_min_value(round(cell_count * id(${yambms_id}_var_cell_min_charge_v) * 10) / 10);
-          id(${yambms_id}_bulk_voltage).traits.set_max_value(round(cell_count * id(${yambms_id}_var_cell_max_charge_v) * 10) / 10);
-          // Float V.
-          id(${yambms_id}_float_voltage).traits.set_min_value(round(cell_count * (id(${yambms_id}_var_cell_min_charge_v) - 0.15) * 10) / 10);
-          id(${yambms_id}_float_voltage).traits.set_max_value(round(cell_count * (id(${yambms_id}_var_cell_min_charge_v) + 0.05) * 10) / 10);
-          // Rebulk V.
-          id(${yambms_id}_rebulk_voltage).traits.set_min_value(round(cell_count * id(${yambms_id}_var_cell_nominal_v) * 10) / 10);
-          id(${yambms_id}_rebulk_voltage).traits.set_max_value(round(cell_count * id(${yambms_id}_var_cell_min_charge_v) * 10) / 10);
+    - priority: 600
+      then:
+        - lambda: |-
+            //
+            // Source : https://batteryuniversity.com/article/bu-216-summary-table-of-lithium-based-batteries
+            //
+            if (${yambms_battery_chemistry} == 1) // LFP
+            {
+              // LFP
+              id(${yambms_id}_var_cell_nominal_v) = 3.20;
+              id(${yambms_id}_var_cell_min_charge_v) = 3.37; // Fully charged at rest
+              id(${yambms_id}_var_cell_max_charge_v) = 3.65;
+              id(${yambms_id}_var_cell_max_discharge_v) = 3.00; // Not used
+            }
+            else if (${yambms_battery_chemistry} == 2) // Li-ion
+            {
+              // Li-ion
+              id(${yambms_id}_var_cell_nominal_v) = 3.60;
+              id(${yambms_id}_var_cell_min_charge_v) = 3.90;
+              id(${yambms_id}_var_cell_max_charge_v) = 4.20;
+              id(${yambms_id}_var_cell_max_discharge_v) = 3.20; // Not used
+            }
+            else if (${yambms_battery_chemistry} == 3) // LTO
+            {
+              // LTO
+              id(${yambms_id}_var_cell_nominal_v) = 2.40;
+              id(${yambms_id}_var_cell_min_charge_v) = 2.55; // Fully charged at rest
+              id(${yambms_id}_var_cell_max_charge_v) = 2.85;
+              id(${yambms_id}_var_cell_max_discharge_v) = 2.00; // Not used
+            }
+            int cell_count = ${yambms_cell_count};
+            // Bulk V.
+            id(${yambms_id}_bulk_voltage).traits.set_min_value(round(cell_count * id(${yambms_id}_var_cell_min_charge_v) * 10) / 10);
+            id(${yambms_id}_bulk_voltage).traits.set_max_value(round(cell_count * id(${yambms_id}_var_cell_max_charge_v) * 10) / 10);
+            // Float V.
+            id(${yambms_id}_float_voltage).traits.set_min_value(round(cell_count * (id(${yambms_id}_var_cell_min_charge_v) - 0.15) * 10) / 10);
+            id(${yambms_id}_float_voltage).traits.set_max_value(round(cell_count * (id(${yambms_id}_var_cell_min_charge_v) + 0.05) * 10) / 10);
+            // Rebulk V.
+            id(${yambms_id}_rebulk_voltage).traits.set_min_value(round(cell_count * id(${yambms_id}_var_cell_nominal_v) * 10) / 10);
+            id(${yambms_id}_rebulk_voltage).traits.set_max_value(round(cell_count * id(${yambms_id}_var_cell_min_charge_v) * 10) / 10);
 
 # YamBMS core lambda
 interval:

--- a/packages/yambms/yambms_core.yaml
+++ b/packages/yambms/yambms_core.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.02
+# Updated : 2026.02.04
 # Version : 1.7.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 

--- a/packages/yambms/yambms_rs485_pylon.yaml
+++ b/packages/yambms/yambms_rs485_pylon.yaml
@@ -38,7 +38,7 @@ esphome:
             id(rs485${rs485_id}_status).publish_state(false);
 
   devices:
-    - id: rs485_rs485${rs485_id}
+    - id: rs485${rs485_id}
       name: "${rs485_name}"
 
 external_components:
@@ -53,7 +53,7 @@ select:
   - platform: template
     name: "YamBMS protocol"
     id: rs485${rs485_id}_protocol
-    device_id: rs485_rs485${rs485_id}
+    device_id: rs485${rs485_id}
     options:
       - "Pylontech"
       - "Disabled"
@@ -66,7 +66,7 @@ switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
     id: rs485${rs485_id}_switch_inverter_heartbeat_monitoring
-    device_id: rs485_rs485${rs485_id}
+    device_id: rs485${rs485_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
@@ -117,7 +117,7 @@ sensor:
   # --- Inverter Heartbeat ---
   - platform: template
     id: rs485${rs485_id}_inverter_heartbeat
-    device_id: rs485_rs485${rs485_id}
+    device_id: rs485${rs485_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -178,7 +178,7 @@ binary_sensor:
   # --- RS485 Status ---
   - platform: template
     id: rs485${rs485_id}_status
-    device_id: rs485_rs485${rs485_id}
+    device_id: rs485${rs485_id}
     name: "Status"
     entity_category: diagnostic
     on_state:

--- a/packages/yambms/yambms_rs485_pylon.yaml
+++ b/packages/yambms/yambms_rs485_pylon.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.03
+# Updated : 2026.02.04
 # Version : 1.3.6
 # GitHub  : https://github.com/fahmula/esphome-pylontech-rs485
 
@@ -18,8 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
 substitutions:
-  # Extended ID
-  ext_rs485_id: "rs485${rs485_id}"
   # The ID of the LED on your board used for this component
   rs485_status_led_id: "virtual_status_light"
 
@@ -37,10 +35,10 @@ esphome:
       then:
         - lambda: |-
             // Initialise rs485 status as off
-            id(${ext_rs485_id}_status).publish_state(false);
+            id(rs485${rs485_id}_status).publish_state(false);
 
   devices:
-    - id: rs485_${ext_rs485_id}
+    - id: rs485_rs485${rs485_id}
       name: "${rs485_name}"
 
 external_components:
@@ -54,8 +52,8 @@ uart:
 select:
   - platform: template
     name: "YamBMS protocol"
-    id: ${ext_rs485_id}_protocol
-    device_id: rs485_${ext_rs485_id}
+    id: rs485${rs485_id}_protocol
+    device_id: rs485_rs485${rs485_id}
     options:
       - "Pylontech"
       - "Disabled"
@@ -67,59 +65,59 @@ select:
 switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
-    id: ${ext_rs485_id}_switch_inverter_heartbeat_monitoring
-    device_id: rs485_${ext_rs485_id}
+    id: rs485${rs485_id}_switch_inverter_heartbeat_monitoring
+    device_id: rs485_rs485${rs485_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
 
 sensor:
   - platform: template
-    id: ${ext_rs485_id}_proxy_soc
+    id: rs485${rs485_id}_proxy_soc
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_voltage
+    id: rs485${rs485_id}_proxy_voltage
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_current
+    id: rs485${rs485_id}_proxy_current
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_temperature
+    id: rs485${rs485_id}_proxy_temperature
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_soh
+    id: rs485${rs485_id}_proxy_soh
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cycle_count
+    id: rs485${rs485_id}_proxy_cycle_count
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_max_cell_v
+    id: rs485${rs485_id}_proxy_max_cell_v
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_min_cell_v
+    id: rs485${rs485_id}_proxy_min_cell_v
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_max_temp
+    id: rs485${rs485_id}_proxy_max_temp
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_min_temp
+    id: rs485${rs485_id}_proxy_min_temp
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_max_charge_v
+    id: rs485${rs485_id}_proxy_max_charge_v
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_min_discharge_v
+    id: rs485${rs485_id}_proxy_min_discharge_v
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_max_charge_i
+    id: rs485${rs485_id}_proxy_max_charge_i
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_max_discharge_i
+    id: rs485${rs485_id}_proxy_max_discharge_i
     internal: true
   # --- Inverter Heartbeat ---
   - platform: template
-    id: ${ext_rs485_id}_inverter_heartbeat
-    device_id: rs485_${ext_rs485_id}
+    id: rs485${rs485_id}_inverter_heartbeat
+    device_id: rs485_rs485${rs485_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -130,57 +128,57 @@ sensor:
 binary_sensor:
   # --- Passive Proxy Alarm/Protection Sensors ---
   - platform: template
-    id: ${ext_rs485_id}_proxy_total_voltage_high_alarm
+    id: rs485${rs485_id}_proxy_total_voltage_high_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_total_voltage_low_alarm
+    id: rs485${rs485_id}_proxy_total_voltage_low_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_temp_high_alarm
+    id: rs485${rs485_id}_proxy_cell_temp_high_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_temp_low_alarm
+    id: rs485${rs485_id}_proxy_cell_temp_low_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_charge_overcurrent_alarm
+    id: rs485${rs485_id}_proxy_charge_overcurrent_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_discharge_overcurrent_alarm
+    id: rs485${rs485_id}_proxy_discharge_overcurrent_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_imbalance_alarm
+    id: rs485${rs485_id}_proxy_cell_imbalance_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_voltage_high_alarm
+    id: rs485${rs485_id}_proxy_cell_voltage_high_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_voltage_low_alarm
+    id: rs485${rs485_id}_proxy_cell_voltage_low_alarm
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_overvoltage_protection
+    id: rs485${rs485_id}_proxy_cell_overvoltage_protection
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_undervoltage_protection
+    id: rs485${rs485_id}_proxy_cell_undervoltage_protection
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_overtemp_protection
+    id: rs485${rs485_id}_proxy_cell_overtemp_protection
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_cell_undertemp_protection
+    id: rs485${rs485_id}_proxy_cell_undertemp_protection
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_charge_overcurrent_protection
+    id: rs485${rs485_id}_proxy_charge_overcurrent_protection
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_discharge_overcurrent_protection
+    id: rs485${rs485_id}_proxy_discharge_overcurrent_protection
     internal: true
   - platform: template
-    id: ${ext_rs485_id}_proxy_system_fault_protection
+    id: rs485${rs485_id}_proxy_system_fault_protection
     internal: true
   # --- RS485 Status ---
   - platform: template
-    id: ${ext_rs485_id}_status
-    device_id: rs485_${ext_rs485_id}
+    id: rs485${rs485_id}_status
+    device_id: rs485_rs485${rs485_id}
     name: "Status"
     entity_category: diagnostic
     on_state:
@@ -195,139 +193,139 @@ interval:
       - lambda: |-
           // Save RS485 options
           id(${yambms_id}_var_inverter_bms_name) = "RS485";
-          id(${yambms_id}_var_inverter_protocol) = id(${ext_rs485_id}_protocol).current_option();
+          id(${yambms_id}_var_inverter_protocol) = id(rs485${rs485_id}_protocol).current_option();
 
   - interval: 100ms
     then:
       - if:
           condition:
-            lambda: 'return id(${ext_rs485_id}_protocol).current_option() == "Pylontech";'
+            lambda: 'return id(rs485${rs485_id}_protocol).current_option() == "Pylontech";'
           then:
             - lambda: !lambda |-
                 // Mirror RS485 status into inverter_com_status
-                if (id(${ext_rs485_id}_status).has_state()) id(inverter_com_status).publish_state(id(${ext_rs485_id}_status).state);
+                if (id(rs485${rs485_id}_status).has_state()) id(inverter_com_status).publish_state(id(rs485${rs485_id}_status).state);
 
                 // --- Check YamBMS initialized + BMS ONLINE/OFFLINE status ---  
                 if ((id(${yambms_id}_var_initialized) == true) && (id(${yambms_id}_bms_combined).state > 0))
                 {
                   // --- STATE 1: BMS is ONLINE ---
                   // Sensor Values
-                  if (id(${yambms_id}_battery_soc).has_state()) id(${ext_rs485_id}_proxy_soc).publish_state(id(${yambms_id}_battery_soc).state);
-                  if (id(${yambms_id}_total_voltage).has_state()) id(${ext_rs485_id}_proxy_voltage).publish_state(id(${yambms_id}_total_voltage).state);
-                  if (id(${yambms_id}_current).has_state()) id(${ext_rs485_id}_proxy_current).publish_state(id(${yambms_id}_current).state);
-                  if (id(${yambms_id}_max_temperature).has_state()) id(${ext_rs485_id}_proxy_temperature).publish_state(id(${yambms_id}_max_temperature).state);
-                  if (id(${yambms_id}_battery_soh).has_state()) id(${ext_rs485_id}_proxy_soh).publish_state(id(${yambms_id}_battery_soh).state);
-                  if (id(${yambms_id}_charging_cycles).has_state()) id(${ext_rs485_id}_proxy_cycle_count).publish_state(id(${yambms_id}_charging_cycles).state);
-                  if (id(${yambms_id}_max_cell_voltage).has_state()) id(${ext_rs485_id}_proxy_max_cell_v).publish_state(id(${yambms_id}_max_cell_voltage).state);
-                  if (id(${yambms_id}_min_cell_voltage).has_state()) id(${ext_rs485_id}_proxy_min_cell_v).publish_state(id(${yambms_id}_min_cell_voltage).state);
-                  if (id(${yambms_id}_max_temperature).has_state()) id(${ext_rs485_id}_proxy_max_temp).publish_state(id(${yambms_id}_max_temperature).state);
-                  if (id(${yambms_id}_min_temperature).has_state()) id(${ext_rs485_id}_proxy_min_temp).publish_state(id(${yambms_id}_min_temperature).state);
-                  if (id(${yambms_id}_requested_charge_voltage).has_state()) id(${ext_rs485_id}_proxy_max_charge_v).publish_state(id(${yambms_id}_requested_charge_voltage).state);
-                  if (id(${yambms_id}_requested_discharge_voltage).has_state()) id(${ext_rs485_id}_proxy_min_discharge_v).publish_state(id(${yambms_id}_requested_discharge_voltage).state);
-                  if (id(${yambms_id}_requested_charge_current).has_state()) id(${ext_rs485_id}_proxy_max_charge_i).publish_state(id(${yambms_id}_requested_charge_current).state);
-                  if (id(${yambms_id}_requested_discharge_current).has_state()) id(${ext_rs485_id}_proxy_max_discharge_i).publish_state(id(${yambms_id}_requested_discharge_current).state);
+                  if (id(${yambms_id}_battery_soc).has_state()) id(rs485${rs485_id}_proxy_soc).publish_state(id(${yambms_id}_battery_soc).state);
+                  if (id(${yambms_id}_total_voltage).has_state()) id(rs485${rs485_id}_proxy_voltage).publish_state(id(${yambms_id}_total_voltage).state);
+                  if (id(${yambms_id}_current).has_state()) id(rs485${rs485_id}_proxy_current).publish_state(id(${yambms_id}_current).state);
+                  if (id(${yambms_id}_max_temperature).has_state()) id(rs485${rs485_id}_proxy_temperature).publish_state(id(${yambms_id}_max_temperature).state);
+                  if (id(${yambms_id}_battery_soh).has_state()) id(rs485${rs485_id}_proxy_soh).publish_state(id(${yambms_id}_battery_soh).state);
+                  if (id(${yambms_id}_charging_cycles).has_state()) id(rs485${rs485_id}_proxy_cycle_count).publish_state(id(${yambms_id}_charging_cycles).state);
+                  if (id(${yambms_id}_max_cell_voltage).has_state()) id(rs485${rs485_id}_proxy_max_cell_v).publish_state(id(${yambms_id}_max_cell_voltage).state);
+                  if (id(${yambms_id}_min_cell_voltage).has_state()) id(rs485${rs485_id}_proxy_min_cell_v).publish_state(id(${yambms_id}_min_cell_voltage).state);
+                  if (id(${yambms_id}_max_temperature).has_state()) id(rs485${rs485_id}_proxy_max_temp).publish_state(id(${yambms_id}_max_temperature).state);
+                  if (id(${yambms_id}_min_temperature).has_state()) id(rs485${rs485_id}_proxy_min_temp).publish_state(id(${yambms_id}_min_temperature).state);
+                  if (id(${yambms_id}_requested_charge_voltage).has_state()) id(rs485${rs485_id}_proxy_max_charge_v).publish_state(id(${yambms_id}_requested_charge_voltage).state);
+                  if (id(${yambms_id}_requested_discharge_voltage).has_state()) id(rs485${rs485_id}_proxy_min_discharge_v).publish_state(id(${yambms_id}_requested_discharge_voltage).state);
+                  if (id(${yambms_id}_requested_charge_current).has_state()) id(rs485${rs485_id}_proxy_max_charge_i).publish_state(id(${yambms_id}_requested_charge_current).state);
+                  if (id(${yambms_id}_requested_discharge_current).has_state()) id(rs485${rs485_id}_proxy_max_discharge_i).publish_state(id(${yambms_id}_requested_discharge_current).state);
                   // Binary Sensors (Alarms/Protections)
                   if (id(${yambms_id}_errors_bitmask_warning).has_state()) {
                     uint16_t mask = id(${yambms_id}_errors_bitmask_warning).state;
-                    id(${ext_rs485_id}_proxy_total_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
-                    id(${ext_rs485_id}_proxy_total_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
-                    id(${ext_rs485_id}_proxy_cell_temp_high_alarm).publish_state((mask & 0x0008) > 0);
-                    id(${ext_rs485_id}_proxy_cell_temp_low_alarm).publish_state((mask & 0x0010) > 0);
-                    id(${ext_rs485_id}_proxy_charge_overcurrent_alarm).publish_state((mask & 0x0100) > 0);
-                    id(${ext_rs485_id}_proxy_discharge_overcurrent_alarm).publish_state((mask & 0x0080) > 0);
-                    id(${ext_rs485_id}_proxy_cell_imbalance_alarm).publish_state((mask & 0x1000) > 0);
-                    id(${ext_rs485_id}_proxy_cell_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
-                    id(${ext_rs485_id}_proxy_cell_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
+                    id(rs485${rs485_id}_proxy_total_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
+                    id(rs485${rs485_id}_proxy_total_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
+                    id(rs485${rs485_id}_proxy_cell_temp_high_alarm).publish_state((mask & 0x0008) > 0);
+                    id(rs485${rs485_id}_proxy_cell_temp_low_alarm).publish_state((mask & 0x0010) > 0);
+                    id(rs485${rs485_id}_proxy_charge_overcurrent_alarm).publish_state((mask & 0x0100) > 0);
+                    id(rs485${rs485_id}_proxy_discharge_overcurrent_alarm).publish_state((mask & 0x0080) > 0);
+                    id(rs485${rs485_id}_proxy_cell_imbalance_alarm).publish_state((mask & 0x1000) > 0);
+                    id(rs485${rs485_id}_proxy_cell_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
+                    id(rs485${rs485_id}_proxy_cell_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
                   }
                   if (id(${yambms_id}_errors_bitmask_alarm).has_state()) {
                     uint16_t mask = id(${yambms_id}_errors_bitmask_alarm).state;
-                    id(${ext_rs485_id}_proxy_cell_overvoltage_protection).publish_state((mask & 0x0002) > 0);
-                    id(${ext_rs485_id}_proxy_cell_undervoltage_protection).publish_state((mask & 0x0004) > 0);
-                    id(${ext_rs485_id}_proxy_cell_overtemp_protection).publish_state((mask & 0x0008) > 0);
-                    id(${ext_rs485_id}_proxy_cell_undertemp_protection).publish_state((mask & 0x0010) > 0);
-                    id(${ext_rs485_id}_proxy_charge_overcurrent_protection).publish_state((mask & 0x0100) > 0);
-                    id(${ext_rs485_id}_proxy_discharge_overcurrent_protection).publish_state((mask & 0x0080) > 0);
-                    id(${ext_rs485_id}_proxy_system_fault_protection).publish_state((mask & 0x0800) > 0);
+                    id(rs485${rs485_id}_proxy_cell_overvoltage_protection).publish_state((mask & 0x0002) > 0);
+                    id(rs485${rs485_id}_proxy_cell_undervoltage_protection).publish_state((mask & 0x0004) > 0);
+                    id(rs485${rs485_id}_proxy_cell_overtemp_protection).publish_state((mask & 0x0008) > 0);
+                    id(rs485${rs485_id}_proxy_cell_undertemp_protection).publish_state((mask & 0x0010) > 0);
+                    id(rs485${rs485_id}_proxy_charge_overcurrent_protection).publish_state((mask & 0x0100) > 0);
+                    id(rs485${rs485_id}_proxy_discharge_overcurrent_protection).publish_state((mask & 0x0080) > 0);
+                    id(rs485${rs485_id}_proxy_system_fault_protection).publish_state((mask & 0x0800) > 0);
                   }
                 } else {
                   // --- STATE 2: BMS is OFFLINE ---
                   // Invalidate all proxy sensors to trigger component's fail-safe.
-                  id(${ext_rs485_id}_proxy_soc).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_voltage).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_current).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_temperature).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_soh).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_cycle_count).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_max_cell_v).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_min_cell_v).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_max_temp).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_min_temp).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_max_charge_v).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_min_discharge_v).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_max_charge_i).publish_state(NAN);
-                  id(${ext_rs485_id}_proxy_max_discharge_i).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_soc).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_voltage).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_current).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_temperature).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_soh).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_cycle_count).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_max_cell_v).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_min_cell_v).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_max_temp).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_min_temp).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_max_charge_v).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_min_discharge_v).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_max_charge_i).publish_state(NAN);
+                  id(rs485${rs485_id}_proxy_max_discharge_i).publish_state(NAN);
 
                   // Publish 'false' to clear any alarms/protections.
-                  id(${ext_rs485_id}_proxy_total_voltage_high_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_total_voltage_low_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_temp_high_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_temp_low_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_charge_overcurrent_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_discharge_overcurrent_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_imbalance_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_voltage_high_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_voltage_low_alarm).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_overvoltage_protection).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_undervoltage_protection).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_overtemp_protection).publish_state(false);
-                  id(${ext_rs485_id}_proxy_cell_undertemp_protection).publish_state(false);
-                  id(${ext_rs485_id}_proxy_charge_overcurrent_protection).publish_state(false);
-                  id(${ext_rs485_id}_proxy_discharge_overcurrent_protection).publish_state(false);
-                  id(${ext_rs485_id}_proxy_system_fault_protection).publish_state(false);
+                  id(rs485${rs485_id}_proxy_total_voltage_high_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_total_voltage_low_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_temp_high_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_temp_low_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_charge_overcurrent_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_discharge_overcurrent_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_imbalance_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_voltage_high_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_voltage_low_alarm).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_overvoltage_protection).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_undervoltage_protection).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_overtemp_protection).publish_state(false);
+                  id(rs485${rs485_id}_proxy_cell_undertemp_protection).publish_state(false);
+                  id(rs485${rs485_id}_proxy_charge_overcurrent_protection).publish_state(false);
+                  id(rs485${rs485_id}_proxy_discharge_overcurrent_protection).publish_state(false);
+                  id(rs485${rs485_id}_proxy_system_fault_protection).publish_state(false);
                 }
 
 pylontech_rs485:
   uart_id: ${rs485_uart_id}
   update_timeout: ${rs485_update_timeout}
   # --- Link to PROXY sensors ---
-  state_of_charge: ${ext_rs485_id}_proxy_soc
-  voltage: ${ext_rs485_id}_proxy_voltage
-  current: ${ext_rs485_id}_proxy_current
-  temperature: ${ext_rs485_id}_proxy_temperature
-  state_of_health: ${ext_rs485_id}_proxy_soh
-  cycle_count: ${ext_rs485_id}_proxy_cycle_count
-  max_cell_voltage: ${ext_rs485_id}_proxy_max_cell_v
-  min_cell_voltage: ${ext_rs485_id}_proxy_min_cell_v
-  max_temperature: ${ext_rs485_id}_proxy_max_temp
-  min_temperature: ${ext_rs485_id}_proxy_min_temp
-  mosfet_temperature: ${ext_rs485_id}_proxy_temperature
-  max_mosfet_temperature: ${ext_rs485_id}_proxy_max_temp
-  min_mosfet_temperature: ${ext_rs485_id}_proxy_min_temp
-  bms_temperature: ${ext_rs485_id}_proxy_temperature
-  max_bms_temperature: ${ext_rs485_id}_proxy_max_temp
-  min_bms_temperature: ${ext_rs485_id}_proxy_min_temp
-  total_voltage_high_alarm: ${ext_rs485_id}_proxy_total_voltage_high_alarm
-  total_voltage_low_alarm: ${ext_rs485_id}_proxy_total_voltage_low_alarm
-  cell_voltage_high_alarm: ${ext_rs485_id}_proxy_cell_voltage_high_alarm
-  cell_voltage_low_alarm: ${ext_rs485_id}_proxy_cell_voltage_low_alarm
-  cell_temp_high_alarm: ${ext_rs485_id}_proxy_cell_temp_high_alarm
-  cell_temp_low_alarm: ${ext_rs485_id}_proxy_cell_temp_low_alarm
-  charge_overcurrent_alarm: ${ext_rs485_id}_proxy_charge_overcurrent_alarm
-  discharge_overcurrent_alarm: ${ext_rs485_id}_proxy_discharge_overcurrent_alarm
-  cell_imbalance_alarm: ${ext_rs485_id}_proxy_cell_imbalance_alarm
-  cell_overvoltage_protection: ${ext_rs485_id}_proxy_cell_overvoltage_protection
-  cell_undervoltage_protection: ${ext_rs485_id}_proxy_cell_undervoltage_protection
-  cell_overtemp_protection: ${ext_rs485_id}_proxy_cell_overtemp_protection
-  cell_undertemp_protection: ${ext_rs485_id}_proxy_cell_undertemp_protection
-  charge_overcurrent_protection: ${ext_rs485_id}_proxy_charge_overcurrent_protection
-  discharge_overcurrent_protection: ${ext_rs485_id}_proxy_discharge_overcurrent_protection
-  system_fault_protection: ${ext_rs485_id}_proxy_system_fault_protection
-  max_voltage: ${ext_rs485_id}_proxy_max_charge_v
-  min_voltage: ${ext_rs485_id}_proxy_min_discharge_v
-  max_charge_current: ${ext_rs485_id}_proxy_max_charge_i
-  max_discharge_current: ${ext_rs485_id}_proxy_max_discharge_i
+  state_of_charge: rs485${rs485_id}_proxy_soc
+  voltage: rs485${rs485_id}_proxy_voltage
+  current: rs485${rs485_id}_proxy_current
+  temperature: rs485${rs485_id}_proxy_temperature
+  state_of_health: rs485${rs485_id}_proxy_soh
+  cycle_count: rs485${rs485_id}_proxy_cycle_count
+  max_cell_voltage: rs485${rs485_id}_proxy_max_cell_v
+  min_cell_voltage: rs485${rs485_id}_proxy_min_cell_v
+  max_temperature: rs485${rs485_id}_proxy_max_temp
+  min_temperature: rs485${rs485_id}_proxy_min_temp
+  mosfet_temperature: rs485${rs485_id}_proxy_temperature
+  max_mosfet_temperature: rs485${rs485_id}_proxy_max_temp
+  min_mosfet_temperature: rs485${rs485_id}_proxy_min_temp
+  bms_temperature: rs485${rs485_id}_proxy_temperature
+  max_bms_temperature: rs485${rs485_id}_proxy_max_temp
+  min_bms_temperature: rs485${rs485_id}_proxy_min_temp
+  total_voltage_high_alarm: rs485${rs485_id}_proxy_total_voltage_high_alarm
+  total_voltage_low_alarm: rs485${rs485_id}_proxy_total_voltage_low_alarm
+  cell_voltage_high_alarm: rs485${rs485_id}_proxy_cell_voltage_high_alarm
+  cell_voltage_low_alarm: rs485${rs485_id}_proxy_cell_voltage_low_alarm
+  cell_temp_high_alarm: rs485${rs485_id}_proxy_cell_temp_high_alarm
+  cell_temp_low_alarm: rs485${rs485_id}_proxy_cell_temp_low_alarm
+  charge_overcurrent_alarm: rs485${rs485_id}_proxy_charge_overcurrent_alarm
+  discharge_overcurrent_alarm: rs485${rs485_id}_proxy_discharge_overcurrent_alarm
+  cell_imbalance_alarm: rs485${rs485_id}_proxy_cell_imbalance_alarm
+  cell_overvoltage_protection: rs485${rs485_id}_proxy_cell_overvoltage_protection
+  cell_undervoltage_protection: rs485${rs485_id}_proxy_cell_undervoltage_protection
+  cell_overtemp_protection: rs485${rs485_id}_proxy_cell_overtemp_protection
+  cell_undertemp_protection: rs485${rs485_id}_proxy_cell_undertemp_protection
+  charge_overcurrent_protection: rs485${rs485_id}_proxy_charge_overcurrent_protection
+  discharge_overcurrent_protection: rs485${rs485_id}_proxy_discharge_overcurrent_protection
+  system_fault_protection: rs485${rs485_id}_proxy_system_fault_protection
+  max_voltage: rs485${rs485_id}_proxy_max_charge_v
+  min_voltage: rs485${rs485_id}_proxy_min_discharge_v
+  max_charge_current: rs485${rs485_id}_proxy_max_charge_i
+  max_discharge_current: rs485${rs485_id}_proxy_max_discharge_i
   requested_force_charge: ${yambms_id}_requested_force_charge
   # --- Inverter Heartbeat & Com Status ---
-  inverter_heartbeat: ${ext_rs485_id}_inverter_heartbeat
-  rs485_status: ${ext_rs485_id}_status
-  heartbeat_switch: ${ext_rs485_id}_switch_inverter_heartbeat_monitoring
+  inverter_heartbeat: rs485${rs485_id}_inverter_heartbeat
+  rs485_status: rs485${rs485_id}_status
+  heartbeat_switch: rs485${rs485_id}_switch_inverter_heartbeat_monitoring

--- a/packages/yambms/yambms_rs485_pylon.yaml
+++ b/packages/yambms/yambms_rs485_pylon.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.02.04
+# Updated : 2026.02.05
 # Version : 1.3.6
 # GitHub  : https://github.com/fahmula/esphome-pylontech-rs485
 
@@ -38,7 +38,7 @@ esphome:
             id(rs485${rs485_id}_status).publish_state(false);
 
   devices:
-    - id: rs485${rs485_id}
+    - id: rs485$_{rs485_id}
       name: "${rs485_name}"
 
 external_components:
@@ -53,7 +53,7 @@ select:
   - platform: template
     name: "YamBMS protocol"
     id: rs485${rs485_id}_protocol
-    device_id: rs485${rs485_id}
+    device_id: rs485_${rs485_id}
     options:
       - "Pylontech"
       - "Disabled"
@@ -66,7 +66,7 @@ switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
     id: rs485${rs485_id}_switch_inverter_heartbeat_monitoring
-    device_id: rs485${rs485_id}
+    device_id: rs485_${rs485_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
@@ -117,7 +117,7 @@ sensor:
   # --- Inverter Heartbeat ---
   - platform: template
     id: rs485${rs485_id}_inverter_heartbeat
-    device_id: rs485${rs485_id}
+    device_id: rs485_${rs485_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -178,7 +178,7 @@ binary_sensor:
   # --- RS485 Status ---
   - platform: template
     id: rs485${rs485_id}_status
-    device_id: rs485${rs485_id}
+    device_id: rs485_${rs485_id}
     name: "Status"
     entity_category: diagnostic
     on_state:

--- a/packages/yambms/yambms_rs485_pylon.yaml
+++ b/packages/yambms/yambms_rs485_pylon.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.3.5
+# Updated : 2026.02.03
+# Version : 1.3.6
 # GitHub  : https://github.com/fahmula/esphome-pylontech-rs485
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -17,9 +17,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
+substitutions:
+  # Extended ID
+  ext_rs485_id: "rs485${rs485_id}"
+  # The ID of the LED on your board used for this component
+  rs485_status_led_id: "virtual_status_light"
+
 esphome:
+  on_boot:
+    - priority: 600.0
+      then:
+        - lambda: |-
+            // Register System
+            id(global_register_led)(${CAT_INV_RS485}, ${rs485_id}, id(${rs485_status_led_id}));
+            // Force register fault as default, will be updated once RS485 is working
+            // (true = fault)
+            id(global_update_fault)(${CAT_INV_RS485}, ${rs485_id}, true);          
+    - priority: -100.0
+      then:
+        - lambda: |-
+            // Initialise rs485 status as off
+            id(${ext_rs485_id}_status).publish_state(false);
+
   devices:
-    - id: rs485_${rs485_id}
+    - id: rs485_${ext_rs485_id}
       name: "${rs485_name}"
 
 external_components:
@@ -33,8 +54,8 @@ uart:
 select:
   - platform: template
     name: "YamBMS protocol"
-    id: ${rs485_id}_protocol
-    device_id: rs485_${rs485_id}
+    id: ${ext_rs485_id}_protocol
+    device_id: rs485_${ext_rs485_id}
     options:
       - "Pylontech"
       - "Disabled"
@@ -46,59 +67,59 @@ select:
 switch:
   - platform: template
     name: "Inverter Heartbeat Monitoring"
-    id: ${rs485_id}_switch_inverter_heartbeat_monitoring
-    device_id: rs485_${rs485_id}
+    id: ${ext_rs485_id}_switch_inverter_heartbeat_monitoring
+    device_id: rs485_${ext_rs485_id}
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: diagnostic
 
 sensor:
   - platform: template
-    id: ${rs485_id}_proxy_soc
+    id: ${ext_rs485_id}_proxy_soc
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_voltage
+    id: ${ext_rs485_id}_proxy_voltage
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_current
+    id: ${ext_rs485_id}_proxy_current
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_temperature
+    id: ${ext_rs485_id}_proxy_temperature
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_soh
+    id: ${ext_rs485_id}_proxy_soh
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cycle_count
+    id: ${ext_rs485_id}_proxy_cycle_count
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_max_cell_v
+    id: ${ext_rs485_id}_proxy_max_cell_v
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_min_cell_v
+    id: ${ext_rs485_id}_proxy_min_cell_v
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_max_temp
+    id: ${ext_rs485_id}_proxy_max_temp
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_min_temp
+    id: ${ext_rs485_id}_proxy_min_temp
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_max_charge_v
+    id: ${ext_rs485_id}_proxy_max_charge_v
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_min_discharge_v
+    id: ${ext_rs485_id}_proxy_min_discharge_v
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_max_charge_i
+    id: ${ext_rs485_id}_proxy_max_charge_i
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_max_discharge_i
+    id: ${ext_rs485_id}_proxy_max_discharge_i
     internal: true
   # --- Inverter Heartbeat ---
   - platform: template
-    id: ${rs485_id}_inverter_heartbeat
-    device_id: rs485_${rs485_id}
+    id: ${ext_rs485_id}_inverter_heartbeat
+    device_id: rs485_${ext_rs485_id}
     name: "Inverter Heartbeat"
     unit_of_measurement: ms
     device_class: duration
@@ -109,59 +130,64 @@ sensor:
 binary_sensor:
   # --- Passive Proxy Alarm/Protection Sensors ---
   - platform: template
-    id: ${rs485_id}_proxy_total_voltage_high_alarm
+    id: ${ext_rs485_id}_proxy_total_voltage_high_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_total_voltage_low_alarm
+    id: ${ext_rs485_id}_proxy_total_voltage_low_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_temp_high_alarm
+    id: ${ext_rs485_id}_proxy_cell_temp_high_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_temp_low_alarm
+    id: ${ext_rs485_id}_proxy_cell_temp_low_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_charge_overcurrent_alarm
+    id: ${ext_rs485_id}_proxy_charge_overcurrent_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_discharge_overcurrent_alarm
+    id: ${ext_rs485_id}_proxy_discharge_overcurrent_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_imbalance_alarm
+    id: ${ext_rs485_id}_proxy_cell_imbalance_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_voltage_high_alarm
+    id: ${ext_rs485_id}_proxy_cell_voltage_high_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_voltage_low_alarm
+    id: ${ext_rs485_id}_proxy_cell_voltage_low_alarm
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_overvoltage_protection
+    id: ${ext_rs485_id}_proxy_cell_overvoltage_protection
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_undervoltage_protection
+    id: ${ext_rs485_id}_proxy_cell_undervoltage_protection
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_overtemp_protection
+    id: ${ext_rs485_id}_proxy_cell_overtemp_protection
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_cell_undertemp_protection
+    id: ${ext_rs485_id}_proxy_cell_undertemp_protection
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_charge_overcurrent_protection
+    id: ${ext_rs485_id}_proxy_charge_overcurrent_protection
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_discharge_overcurrent_protection
+    id: ${ext_rs485_id}_proxy_discharge_overcurrent_protection
     internal: true
   - platform: template
-    id: ${rs485_id}_proxy_system_fault_protection
+    id: ${ext_rs485_id}_proxy_system_fault_protection
     internal: true
   # --- RS485 Status ---
   - platform: template
-    id: ${rs485_id}_status
-    device_id: rs485_${rs485_id}
+    id: ${ext_rs485_id}_status
+    device_id: rs485_${ext_rs485_id}
     name: "Status"
     entity_category: diagnostic
+    on_state:
+      then:
+        - lambda: |-
+            // Pass the current state to the update function
+            id(global_update_fault)(${CAT_INV_RS485}, ${rs485_id}, !x);
 
 interval:
   - interval: 24h
@@ -169,139 +195,139 @@ interval:
       - lambda: |-
           // Save RS485 options
           id(${yambms_id}_var_inverter_bms_name) = "RS485";
-          id(${yambms_id}_var_inverter_protocol) = id(${rs485_id}_protocol).current_option();
+          id(${yambms_id}_var_inverter_protocol) = id(${ext_rs485_id}_protocol).current_option();
 
   - interval: 100ms
     then:
       - if:
           condition:
-            lambda: 'return id(${rs485_id}_protocol).current_option() == "Pylontech";'
+            lambda: 'return id(${ext_rs485_id}_protocol).current_option() == "Pylontech";'
           then:
             - lambda: !lambda |-
                 // Mirror RS485 status into inverter_com_status
-                if (id(${rs485_id}_status).has_state()) id(inverter_com_status).publish_state(id(${rs485_id}_status).state);
+                if (id(${ext_rs485_id}_status).has_state()) id(inverter_com_status).publish_state(id(${ext_rs485_id}_status).state);
 
                 // --- Check YamBMS initialized + BMS ONLINE/OFFLINE status ---  
                 if ((id(${yambms_id}_var_initialized) == true) && (id(${yambms_id}_bms_combined).state > 0))
                 {
                   // --- STATE 1: BMS is ONLINE ---
                   // Sensor Values
-                  if (id(${yambms_id}_battery_soc).has_state()) id(${rs485_id}_proxy_soc).publish_state(id(${yambms_id}_battery_soc).state);
-                  if (id(${yambms_id}_total_voltage).has_state()) id(${rs485_id}_proxy_voltage).publish_state(id(${yambms_id}_total_voltage).state);
-                  if (id(${yambms_id}_current).has_state()) id(${rs485_id}_proxy_current).publish_state(id(${yambms_id}_current).state);
-                  if (id(${yambms_id}_max_temperature).has_state()) id(${rs485_id}_proxy_temperature).publish_state(id(${yambms_id}_max_temperature).state);
-                  if (id(${yambms_id}_battery_soh).has_state()) id(${rs485_id}_proxy_soh).publish_state(id(${yambms_id}_battery_soh).state);
-                  if (id(${yambms_id}_charging_cycles).has_state()) id(${rs485_id}_proxy_cycle_count).publish_state(id(${yambms_id}_charging_cycles).state);
-                  if (id(${yambms_id}_max_cell_voltage).has_state()) id(${rs485_id}_proxy_max_cell_v).publish_state(id(${yambms_id}_max_cell_voltage).state);
-                  if (id(${yambms_id}_min_cell_voltage).has_state()) id(${rs485_id}_proxy_min_cell_v).publish_state(id(${yambms_id}_min_cell_voltage).state);
-                  if (id(${yambms_id}_max_temperature).has_state()) id(${rs485_id}_proxy_max_temp).publish_state(id(${yambms_id}_max_temperature).state);
-                  if (id(${yambms_id}_min_temperature).has_state()) id(${rs485_id}_proxy_min_temp).publish_state(id(${yambms_id}_min_temperature).state);
-                  if (id(${yambms_id}_requested_charge_voltage).has_state()) id(${rs485_id}_proxy_max_charge_v).publish_state(id(${yambms_id}_requested_charge_voltage).state);
-                  if (id(${yambms_id}_requested_discharge_voltage).has_state()) id(${rs485_id}_proxy_min_discharge_v).publish_state(id(${yambms_id}_requested_discharge_voltage).state);
-                  if (id(${yambms_id}_requested_charge_current).has_state()) id(${rs485_id}_proxy_max_charge_i).publish_state(id(${yambms_id}_requested_charge_current).state);
-                  if (id(${yambms_id}_requested_discharge_current).has_state()) id(${rs485_id}_proxy_max_discharge_i).publish_state(id(${yambms_id}_requested_discharge_current).state);
+                  if (id(${yambms_id}_battery_soc).has_state()) id(${ext_rs485_id}_proxy_soc).publish_state(id(${yambms_id}_battery_soc).state);
+                  if (id(${yambms_id}_total_voltage).has_state()) id(${ext_rs485_id}_proxy_voltage).publish_state(id(${yambms_id}_total_voltage).state);
+                  if (id(${yambms_id}_current).has_state()) id(${ext_rs485_id}_proxy_current).publish_state(id(${yambms_id}_current).state);
+                  if (id(${yambms_id}_max_temperature).has_state()) id(${ext_rs485_id}_proxy_temperature).publish_state(id(${yambms_id}_max_temperature).state);
+                  if (id(${yambms_id}_battery_soh).has_state()) id(${ext_rs485_id}_proxy_soh).publish_state(id(${yambms_id}_battery_soh).state);
+                  if (id(${yambms_id}_charging_cycles).has_state()) id(${ext_rs485_id}_proxy_cycle_count).publish_state(id(${yambms_id}_charging_cycles).state);
+                  if (id(${yambms_id}_max_cell_voltage).has_state()) id(${ext_rs485_id}_proxy_max_cell_v).publish_state(id(${yambms_id}_max_cell_voltage).state);
+                  if (id(${yambms_id}_min_cell_voltage).has_state()) id(${ext_rs485_id}_proxy_min_cell_v).publish_state(id(${yambms_id}_min_cell_voltage).state);
+                  if (id(${yambms_id}_max_temperature).has_state()) id(${ext_rs485_id}_proxy_max_temp).publish_state(id(${yambms_id}_max_temperature).state);
+                  if (id(${yambms_id}_min_temperature).has_state()) id(${ext_rs485_id}_proxy_min_temp).publish_state(id(${yambms_id}_min_temperature).state);
+                  if (id(${yambms_id}_requested_charge_voltage).has_state()) id(${ext_rs485_id}_proxy_max_charge_v).publish_state(id(${yambms_id}_requested_charge_voltage).state);
+                  if (id(${yambms_id}_requested_discharge_voltage).has_state()) id(${ext_rs485_id}_proxy_min_discharge_v).publish_state(id(${yambms_id}_requested_discharge_voltage).state);
+                  if (id(${yambms_id}_requested_charge_current).has_state()) id(${ext_rs485_id}_proxy_max_charge_i).publish_state(id(${yambms_id}_requested_charge_current).state);
+                  if (id(${yambms_id}_requested_discharge_current).has_state()) id(${ext_rs485_id}_proxy_max_discharge_i).publish_state(id(${yambms_id}_requested_discharge_current).state);
                   // Binary Sensors (Alarms/Protections)
                   if (id(${yambms_id}_errors_bitmask_warning).has_state()) {
                     uint16_t mask = id(${yambms_id}_errors_bitmask_warning).state;
-                    id(${rs485_id}_proxy_total_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
-                    id(${rs485_id}_proxy_total_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
-                    id(${rs485_id}_proxy_cell_temp_high_alarm).publish_state((mask & 0x0008) > 0);
-                    id(${rs485_id}_proxy_cell_temp_low_alarm).publish_state((mask & 0x0010) > 0);
-                    id(${rs485_id}_proxy_charge_overcurrent_alarm).publish_state((mask & 0x0100) > 0);
-                    id(${rs485_id}_proxy_discharge_overcurrent_alarm).publish_state((mask & 0x0080) > 0);
-                    id(${rs485_id}_proxy_cell_imbalance_alarm).publish_state((mask & 0x1000) > 0);
-                    id(${rs485_id}_proxy_cell_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
-                    id(${rs485_id}_proxy_cell_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
+                    id(${ext_rs485_id}_proxy_total_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
+                    id(${ext_rs485_id}_proxy_total_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
+                    id(${ext_rs485_id}_proxy_cell_temp_high_alarm).publish_state((mask & 0x0008) > 0);
+                    id(${ext_rs485_id}_proxy_cell_temp_low_alarm).publish_state((mask & 0x0010) > 0);
+                    id(${ext_rs485_id}_proxy_charge_overcurrent_alarm).publish_state((mask & 0x0100) > 0);
+                    id(${ext_rs485_id}_proxy_discharge_overcurrent_alarm).publish_state((mask & 0x0080) > 0);
+                    id(${ext_rs485_id}_proxy_cell_imbalance_alarm).publish_state((mask & 0x1000) > 0);
+                    id(${ext_rs485_id}_proxy_cell_voltage_high_alarm).publish_state((mask & 0x0002) > 0);
+                    id(${ext_rs485_id}_proxy_cell_voltage_low_alarm).publish_state((mask & 0x0004) > 0);
                   }
                   if (id(${yambms_id}_errors_bitmask_alarm).has_state()) {
                     uint16_t mask = id(${yambms_id}_errors_bitmask_alarm).state;
-                    id(${rs485_id}_proxy_cell_overvoltage_protection).publish_state((mask & 0x0002) > 0);
-                    id(${rs485_id}_proxy_cell_undervoltage_protection).publish_state((mask & 0x0004) > 0);
-                    id(${rs485_id}_proxy_cell_overtemp_protection).publish_state((mask & 0x0008) > 0);
-                    id(${rs485_id}_proxy_cell_undertemp_protection).publish_state((mask & 0x0010) > 0);
-                    id(${rs485_id}_proxy_charge_overcurrent_protection).publish_state((mask & 0x0100) > 0);
-                    id(${rs485_id}_proxy_discharge_overcurrent_protection).publish_state((mask & 0x0080) > 0);
-                    id(${rs485_id}_proxy_system_fault_protection).publish_state((mask & 0x0800) > 0);
+                    id(${ext_rs485_id}_proxy_cell_overvoltage_protection).publish_state((mask & 0x0002) > 0);
+                    id(${ext_rs485_id}_proxy_cell_undervoltage_protection).publish_state((mask & 0x0004) > 0);
+                    id(${ext_rs485_id}_proxy_cell_overtemp_protection).publish_state((mask & 0x0008) > 0);
+                    id(${ext_rs485_id}_proxy_cell_undertemp_protection).publish_state((mask & 0x0010) > 0);
+                    id(${ext_rs485_id}_proxy_charge_overcurrent_protection).publish_state((mask & 0x0100) > 0);
+                    id(${ext_rs485_id}_proxy_discharge_overcurrent_protection).publish_state((mask & 0x0080) > 0);
+                    id(${ext_rs485_id}_proxy_system_fault_protection).publish_state((mask & 0x0800) > 0);
                   }
                 } else {
                   // --- STATE 2: BMS is OFFLINE ---
                   // Invalidate all proxy sensors to trigger component's fail-safe.
-                  id(${rs485_id}_proxy_soc).publish_state(NAN);
-                  id(${rs485_id}_proxy_voltage).publish_state(NAN);
-                  id(${rs485_id}_proxy_current).publish_state(NAN);
-                  id(${rs485_id}_proxy_temperature).publish_state(NAN);
-                  id(${rs485_id}_proxy_soh).publish_state(NAN);
-                  id(${rs485_id}_proxy_cycle_count).publish_state(NAN);
-                  id(${rs485_id}_proxy_max_cell_v).publish_state(NAN);
-                  id(${rs485_id}_proxy_min_cell_v).publish_state(NAN);
-                  id(${rs485_id}_proxy_max_temp).publish_state(NAN);
-                  id(${rs485_id}_proxy_min_temp).publish_state(NAN);
-                  id(${rs485_id}_proxy_max_charge_v).publish_state(NAN);
-                  id(${rs485_id}_proxy_min_discharge_v).publish_state(NAN);
-                  id(${rs485_id}_proxy_max_charge_i).publish_state(NAN);
-                  id(${rs485_id}_proxy_max_discharge_i).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_soc).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_voltage).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_current).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_temperature).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_soh).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_cycle_count).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_max_cell_v).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_min_cell_v).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_max_temp).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_min_temp).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_max_charge_v).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_min_discharge_v).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_max_charge_i).publish_state(NAN);
+                  id(${ext_rs485_id}_proxy_max_discharge_i).publish_state(NAN);
 
                   // Publish 'false' to clear any alarms/protections.
-                  id(${rs485_id}_proxy_total_voltage_high_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_total_voltage_low_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_cell_temp_high_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_cell_temp_low_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_charge_overcurrent_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_discharge_overcurrent_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_cell_imbalance_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_cell_voltage_high_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_cell_voltage_low_alarm).publish_state(false);
-                  id(${rs485_id}_proxy_cell_overvoltage_protection).publish_state(false);
-                  id(${rs485_id}_proxy_cell_undervoltage_protection).publish_state(false);
-                  id(${rs485_id}_proxy_cell_overtemp_protection).publish_state(false);
-                  id(${rs485_id}_proxy_cell_undertemp_protection).publish_state(false);
-                  id(${rs485_id}_proxy_charge_overcurrent_protection).publish_state(false);
-                  id(${rs485_id}_proxy_discharge_overcurrent_protection).publish_state(false);
-                  id(${rs485_id}_proxy_system_fault_protection).publish_state(false);
+                  id(${ext_rs485_id}_proxy_total_voltage_high_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_total_voltage_low_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_temp_high_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_temp_low_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_charge_overcurrent_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_discharge_overcurrent_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_imbalance_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_voltage_high_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_voltage_low_alarm).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_overvoltage_protection).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_undervoltage_protection).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_overtemp_protection).publish_state(false);
+                  id(${ext_rs485_id}_proxy_cell_undertemp_protection).publish_state(false);
+                  id(${ext_rs485_id}_proxy_charge_overcurrent_protection).publish_state(false);
+                  id(${ext_rs485_id}_proxy_discharge_overcurrent_protection).publish_state(false);
+                  id(${ext_rs485_id}_proxy_system_fault_protection).publish_state(false);
                 }
 
 pylontech_rs485:
   uart_id: ${rs485_uart_id}
   update_timeout: ${rs485_update_timeout}
   # --- Link to PROXY sensors ---
-  state_of_charge: ${rs485_id}_proxy_soc
-  voltage: ${rs485_id}_proxy_voltage
-  current: ${rs485_id}_proxy_current
-  temperature: ${rs485_id}_proxy_temperature
-  state_of_health: ${rs485_id}_proxy_soh
-  cycle_count: ${rs485_id}_proxy_cycle_count
-  max_cell_voltage: ${rs485_id}_proxy_max_cell_v
-  min_cell_voltage: ${rs485_id}_proxy_min_cell_v
-  max_temperature: ${rs485_id}_proxy_max_temp
-  min_temperature: ${rs485_id}_proxy_min_temp
-  mosfet_temperature: ${rs485_id}_proxy_temperature
-  max_mosfet_temperature: ${rs485_id}_proxy_max_temp
-  min_mosfet_temperature: ${rs485_id}_proxy_min_temp
-  bms_temperature: ${rs485_id}_proxy_temperature
-  max_bms_temperature: ${rs485_id}_proxy_max_temp
-  min_bms_temperature: ${rs485_id}_proxy_min_temp
-  total_voltage_high_alarm: ${rs485_id}_proxy_total_voltage_high_alarm
-  total_voltage_low_alarm: ${rs485_id}_proxy_total_voltage_low_alarm
-  cell_voltage_high_alarm: ${rs485_id}_proxy_cell_voltage_high_alarm
-  cell_voltage_low_alarm: ${rs485_id}_proxy_cell_voltage_low_alarm
-  cell_temp_high_alarm: ${rs485_id}_proxy_cell_temp_high_alarm
-  cell_temp_low_alarm: ${rs485_id}_proxy_cell_temp_low_alarm
-  charge_overcurrent_alarm: ${rs485_id}_proxy_charge_overcurrent_alarm
-  discharge_overcurrent_alarm: ${rs485_id}_proxy_discharge_overcurrent_alarm
-  cell_imbalance_alarm: ${rs485_id}_proxy_cell_imbalance_alarm
-  cell_overvoltage_protection: ${rs485_id}_proxy_cell_overvoltage_protection
-  cell_undervoltage_protection: ${rs485_id}_proxy_cell_undervoltage_protection
-  cell_overtemp_protection: ${rs485_id}_proxy_cell_overtemp_protection
-  cell_undertemp_protection: ${rs485_id}_proxy_cell_undertemp_protection
-  charge_overcurrent_protection: ${rs485_id}_proxy_charge_overcurrent_protection
-  discharge_overcurrent_protection: ${rs485_id}_proxy_discharge_overcurrent_protection
-  system_fault_protection: ${rs485_id}_proxy_system_fault_protection
-  max_voltage: ${rs485_id}_proxy_max_charge_v
-  min_voltage: ${rs485_id}_proxy_min_discharge_v
-  max_charge_current: ${rs485_id}_proxy_max_charge_i
-  max_discharge_current: ${rs485_id}_proxy_max_discharge_i
+  state_of_charge: ${ext_rs485_id}_proxy_soc
+  voltage: ${ext_rs485_id}_proxy_voltage
+  current: ${ext_rs485_id}_proxy_current
+  temperature: ${ext_rs485_id}_proxy_temperature
+  state_of_health: ${ext_rs485_id}_proxy_soh
+  cycle_count: ${ext_rs485_id}_proxy_cycle_count
+  max_cell_voltage: ${ext_rs485_id}_proxy_max_cell_v
+  min_cell_voltage: ${ext_rs485_id}_proxy_min_cell_v
+  max_temperature: ${ext_rs485_id}_proxy_max_temp
+  min_temperature: ${ext_rs485_id}_proxy_min_temp
+  mosfet_temperature: ${ext_rs485_id}_proxy_temperature
+  max_mosfet_temperature: ${ext_rs485_id}_proxy_max_temp
+  min_mosfet_temperature: ${ext_rs485_id}_proxy_min_temp
+  bms_temperature: ${ext_rs485_id}_proxy_temperature
+  max_bms_temperature: ${ext_rs485_id}_proxy_max_temp
+  min_bms_temperature: ${ext_rs485_id}_proxy_min_temp
+  total_voltage_high_alarm: ${ext_rs485_id}_proxy_total_voltage_high_alarm
+  total_voltage_low_alarm: ${ext_rs485_id}_proxy_total_voltage_low_alarm
+  cell_voltage_high_alarm: ${ext_rs485_id}_proxy_cell_voltage_high_alarm
+  cell_voltage_low_alarm: ${ext_rs485_id}_proxy_cell_voltage_low_alarm
+  cell_temp_high_alarm: ${ext_rs485_id}_proxy_cell_temp_high_alarm
+  cell_temp_low_alarm: ${ext_rs485_id}_proxy_cell_temp_low_alarm
+  charge_overcurrent_alarm: ${ext_rs485_id}_proxy_charge_overcurrent_alarm
+  discharge_overcurrent_alarm: ${ext_rs485_id}_proxy_discharge_overcurrent_alarm
+  cell_imbalance_alarm: ${ext_rs485_id}_proxy_cell_imbalance_alarm
+  cell_overvoltage_protection: ${ext_rs485_id}_proxy_cell_overvoltage_protection
+  cell_undervoltage_protection: ${ext_rs485_id}_proxy_cell_undervoltage_protection
+  cell_overtemp_protection: ${ext_rs485_id}_proxy_cell_overtemp_protection
+  cell_undertemp_protection: ${ext_rs485_id}_proxy_cell_undertemp_protection
+  charge_overcurrent_protection: ${ext_rs485_id}_proxy_charge_overcurrent_protection
+  discharge_overcurrent_protection: ${ext_rs485_id}_proxy_discharge_overcurrent_protection
+  system_fault_protection: ${ext_rs485_id}_proxy_system_fault_protection
+  max_voltage: ${ext_rs485_id}_proxy_max_charge_v
+  min_voltage: ${ext_rs485_id}_proxy_min_discharge_v
+  max_charge_current: ${ext_rs485_id}_proxy_max_charge_i
+  max_discharge_current: ${ext_rs485_id}_proxy_max_discharge_i
   requested_force_charge: ${yambms_id}_requested_force_charge
   # --- Inverter Heartbeat & Com Status ---
-  inverter_heartbeat: ${rs485_id}_inverter_heartbeat
-  rs485_status: ${rs485_id}_status
-  heartbeat_switch: ${rs485_id}_switch_inverter_heartbeat_monitoring
+  inverter_heartbeat: ${ext_rs485_id}_inverter_heartbeat
+  rs485_status: ${ext_rs485_id}_status
+  heartbeat_switch: ${ext_rs485_id}_switch_inverter_heartbeat_monitoring

--- a/packages/yambms/yambms_rs485_pylon_web_server.yaml
+++ b/packages/yambms/yambms_rs485_pylon_web_server.yaml
@@ -22,12 +22,12 @@ packages:
 
 select:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${rs485_id}_protocol
+  - id: !extend ${ext_rs485_id}_protocol
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
 
 binary_sensor:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${rs485_id}_status
+  - id: !extend ${ext_rs485_id}_status
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol

--- a/packages/yambms/yambms_rs485_pylon_web_server.yaml
+++ b/packages/yambms/yambms_rs485_pylon_web_server.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.08.11
-# Version : 1.1.1
+# Updated : 2026.02.04
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -22,12 +22,12 @@ packages:
 
 select:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${ext_rs485_id}_protocol
+  - id: !extend rs485${rs485_id}_protocol
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol
 
 binary_sensor:
   # YamBMS - Inverter Communication Protocol
-  - id: !extend ${ext_rs485_id}_status
+  - id: !extend rs485${rs485_id}_status
     web_server:
       sorting_group_id: yambms_inverter_communication_protocol

--- a/packages/yambms/yambms_service.yaml
+++ b/packages/yambms/yambms_service.yaml
@@ -19,9 +19,10 @@
 
 esphome:
   on_boot:
-    then:
-    - lambda: id(${yambms_id}_running_version).publish_state("${yambms_version}");
-    - lambda: id(${yambms_id}_last_version).publish_state("${yambms_version}");
+    - priority: 600
+      then:
+      - lambda: id(${yambms_id}_running_version).publish_state("${yambms_version}");
+      - lambda: id(${yambms_id}_last_version).publish_state("${yambms_version}");
 
 text_sensor:
   # +--------------------------------------+

--- a/packages/yambms/yambms_service.yaml
+++ b/packages/yambms/yambms_service.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.30
-# Version : 1.2.3
+# Updated : 2026.02.04
+# Version : 1.2.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )


### PR DESCRIPTION
This PR introduces a complete overhaul of the system’s health monitoring and LED status logic.

It replaces previous LED control with a **Centralized Fault Registry (Backend)** and implements **Synchronized Diagnostic Blink Codes (Frontend)**. This ensures that multiple BMS modules, inverters, and peripherals report errors in a unified, synchronized manner via LED control.

### Centralized Fault Registry

**Dynamic Storage**: A global 2D-vector (global_instance_faults) that automatically tracks health status for up to 16 categories (API, BMS, canbus, etc.) and unlimited instances (multiple batteries, etc) per category.

**Event-Driven**: Faults are updated via a lightweight global function (global_update_fault).

**HA Integration**: Automatically publishes a raw JSON sensor (system_fault_data) containing the complete system health matrix for easy parsing in Home Assistant via a markdown card.

<img width="220" height="230" alt="image" src="https://github.com/user-attachments/assets/b4b34e91-7bdd-4a75-b117-9e528527106f" />

```
type: markdown
content: |-
  | Component | Instance Status |
  | :--- | :--- |
  {%- set raw = states('sensor.yambms_demo_system_fault_data') %}
  {%- if raw not in ['unknown', 'unavailable', 'none'] %}
      {%- set data = raw | from_json %}
      {%- set names = ['API / MQTT', 'BMS', 'CAN->INV', 'RS485->INV', 'Shunt', 'Balancer', 'Network', 'Aux 1', 'Cat 8', 'Cat 9', 'Cat 10', 'Cat 11', 'Cat 12', 'Cat 13', 'Cat 14', 'Cat 15'] %}
      {%- for cat_idx in range(0, 16) %}
        {%- set instances = data[cat_idx] %}
        {%- if instances | count > 0 %}
          {%- set ns = namespace(visual='') %}
          {%- for inst in instances %}
            {#- Accessible Icons: Cross/Check for shape-based recognition -#}
            {%- set icon = '❌' if inst == 1 else '✅' %}
            {%- set ns.visual = ns.visual ~ icon ~ '  ' %}
          {%- endfor %}
    | {{ names[cat_idx] }} | {{ ns.visual }} |
        {%- endif %}
      {%- endfor %}
    {%- else %}
  | System | Initializing... |
    {%- endif %}
```



**Fault Mask**: Maintains a 16-bit integer mask (global_system_fault_mask) for efficient checks by other functions.

---

### Synchronized Diagnostic LED Blink Codes

Replaced the previous logic with a structured and efficient logic supporting multi-LED output:

**Heartbeat**: When healthy, LEDs pulse green for 1 second, off for 2 seconds.

**Diagnostic Codes**: When a fault is deteched, LEDs transmit a specific number of blinks corresponding to the Fault Category (e.g., 2 blinks = BMS Error, 5 blinks= Shunt Error).

**LED synchronisation**: On a multi-LED board, all LEDs share a common time base. The 1 second pulse happens simultaneously on all LEDs, making the board easier to read.

**Fault Spotlight Mode**: When a fault is active, healthy LEDs turn off during the blink phase to reduce visual noise and highlight the faulty component.

**Multi-Fault Rotation**: If one LED monitors multiple components (e.g., BMS + Shunt) and both fail, the LED automatically rotates through the error codes sequentially.

---

### Configuration

Users can now map specific components to specific hardware LEDs using the *_status_led_id substitution in their package configuration.

Example:
```
# Assign BMS 1 to the first led
bms_status_led_id: 'led_1'

# Assign Inverter CANBUS to the second led
canbus_status_led_id: 'led_2'

# Shared LED Strategy (Both report to the same LED)
# The LED will rotate codes if both fail.
bms_status_led_id: 'esp_light'
canbus_status_led_id: 'esp_light'
```

---

### Documentation

Updated YamBMS_behaviour.md.
- Blink reference table (1=API / MQTT, 2=BMS, etc.).
- Advanced features (Spotlight, Rotation).

Updated template YAMLs.

--- 

### Breaking Changes

The main YAML will need to be updated, templates have been altered as needed.\
Note that canbus_id and rs485_id must be a number.
