### PR TITLE
Clamp Modbus client sensors to reasonable values

### DIFF
--- a/packages/balancer/balancer_modbus_client.yaml
+++ b/packages/balancer/balancer_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.4
+# Updated : 2026.02.06
+# Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -95,6 +95,10 @@ sensor:
     device_class: voltage
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -116,6 +120,10 @@ sensor:
     device_class: voltage
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001

--- a/packages/bms/bms_combine_modbus_client.yaml
+++ b/packages/bms/bms_combine_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.2.6
+# Updated : 2026.02.06
+# Version : 1.2.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -134,6 +134,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -152,6 +156,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: -1000
+          max_value: 1000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -170,6 +178,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: -20000
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -188,6 +200,10 @@ sensor:
     filters:
       - lambda: if(!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -206,6 +222,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 5000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -224,6 +244,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 5000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -241,6 +265,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -259,6 +287,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 1000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -277,6 +309,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 1000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -295,6 +331,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -312,6 +352,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 32
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -330,6 +374,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -347,6 +395,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 32
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -365,6 +417,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.1
+      - clamp:
+          min_value: -50
+          max_value: 125
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.1
@@ -382,6 +438,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 1699
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -400,6 +460,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.1
+      - clamp:
+          min_value: -50
+          max_value: 125
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.1
@@ -417,6 +481,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 1699
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -435,6 +503,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -453,6 +525,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -472,6 +548,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -507,6 +587,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -525,6 +609,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -543,6 +631,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1

--- a/packages/bms/bms_combine_modbus_client_dev.yaml
+++ b/packages/bms/bms_combine_modbus_client_dev.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.2.7
+# Updated : 2026.02.06
+# Version : 1.2.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -84,7 +84,7 @@ binary_sensor:
     modbus_controller_id: modbus_controller${bms_id}
     id: bms${bms_id}_online_status
     device_id: bms_${bms_id}
-    name: "Online Status"
+    name: "Online status"
     trigger_on_initial_state: true
     register_type: read
     address: 1
@@ -133,6 +133,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -151,6 +155,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: -1000
+          max_value: 1000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -169,6 +177,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: -20000
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -187,6 +199,10 @@ sensor:
     filters:
       - lambda: if(!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -205,6 +221,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 5000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -223,6 +243,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 5000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -240,6 +264,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -258,6 +286,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 1000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -276,6 +308,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 1000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -294,6 +330,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -311,6 +351,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 32
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -329,6 +373,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -346,6 +394,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 32
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -364,6 +416,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.1
+      - clamp:
+          min_value: -50
+          max_value: 125
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.1
@@ -381,6 +437,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 32
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -399,6 +459,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.1
+      - clamp:
+          min_value: -50
+          max_value: 125
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.1
@@ -416,6 +480,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 32
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -434,6 +502,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -452,6 +524,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -471,6 +547,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 5
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.001
@@ -506,6 +586,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -524,6 +608,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 20000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -542,6 +630,10 @@ sensor:
     filters:
       - lambda: if (!id(bms${bms_id}_online_status).state) return 0; else return x;
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1

--- a/packages/shunt/shunt_combine_modbus_client.yaml
+++ b/packages/shunt/shunt_combine_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.7
+# Updated : 2026.02.06
+# Version : 1.1.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -72,6 +72,10 @@ sensor:
     device_class: voltage
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -89,6 +93,10 @@ sensor:
     device_class: current
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: -500
+          max_value: 500
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -106,6 +114,10 @@ sensor:
     device_class: power
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: -10000
+          max_value: 10000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -123,6 +135,10 @@ sensor:
     device_class: battery
     filters:
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -140,6 +156,10 @@ sensor:
     device_class: power
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 10000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -157,6 +177,10 @@ sensor:
     device_class: power
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 10000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01

--- a/packages/shunt/shunt_combine_modbus_client_dev.yaml
+++ b/packages/shunt/shunt_combine_modbus_client_dev.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.8
+# Updated : 2026.02.06
+# Version : 1.1.9
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -72,6 +72,10 @@ sensor:
     device_class: voltage
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -89,6 +93,10 @@ sensor:
     device_class: current
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: -500
+          max_value: 500
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -106,6 +114,10 @@ sensor:
     device_class: power
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: -10000
+          max_value: 10000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -123,6 +135,10 @@ sensor:
     device_class: battery
     filters:
       - multiply: 1
+      - clamp:
+          min_value: 0
+          max_value: 100
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 1
@@ -140,6 +156,10 @@ sensor:
     device_class: power
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 10000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01
@@ -157,6 +177,10 @@ sensor:
     device_class: power
     filters:
       - multiply: 0.001
+      - clamp:
+          min_value: 0
+          max_value: 10000
+          ignore_out_of_range: true
       - or:
         - throttle: 10s
         - delta: 0.01


### PR DESCRIPTION
When a Modbus read fails (disconnect, reboot of Modbus server node), the read may return 0xFF/0xFFFF before the Modbus controller marks the device as offline. This leads to things like SOC 65535% (0xFFFF):

<img width="2505" height="637" alt="image" src="https://github.com/user-attachments/assets/e84347fa-e15a-424d-8bb5-b46e552fb1ec" />

This commit adds a `clamp` filter to the Modbus client sensors which will ignore values out of typical sensor ranges.