### PR TITLE
Switch to VictronMPPT-ESPHOME fork

### DIFF
--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.7
+# Updated : 2026.02.16
+# Version : 1.1.8
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -25,8 +25,8 @@ packages:
 # +--------------------------------------+
 
 external_components:
-  - source: github://KinDR007/VictronMPPT-ESPHOME@main
-    refresh: 0s
+  - source: github://GHswitt/VictronMPPT-ESPHOME@main
+    refresh: 60s
 
 victron:
   - uart_id: ${shunt_uart_id}

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.16
-# Version : 1.1.8
+# Version : 1.1.9
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -45,21 +45,18 @@ binary_sensor:
       name: "relay state"
   # Required sensors cannot be retrieved from Shunt
   # online_status
-  - platform: template
-    id: shunt${shunt_id}_online_status
-    device_id: shunt_${shunt_id}
-    name: "Online Status"
-    trigger_on_initial_state: true
-    on_state:
-      then:
-        - lambda: |-
-            // Pass the current state to the update function
-            id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
-    lambda: |-
-      if (id(shunt${shunt_id}_voltage).state > 0)
-        return true;
-      else
-        return false;
+  - platform: victron
+    victron_id: victron${shunt_id}
+    online:
+      id: shunt${shunt_id}_online_status
+      device_id: shunt_${shunt_id}
+      name: "Online status"
+      trigger_on_initial_state: true
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 sensor:
   - platform: victron

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.04
-# Version : 1.1.5
+# Updated : 2026.02.16
+# Version : 1.1.6
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -25,8 +25,8 @@ packages:
 # +--------------------------------------+
 
 external_components:
-  - source: github://KinDR007/VictronMPPT-ESPHOME@main
-    refresh: 0s
+  - source: github://GHswitt/VictronMPPT-ESPHOME@main
+    refresh: 60s
 
 victron:
   - uart_id: ${shunt_uart_id}

--- a/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
+++ b/packages/shunt/shunt_sensors_Victron_SmartShunt_UART_minimal.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.16
-# Version : 1.1.6
+# Version : 1.1.7
 # GitHub  : https://github.com/KinDR007/VictronMPPT-ESPHOME
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -39,20 +39,18 @@ victron:
 
 binary_sensor:
   # online_status
-  - platform: template
-    id: shunt${shunt_id}_online_status
-    device_id: shunt_${shunt_id}
-    name: "Online status"
-    on_state:
-      then:
-        - lambda: |-
-            // Pass the current state to the update function
-            id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
-    lambda: |-
-      if (id(shunt${shunt_id}_voltage).state > 0)
-        return true;
-      else
-        return false;
+  - platform: victron
+    victron_id: victron${shunt_id}
+    online:
+      id: shunt${shunt_id}_online_status
+      device_id: shunt_${shunt_id}
+      name: "Online status"
+      trigger_on_initial_state: true
+      on_state:
+        then:
+          - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 sensor:
   - platform: victron


### PR DESCRIPTION
This PR includes the following improvements:
- Include PR 212: Checksum validation: Verify the checksum to detect
  transmission errors (https://github.com/KinDR007/VictronMPPT-ESPHOME/pull/212 / https://github.com/GHswitt/VictronMPPT-ESPHOME/commit/ac642be1a4b734efdbfb8719c0ae4a66ab483216)
- Improve logging: More log messages and output shunt ID (https://github.com/GHswitt/VictronMPPT-ESPHOME/commit/6672955a1b7f06ad53797a6da3a05bcd9cc50767)
- Add online sensor and timeout parameter: Disconnects were not
  detected. This adds a binary_sensor that gets set to false if no
  data is received for a specified time (default=5s). (https://github.com/GHswitt/VictronMPPT-ESPHOME/commit/a3a20da7a8ea18718b405efcab5a6914fae6c514)
- Fix throttle algorithm: Each frame type gets its own throttle
  handling (https://github.com/GHswitt/VictronMPPT-ESPHOME/commit/89eb8db1e8a4b08de3f83ada5b114320710b0277)

https://github.com/KinDR007/VictronMPPT-ESPHOME/compare/main...GHswitt:VictronMPPT-ESPHOME:main