### PR TITLE
Remove unused shunt Modbus registers charging_power/discharging_power

### DIFF
--- a/packages/shunt/shunt_base.yaml
+++ b/packages/shunt/shunt_base.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.03
-# Version : 1.1.6
+# Updated : 2026.02.13
+# Version : 1.1.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -22,6 +22,34 @@ packages:
   led_assign: !include shunt_base_led_assign.yaml
 
 sensor:
+  # Battery Charging Power
+  - platform: template
+    name: "Battery Charging Power"
+    id: shunt${shunt_id}_battery_charging_power
+    device_id: shunt_${shunt_id}
+    update_interval: ${shunt_update_interval}
+    unit_of_measurement: 'W'
+    device_class: power
+    accuracy_decimals: 0
+    lambda: |-
+      if (id(shunt${shunt_id}_power).state > 0)
+        return id(shunt${shunt_id}_power).state;
+      else return 0;
+
+  # Battery Discharging Power
+  - platform: template
+    name: "Battery Discharging Power"
+    id: shunt${shunt_id}_battery_discharging_power
+    device_id: shunt_${shunt_id}
+    update_interval: ${shunt_update_interval}
+    unit_of_measurement: 'W'
+    device_class: power
+    accuracy_decimals: 0
+    lambda: |-
+      if (id(shunt${shunt_id}_power).state <= 0)
+        return (id(shunt${shunt_id}_power).state * -1); // Must be positive energy
+      else return 0;
+
   # Daily Charging Energy
   - platform: total_daily_energy
     name: "Daily Charging Energy"

--- a/packages/shunt/shunt_base_minimal.yaml
+++ b/packages/shunt/shunt_base_minimal.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.18
-# Version : 1.1.3
+# Updated : 2026.02.13
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -19,32 +19,3 @@
 
 packages:
   sub_device: !include shunt_base_sub_device.yaml
-
-sensor:
-  # Battery Charging Power
-  - platform: template
-    name: "Battery Charging Power"
-    id: shunt${shunt_id}_battery_charging_power
-    device_id: shunt_${shunt_id}
-    update_interval: ${shunt_update_interval}
-    unit_of_measurement: 'W'
-    device_class: power
-    accuracy_decimals: 0
-    lambda: |-
-      if (id(shunt${shunt_id}_power).state > 0)
-        return id(shunt${shunt_id}_power).state;
-      else return 0;
-
-  # Battery Discharging Power
-  - platform: template
-    name: "Battery Discharging Power"
-    id: shunt${shunt_id}_battery_discharging_power
-    device_id: shunt_${shunt_id}
-    update_interval: ${shunt_update_interval}
-    unit_of_measurement: 'W'
-    device_class: power
-    accuracy_decimals: 0
-    lambda: |-
-      if (id(shunt${shunt_id}_power).state <= 0)
-        return (id(shunt${shunt_id}_power).state * -1); // Must be positive energy
-      else return 0;

--- a/packages/shunt/shunt_combine_modbus_client.yaml
+++ b/packages/shunt/shunt_combine_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.06
-# Version : 1.1.9
+# Updated : 2026.02.13
+# Version : 1.1.10
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -142,45 +142,4 @@ sensor:
       - or:
         - throttle: 10s
         - delta: 1
-  # charging_power
-  - platform: modbus_controller
-    modbus_controller_id: modbus_controller_shunt${shunt_id}
-    id: shunt${shunt_id}_charging_power
-    device_id: shunt_${shunt_id}
-    name: "Charging Power"
-    register_type: read
-    address: 9
-    value_type: U_DWORD
-    accuracy_decimals: 2
-    unit_of_measurement: W
-    device_class: power
-    filters:
-      - multiply: 0.001
-      - clamp:
-          min_value: 0
-          max_value: 10000
-          ignore_out_of_range: true
-      - or:
-        - throttle: 10s
-        - delta: 0.01
-  # discharging_power
-  - platform: modbus_controller
-    modbus_controller_id: modbus_controller_shunt${shunt_id}
-    id: shunt${shunt_id}_discharging_power
-    device_id: shunt_${shunt_id}
-    name: "Discharging Power"
-    register_type: read
-    address: 11
-    value_type: U_DWORD
-    accuracy_decimals: 2
-    unit_of_measurement: W
-    device_class: power
-    filters:
-      - multiply: 0.001
-      - clamp:
-          min_value: 0
-          max_value: 10000
-          ignore_out_of_range: true
-      - or:
-        - throttle: 10s
-        - delta: 0.01
+

--- a/packages/shunt/shunt_combine_modbus_client.yaml
+++ b/packages/shunt/shunt_combine_modbus_client.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.13
-# Version : 1.1.10
+# Version : 1.2.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/packages/shunt/shunt_modbus_server.yaml
+++ b/packages/shunt/shunt_modbus_server.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.06
-# Version : 1.1.3
+# Updated : 2026.02.13
+# Version : 1.1.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -46,13 +46,4 @@ modbus_controller:
           value_type: U_WORD
           read_lambda: |-
             return uint16_t(id(shunt${shunt_id}_soc).state);
-        # charging_power (mW)
-        - address: 9
-          value_type: U_DWORD
-          read_lambda: |-
-            return uint32_t(id(shunt${shunt_id}_battery_charging_power).state * 1000);
-        # discharging_power (mW)
-        - address: 11
-          value_type: U_DWORD
-          read_lambda: |-
-            return uint32_t(id(shunt${shunt_id}_battery_discharging_power).state * 1000);
+

--- a/packages/shunt/shunt_modbus_server_dev.yaml
+++ b/packages/shunt/shunt_modbus_server_dev.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.06
-# Version : 1.1.4
+# Updated : 2026.02.13
+# Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -46,13 +46,4 @@ modbus_server:
           value_type: U_WORD
           read_lambda: |-
             return uint16_t(id(shunt${shunt_id}_soc).state);
-        # charging_power (mW)
-        - address: 9
-          value_type: U_DWORD
-          read_lambda: |-
-            return uint32_t(id(shunt${shunt_id}_battery_charging_power).state * 1000);
-        # discharging_power (mW)
-        - address: 11
-          value_type: U_DWORD
-          read_lambda: |-
-            return uint32_t(id(shunt${shunt_id}_battery_discharging_power).state * 1000);
+


### PR DESCRIPTION
The shunt Modbus registers included two registers derived from the Power register:

- Battery Charging Power
- Battery Discharging Power

These were unused and are calculated from the shunt Power. However these registers were transmitted which adds load to the Modbus.

This PR removes these registers.