### PR TITLE
Auto CCL and DCL to new loop

### DIFF
--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.30
-# Version : 1.2.8
+# Updated : 2026.02.07
+# Version : 1.2.9
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -16,6 +16,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+esphome:
+  on_boot:
+    - priority: -100.0
+      then:
+        - lambda: |-
+            id(${yambms_id}_var_auto_ccl_functions_count)++;
 
 substitutions:
   # +--------------------------------------+
@@ -39,67 +46,95 @@ switch:
     optimistic: true
     entity_category: config
 
-sensor:
-  # +--------------------------------------+
-  # | Auto Charge Current Limit            |
-  # +--------------------------------------+
-  # First, an initial charge current delta is calculated based upon the maximum cell voltage but only if the Auto Charge Current switch is enabled.
-  - platform: copy
-    source_id: ${yambms_id}_max_cell_voltage
-    name: ${name} ${yambms_name} Initial Charge Current
-    id: auto_ccl_initial
-    unit_of_measurement: A
-    device_class: current
-    internal: true
-    filters:
-    - lambda: |-
-        // Variables
-        double max_charge_a = id(${yambms_id}_max_charge_current).state;
-        double cell_bulk_v = (id(${yambms_id}_bulk_voltage).state / id(${yambms_id}_cell_count).state);
-        double cell_float_v = (id(${yambms_id}_float_voltage).state / id(${yambms_id}_cell_count).state);
-        double cell_high_v = ((id(${yambms_id}_cell_ovp).state + cell_bulk_v) / 2);
+interval:
+  - interval: ${yambms_update_interval}
+    then:
+      # +------------------------------------------+
+      # | Auto Charge Current Limit                |
+      # +------------------------------------------+
+      - lambda: |-
+          int cc_step = id(${yambms_id}_var_charge_current_step);
+          if (cc_step >= 1 && cc_step < id(${yambms_id}_var_auto_ccl_functions_count) + 1)
+          {
+            ESP_LOGD("yambms_debug", "Entering Auto CCL...");
 
-        // Auto Charge Current function
-        if (!id(${yambms_id}_switch_auto_ccl).state) {
-          // No change to charge current required
-          return 0.0;
-        } else if (id(${yambms_id}_max_cell_voltage).state > cell_high_v) {
-          // Set CCL delta to maximum as max cell voltage too high
-          return -max_charge_a;
-        } else {
-          // Set CCL delta to automatic value
-          return max(0.0,(- pow(${charge_a_factor_curve_end}, pow( max(0.0, ((x - cell_float_v) / (cell_high_v - cell_float_v))),${charge_a_factor_curve_shape}))+2) * max_charge_a)
-          - max_charge_a;
-        }
+            // Use static variables to persist state between interval runs
+            static float current_output = 0.0f;
+            static bool is_initialized = false;
 
-  # Second, an exponential moving average is calculated. This will be used to smooth the transition between different initial charge current values.
-  - platform: copy
-    source_id: auto_ccl_initial
-    name: ${name} ${yambms_name} Moving Average Charge Current
-    id:  auto_ccl_moving_average
-    unit_of_measurement: A
-    device_class: current
-    internal: true
-    filters:
-    - exponential_moving_average:
-        alpha: 0.15
-        send_every: 1
-        send_first_at: 1
+            // Configuration
+            float max_current           = id(${yambms_id}_max_charge_current).state;
+            auto& output_id             = id(${yambms_id}_var_auto_ccl);
+            float alpha                 = 0.15f;
+            float min_amp_increase_step = 1.0; 
 
-  # Third, if the instantaneous initial charge current value is lower than the moving average, use that, otherwise use the moving average.
-  # This means that cell voltage spikes will be reacted to quickly, but reduced cell voltages will not, preventing oscillation of requested current.
-  - platform: copy
-    source_id: auto_ccl_initial
-    name: ${name} ${yambms_name} Auto Charge Current
-    id: auto_ccl
-    unit_of_measurement: A
-    device_class: current
-    accuracy_decimals: 1
-    internal: true
-    filters:
-    - lambda: |-
-        // Variables
-        double auto_ccl = round((min(id(auto_ccl_moving_average).state, x) * 10) / 10);
+            // Define raw inputs
+            float max_cell_v = id(${yambms_id}_max_cell_voltage).state;
+            float cell_count = id(${yambms_id}_cell_count).state;
 
-        id(${yambms_id}_var_auto_ccl) = auto_ccl;
-        return auto_ccl;
+            float cell_bulk_v = (id(${yambms_id}_bulk_voltage).state / cell_count);
+            float cell_float_v = (id(${yambms_id}_float_voltage).state / cell_count);
+            float cell_high_v = ((id(${yambms_id}_cell_ovp).state + cell_bulk_v) / 2);
+
+            // Exit if critical data is missing
+            if (isnan(max_current) || isnan(max_cell_v) || isnan(cell_count)) {
+              output_id = 0.0f;
+              id(${yambms_id}_var_charge_current_step)++;
+              return;
+            }
+          
+            // Check switch enabled
+            if (!id(${yambms_id}_switch_auto_ccl).state) {
+              output_id = 0.0f;
+              id(${yambms_id}_var_charge_current_step)++;
+              return;
+            }
+
+            // Calculate initial current delta
+            double delta = 0.0;
+
+            if (max_cell_v > cell_high_v) {
+              delta = -max_current;
+            } else {
+              double ratio = max(0.0, ((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
+              double curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
+              delta = max(0.0, (-curve + 2) * max_current) - max_current;
+            }
+
+            if (!is_initialized) {
+              current_output = delta;
+              is_initialized = true;
+            }
+
+            // Apply decrease in current instantly      
+            // This means that cell voltage increases will be reacted to quickly
+            if (delta < current_output) {
+               current_output = delta;
+            } 
+            // Apply increase in current slowly, prevent oscillation of cell voltage
+            else {
+               // Calculate the gap to output
+               float gap = delta - current_output;
+               
+               // Calculate exponential moving average
+               float step = gap * alpha;
+               
+               // Apply minimum increase step
+               // If the calculated step is tiny, force it to be at least min_amp_increase_step
+               if (step < min_amp_increase_step) {
+                   step = min_amp_increase_step;
+               }
+               
+               // Calculate output
+               if (step > gap) {
+                   current_output = delta;
+               } else {
+                   current_output += step;
+               }
+            }
+
+            // Update global
+            current_output = round(current_output * 10) / 10.0;
+            output_id = current_output;
+            id(${yambms_id}_var_charge_current_step)++;
+          }

--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -66,7 +66,7 @@ interval:
             float max_current           = id(${yambms_id}_max_charge_current).state;
             auto& output_id             = id(${yambms_id}_var_auto_ccl);
             float alpha                 = 0.15f;
-            float min_amp_increase_step = 1.0; 
+            float min_amp_increase_step = 1.0f; 
 
             // Define raw inputs
             float max_cell_v = id(${yambms_id}_max_cell_voltage).state;
@@ -74,7 +74,7 @@ interval:
 
             float cell_bulk_v = (id(${yambms_id}_bulk_voltage).state / cell_count);
             float cell_float_v = (id(${yambms_id}_float_voltage).state / cell_count);
-            float cell_high_v = ((id(${yambms_id}_cell_ovp).state + cell_bulk_v) / 2);
+            float cell_high_v = ((id(${yambms_id}_cell_ovp).state + cell_bulk_v) / 2.0f);
 
             // Exit if critical data is missing
             if (isnan(max_current) || isnan(max_cell_v) || isnan(cell_count)) {
@@ -91,14 +91,14 @@ interval:
             }
 
             // Calculate initial current delta
-            double delta = 0.0;
+            float delta = 0.0f;
 
             if (max_cell_v > cell_high_v) {
               delta = -max_current;
             } else {
-              double ratio = max(0.0f, (float)((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
-              double curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
-              delta = max(0.0, (-curve + 2) * max_current) - max_current;
+              float ratio = max(0.0f, ((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
+              float curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
+              delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
             }
 
             if (!is_initialized) {
@@ -134,7 +134,7 @@ interval:
             }
 
             // Update global
-            current_output = round(current_output * 10) / 10.0;
+            current_output = round(current_output * 10.0f) / 10.0f;
             output_id = current_output;
             id(${yambms_id}_var_charge_current_step)++;
           }

--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -96,7 +96,7 @@ interval:
             if (max_cell_v > cell_high_v) {
               delta = -max_current;
             } else {
-              double ratio = max(0.0, ((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
+              double ratio = max(0.0f, (float)((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
               double curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
               delta = max(0.0, (-curve + 2) * max_current) - max_current;
             }

--- a/packages/yambms/yambms_auto_dcl.yaml
+++ b/packages/yambms/yambms_auto_dcl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.30
-# Version : 1.2.8
+# Updated : 2026.02.07
+# Version : 1.2.9
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -16,6 +16,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+esphome:
+  on_boot:
+    - priority: -100.0
+      then:
+        - lambda: |-
+            id(${yambms_id}_var_auto_dcl_functions_count)++;
 
 substitutions:
   # +--------------------------------------+
@@ -40,65 +47,91 @@ switch:
     optimistic: true
     entity_category: config
 
-sensor:
-  # +--------------------------------------+
-  # | Auto Discharge Current Limit         |
-  # +--------------------------------------+
-  # First, an initial discharge current is calculated based upon the minimum cell voltage but only if the Auto Discharge Current switch is enabled.
-  - platform: copy
-    source_id: ${yambms_id}_min_cell_voltage
-    name: ${name} ${yambms_name} Initial Discharge Current
-    id: auto_dcl_initial
-    unit_of_measurement: A
-    device_class: current
-    internal: true
-    filters:
-    - lambda: |-
-        // Variables
-        double max_discharge_a = id(${yambms_id}_max_discharge_current).state;
-        double cell_low_v = id(${yambms_id}_cell_uvp).state + 0.2;
+interval:
+  - interval: ${yambms_update_interval}
+    then:
+      # +------------------------------------------+
+      # | Auto Discharge Current Limit             |
+      # +------------------------------------------+
+      - lambda: |-
+          int dc_step = id(${yambms_id}_var_discharge_current_step);
+          if (dc_step >= 1 && dc_step < id(${yambms_id}_var_auto_dcl_functions_count) + 1)
+          {
+            ESP_LOGD("yambms_debug", "Entering Auto DCL...");
 
-        // Auto Discharge Current function
-        if (!id(${yambms_id}_switch_auto_dcl).state) {
-          // No change to discharge current required
-          return 0.0;
-        } else if (id(${yambms_id}_min_cell_voltage).state < cell_low_v) {
-          // Set DCL delta to maximum as min cell voltage too low
-          return -max_discharge_a;
-        } else {
-          // Set DCL delta to automatic value
-          return max(0.0,(- pow(${discharge_a_factor_curve_end}, pow( max(0.0, ((x - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v}))),${discharge_a_factor_curve_shape}))+2) * max_discharge_a)
-          - max_discharge_a;
-        }
+            // Use static variables to persist state between interval runs
+            static float current_output = 0.0f;
+            static bool is_initialized = false;
 
-  # Second, an exponential moving average is calculated. This will be used to smooth the transition between different initial discharge current values.
-  - platform: copy
-    source_id: auto_dcl_initial
-    name: ${name} ${yambms_name} Moving Average Discharge Current
-    id:  auto_dcl_moving_average
-    unit_of_measurement: A
-    device_class: current
-    internal: true
-    filters:
-    - exponential_moving_average:
-        alpha: 0.15
-        send_every: 1
-        send_first_at: 1
+            // Configuration
+            float max_current           = id(${yambms_id}_max_discharge_current).state;
+            auto& output_id             = id(${yambms_id}_var_auto_dcl);
+            float alpha                 = 0.15f;
+            float min_amp_increase_step = 1.0; 
 
-  # Third, if the instantaneous initial discharge current value is lower than the moving average, use that, otherwise use the moving average.
-  # This means that cell voltage drops will be reacted to quickly, but increased cell voltages will not, preventing oscillation of requested current.
-  - platform: copy
-    source_id: auto_dcl_initial
-    name: ${name} ${yambms_name} Auto Discharge Current
-    id: auto_dcl
-    unit_of_measurement: A
-    device_class: current
-    accuracy_decimals: 1
-    internal: true
-    filters:
-    - lambda: |-
-        // Variables
-        double auto_dcl = round((min(id(auto_dcl_moving_average).state, x) * 10) / 10);
+            // Define raw inputs
+            float min_cell_v = id(${yambms_id}_min_cell_voltage).state;
+            float cell_low_v = id(${yambms_id}_cell_uvp).state + 0.2;
 
-        id(${yambms_id}_var_auto_dcl) = auto_dcl;
-        return auto_dcl;
+            // Exit if critical data is missing
+            if (isnan(max_current) || isnan(min_cell_v) || isnan(cell_low_v)) {
+              output_id = 0.0f;
+              id(${yambms_id}_var_discharge_current_step)++;
+              return;
+            }
+          
+            // Check switch enabled
+            if (!id(${yambms_id}_switch_auto_dcl).state) {
+              output_id = 0.0f;
+              id(${yambms_id}_var_discharge_current_step)++;
+              return;
+            }
+
+            // Calculate initial current delta
+            double delta = 0.0;
+
+            if (min_cell_v < cell_low_v) {
+              delta = -max_current;
+            } else {
+              double ratio = max(0.0, ((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
+              double curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
+              delta = max(0.0, (-curve + 2) * max_current) - max_current;
+            }
+
+            if (!is_initialized) {
+              current_output = delta;
+              is_initialized = true;
+            }
+
+            // Apply decrease in current instantly      
+            // This means that cell voltage decreases will be reacted to quickly
+            if (delta < current_output) {
+               current_output = delta;
+            } 
+            // Apply increase in current slowly, prevent oscillation of cell voltage
+            else {
+               // Calculate the gap to output
+               float gap = delta - current_output;
+               
+               // Calculate exponential moving average
+               float step = gap * alpha;
+               
+               // Apply minimum increase step
+               // If the calculated step is tiny, force it to be at least min_amp_increase_step
+               if (step < min_amp_increase_step) {
+                   step = min_amp_increase_step;
+               }
+               
+               // Calculate output
+               if (step > gap) {
+                   current_output = delta;
+               } else {
+                   current_output += step;
+               }
+            }
+
+            // Update global
+            current_output = round(current_output * 10) / 10.0;
+            output_id = current_output;
+            id(${yambms_id}_var_discharge_current_step)++;
+          }

--- a/packages/yambms/yambms_auto_dcl.yaml
+++ b/packages/yambms/yambms_auto_dcl.yaml
@@ -67,11 +67,11 @@ interval:
             float max_current           = id(${yambms_id}_max_discharge_current).state;
             auto& output_id             = id(${yambms_id}_var_auto_dcl);
             float alpha                 = 0.15f;
-            float min_amp_increase_step = 1.0; 
+            float min_amp_increase_step = 1.0f; 
 
             // Define raw inputs
             float min_cell_v = id(${yambms_id}_min_cell_voltage).state;
-            float cell_low_v = id(${yambms_id}_cell_uvp).state + 0.2;
+            float cell_low_v = id(${yambms_id}_cell_uvp).state + 0.2f;
 
             // Exit if critical data is missing
             if (isnan(max_current) || isnan(min_cell_v) || isnan(cell_low_v)) {
@@ -88,14 +88,14 @@ interval:
             }
 
             // Calculate initial current delta
-            double delta = 0.0;
+            float delta = 0.0f;
 
             if (min_cell_v < cell_low_v) {
               delta = -max_current;
             } else {
-              double ratio = max(0.0f, (float)((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
-              double curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
-              delta = max(0.0, (-curve + 2) * max_current) - max_current;
+              float ratio = max(0.0f, (float)((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
+              float curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
+              delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
             }
 
             if (!is_initialized) {
@@ -131,7 +131,7 @@ interval:
             }
 
             // Update global
-            current_output = round(current_output * 10) / 10.0;
+            current_output = round(current_output * 10.0f) / 10.0f;
             output_id = current_output;
             id(${yambms_id}_var_discharge_current_step)++;
           }

--- a/packages/yambms/yambms_auto_dcl.yaml
+++ b/packages/yambms/yambms_auto_dcl.yaml
@@ -93,7 +93,7 @@ interval:
             if (min_cell_v < cell_low_v) {
               delta = -max_current;
             } else {
-              double ratio = max(0.0, ((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
+              double ratio = max(0.0f, (float)((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
               double curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
               delta = max(0.0, (-curve + 2) * max_current) - max_current;
             }


### PR DESCRIPTION
Updated auto CCL and DCL functions, now full lambda integrated with the loop as described in #182.

Testing auto CCL with a full charge overnight.

Both files still use 'fast decrease, slow increase` logic, but the minimum increase step is now 1 amp.