### PR TITLE
Update board configurations and add no LED control options

### DIFF
--- a/packages/board/board_ESP32-C3_ETH01-EVO.yaml
+++ b/packages/board/board_ESP32-C3_ETH01-EVO.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.3.2
+# Updated : 2026.02.05
+# Version : 1.3.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -34,6 +34,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_ethernet: !include ../base/device_base_ethernet.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: esp32-c3-devkitm-1

--- a/packages/board/board_ESP32-S3_AtomS3.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.05
-# Version : 1.3.6
+# Version : 1.3.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -48,6 +48,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_wifi: !include ../base/device_base_wifi.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: m5stack-atoms3

--- a/packages/board/board_ESP32-S3_AtomS3R.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3R.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.05
-# Version : 1.3.6
+# Version : 1.3.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -48,6 +48,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_wifi: !include ../base/device_base_wifi.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: m5stack-atoms3

--- a/packages/board/board_ESP32-S3_AtomS3_ili9xxx.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3_ili9xxx.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.05
-# Version : 1.3.6
+# Version : 1.3.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/packages/board/board_ESP32-S3_AtomS3_ili9xxx.yaml
+++ b/packages/board/board_ESP32-S3_AtomS3_ili9xxx.yaml
@@ -48,6 +48,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_wifi: !include ../base/device_base_wifi.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: m5stack-atoms3

--- a/packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml
+++ b/packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.1.4
+# Updated : 2026.02.05
+# Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -36,6 +36,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_wifi: !include ../base/device_base_wifi.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: esp32-s3-devkitc-1

--- a/packages/board/board_ESP32-S3_WS-ETH.yaml
+++ b/packages/board/board_ESP32-S3_WS-ETH.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.1.4
+# Updated : 2026.02.05
+# Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -42,6 +42,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_ethernet: !include ../base/device_base_ethernet.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: esp32-s3-devkitc-1

--- a/packages/board/board_ESP32-S3_WS-RS485-CAN.yaml
+++ b/packages/board/board_ESP32-S3_WS-RS485-CAN.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.1.7
+# Updated : 2026.02.05
+# Version : 1.1.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -48,6 +48,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_wifi: !include ../base/device_base_wifi.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: esp32-s3-devkitc-1

--- a/packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml
+++ b/packages/board/board_ESP32-S3_WS-Touch-LCD-4.3.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.1.7
+# Updated : 2026.02.05
+# Version : 1.1.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -46,6 +46,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_wifi: !include ../base/device_base_wifi.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: esp32-s3-devkitc-1

--- a/packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml
+++ b/packages/board/board_ESP32-S3_WS-Touch-LCD-7.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.1.7
+# Updated : 2026.02.05
+# Version : 1.1.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -44,6 +44,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_wifi: !include ../base/device_base_wifi.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: esp32-s3-devkitc-1

--- a/packages/board/board_ESP32_EVB.yaml
+++ b/packages/board/board_ESP32_EVB.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.31
-# Version : 1.1.6
+# Updated : 2026.02.05
+# Version : 1.1.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -36,6 +36,7 @@ substitutions:
 packages:
   device_base: !include ../base/device_base.yaml
   device_base_ethernet: !include ../base/device_base_ethernet.yaml
+  no_led_control: !include board_options_no_led_control.yaml
 
 esp32:
   board: esp32-evb

--- a/packages/board/board_options_no_led_control.yaml
+++ b/packages/board/board_options_no_led_control.yaml
@@ -1,0 +1,61 @@
+# Updated : 2026.02.05
+# Version : 1.1.1
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+
+substitutions:
+  global_status_led: "esp_light"
+
+globals:
+
+  # ---------------------------------------------------------
+  # Global Function: Update LED assignment - No LED version
+  # ---------------------------------------------------------
+  - id: global_register_led
+    type: std::function<void(int, int, esphome::light::LightState*)>
+    initial_value: |-
+      [](int category, int instance, esphome::light::LightState* led) {
+        // Do nothing - This board does not have a LED
+      }
+
+
+output:
+  - platform: template
+    id: virtual_output
+    type: binary
+    write_action: []
+
+  # Fake esp_light output
+  - platform: template
+    id: esp_light_output
+    type: binary
+    write_action: []
+
+light:
+  # Fake light to act as a placeholder for LED control logic
+  - platform: binary
+    id: virtual_status_light
+    output: virtual_output
+
+  # Fake esp_light
+  - platform: binary
+    id: esp_light
+    output: esp_light_output
+
+
+


### PR DESCRIPTION
Additional stripped down version of `board_options_led_control.yaml` created to handle boards with no LED.

`board_options_no_led_control.yaml` contains 2 fake LEDs which are referenced by package substitutions.
The global function `global_register_led` has been gutted, but still remains so that component packages compile correctly.
The vector `global_led_registry` has been removed, alongside the led control code itself.