### PR TITLE
Basen: Add "Enable communication" switch

### DIFF
--- a/packages/bms/bms_sensors_BASEN_RS485_full.yaml
+++ b/packages/bms/bms_sensors_BASEN_RS485_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.12
+# Updated : 2026.02.16
+# Version : 1.1.13
 # GitHub  : https://github.com/GHswitt/esphome-basen
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -619,6 +619,11 @@ number:
       name: "Heating off temperature"
 
 switch:
+  - platform: basen_bms
+    basen_bms_id: basen_bms_id${bms_id}
+    enable:
+      device_id: bms_${bms_id}
+      name: "Enable communication"
   - platform: basen_bms
     basen_bms_id: basen_bms_id${bms_id}
     heating:


### PR DESCRIPTION
Add switch to enable/disable communication with Basen BMS. For example this can be used during maintenance to disable communication with the selected battery.

<img width="780" height="173" alt="image" src="https://github.com/user-attachments/assets/ac4b5c8b-c835-40d3-a34b-99be2317a81e" />

<img width="499" height="362" alt="image" src="https://github.com/user-attachments/assets/f8f7a9d2-4270-4a3b-8a26-e73aafbdb148" />
