### PR TITLE
Add filters to Deye temperature sensors

### DIFF
--- a/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.10
+# Updated : 2026.02.14
+# Version : 1.1.11
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -500,6 +500,11 @@ sensor:
     device_class: 'temperature'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - exponential_moving_average:
+          alpha: 0.1
+          send_every: 4
+      - delta: 0.2
 
   # Min. temperature sensor (fixed)
   - platform: template
@@ -521,6 +526,11 @@ sensor:
     device_class: 'temperature'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - exponential_moving_average:
+          alpha: 0.1
+          send_every: 4
+      - delta: 0.2
 
   # Max. temperature sensor (fixed)
   - platform: template

--- a/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.10
+# Updated : 2026.02.14
+# Version : 1.1.11
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -359,6 +359,11 @@ sensor:
     device_class: 'temperature'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - exponential_moving_average:
+          alpha: 0.1
+          send_every: 4
+      - delta: 1
 
   # Min. temperature sensor (fixed)
   - platform: template
@@ -380,6 +385,11 @@ sensor:
     device_class: 'temperature'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - exponential_moving_average:
+          alpha: 0.1
+          send_every: 4
+      - delta: 1
 
   # Max. temperature sensor (fixed)
   - platform: template
@@ -395,6 +405,7 @@ sensor:
   # Cell OVP: Unsupported
   - platform: template
     unit_of_measurement: 'V'
+    device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
     id: bms${bms_id}_cell_ovp
@@ -406,6 +417,7 @@ sensor:
   # Cell UVP: Unsupported
   - platform: template
     unit_of_measurement: 'V'
+    device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
     id: bms${bms_id}_cell_uvp
@@ -417,6 +429,7 @@ sensor:
   # Cell balance trigger voltage: Unsupported
   - platform: template
     unit_of_measurement: 'V'
+    device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
     id: bms${bms_id}_bms_balance_trigger_voltage


### PR DESCRIPTION
The Deye batteries are creating some noise on the temperature sensors as they only have full degree steps:

<img width="1325" height="742" alt="image" src="https://github.com/user-attachments/assets/9faefa78-14c4-4fcc-ae6d-ad0331b8cbe8" />

This commit adds a filter similar to the Basen one.

Draft: Currently testing.