### PR TITLE
RP2040 fix - remove global fault mask logging

### DIFF
--- a/packages/base/device_base_fault_registry.yaml
+++ b/packages/base/device_base_fault_registry.yaml
@@ -128,11 +128,6 @@ interval:
           ESP_LOGI("health_rpt", "│     SYSTEM HEALTH REPORT     │");
           ESP_LOGI("health_rpt", "└──────────────────────────────┘");
 
-          // Log Master Bitmask
-          uint16_t mask = id(global_system_fault_mask);
-          std::string binary_mask = std::bitset<16>(mask).to_string();
-          ESP_LOGI("health_rpt", "Global Fault Mask: %d (Binary: %s)", mask, binary_mask.c_str());
-
           bool system_clean = true;
 
           // Iterate through all 16 Categories

--- a/packages/base/device_base_fault_registry.yaml
+++ b/packages/base/device_base_fault_registry.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.01
-# Version : 1.0.0
+# Updated : 2026.02.05
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )


### PR DESCRIPTION
Removed logging of the global fault mask in the health report, RP2040 does not have std::bitset in the toolchain