### PR TITLE
Auto CCL & DCL - Re-implement Soft Current Ramp

### DIFF
--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -98,7 +98,7 @@ interval:
                 }
             }
             // If switch is off, delta stays 0.0f. 
-            // The logic below will smoothly ramp from the old negative value back to 0.
+            // Smoothly ramp from the old negative value back to 0 if required
 
             if (!is_initialized) {
               current_output = delta;

--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.09
-# Version : 1.2.10
+# Version : 1.3.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.07
-# Version : 1.2.9
+# Updated : 2026.02.09
+# Version : 1.2.10
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -83,23 +83,22 @@ interval:
               return;
             }
           
-            // Check switch enabled
-            if (!id(${yambms_id}_switch_auto_ccl).state) {
-              output_id = 0.0f;
-              id(${yambms_id}_var_charge_current_step)++;
-              return;
-            }
-
-            // Calculate initial current delta
+            // Default target is 0.0 (No reduction in current)
             float delta = 0.0f;
 
-            if (max_cell_v > cell_high_v) {
-              delta = -max_current;
-            } else {
-              float ratio = max(0.0f, ((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
-              float curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
-              delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
+            // Only calculate a reduction if the switch is ON
+            if (id(${yambms_id}_switch_auto_ccl).state) {
+                if (max_cell_v > cell_high_v) {
+                  delta = -max_current;
+                } else {
+                  // Calculate curve
+                  float ratio = max(0.0f, (float)((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
+                  float curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
+                  delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
+                }
             }
+            // If switch is off, delta stays 0.0f. 
+            // The logic below will smoothly ramp from the old negative value back to 0.
 
             if (!is_initialized) {
               current_output = delta;

--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -86,7 +86,7 @@ interval:
             // Default target is 0.0 (No reduction in current)
             float delta = 0.0f;
 
-            // Only calculate a reduction if the switch is ON
+            // Only calculate a reduction if the switch is on
             if (id(${yambms_id}_switch_auto_ccl).state) {
                 if (max_cell_v > cell_high_v) {
                   delta = -max_current;

--- a/packages/yambms/yambms_auto_dcl.yaml
+++ b/packages/yambms/yambms_auto_dcl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.07
-# Version : 1.2.9
+# Updated : 2026.02.09
+# Version : 1.2.10
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -80,23 +80,22 @@ interval:
               return;
             }
           
-            // Check switch enabled
-            if (!id(${yambms_id}_switch_auto_dcl).state) {
-              output_id = 0.0f;
-              id(${yambms_id}_var_discharge_current_step)++;
-              return;
-            }
-
-            // Calculate initial current delta
+            // Default target is 0.0 (No reduction in current)
             float delta = 0.0f;
 
-            if (min_cell_v < cell_low_v) {
-              delta = -max_current;
-            } else {
-              float ratio = max(0.0f, (float)((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
-              float curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
-              delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
+            // Only calculate a reduction if the switch is on
+            if (id(${yambms_id}_switch_auto_dcl).state) {
+                if (min_cell_v < cell_low_v) {
+                  delta = -max_current;
+                } else {
+                  // Calculate a curve based on the cell voltage.
+                  float ratio = max(0.0f, (float)((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
+                  float curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
+                  delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
+                }
             }
+            // If switch is off, delta stays 0.0f. 
+            // Smoothly ramp from the old negative value back to 0 if required
 
             if (!is_initialized) {
               current_output = delta;


### PR DESCRIPTION
After continued testing I've decided to re-implement the ramp up of current when the function is disabled.
Testing confirms that disabling the function during heavy charge or discharge can lead to large cell voltage changes, which in turn can trip BMS protection.