### PR TITLE
Added offline skip to harden against disconnects.

### DIFF
--- a/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
@@ -80,8 +80,6 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: "online status"
-    filters:
-      - delayed_off: 15s
     trigger_on_initial_state: true
     on_state:
       then:

--- a/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_PACE_RS485_bms_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.8
+# Updated : 2026.02.06
+# Version : 1.1.9
 # GitHub  : https://github.com/syssi/esphome-pace-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -31,6 +31,7 @@ modbus_controller:
     modbus_id: ${pace_modbus_id}
     command_throttle: ${pace_modbus_command_throttle}
     update_interval: ${pace_modbus_update_interval}
+    offline_skip_updates: 5
     on_online:
       then:
         - logger.log: "Pace BMS ${bms_id} back online !"
@@ -79,6 +80,8 @@ binary_sensor:
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
     name: "online status"
+    filters:
+      - delayed_off: 15s
     trigger_on_initial_state: true
     on_state:
       then:


### PR DESCRIPTION
This is a small tweak to harden the BMS readings and prevent flapping when the device is low on ram.

Example:
<img width="600" height="517" alt="image" src="https://github.com/user-attachments/assets/5831802f-6a37-4f9a-b663-be8a8a64c946" />

I only notice the issue when I have logging turned on but I figured it would be useful to have to harden against disconnects.