### PR TITLE
Add fault registry calls to Modbus clients

### DIFF
--- a/packages/balancer/balancer_modbus_client.yaml
+++ b/packages/balancer/balancer_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.06
-# Version : 1.1.7
+# Updated : 2026.02.19
+# Version : 1.1.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -46,6 +46,9 @@ modbus_controller:
         - lambda: |-
             id(balancer${bms_id}_online_status).publish_state(false);
             id(balancer${bms_id}_equalizing).publish_state(false);
+        - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BALANCER}, ${bms_id}, 1);    
 
 # +--------------------------------------+
 # | Component entities                   |
@@ -65,6 +68,9 @@ binary_sensor:
       then:
         - lambda: |-
             id(bms${bms_id}_var_ext_balancer_online) = x;
+        - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BALANCER}, ${bms_id}, !x);
   # equalizing
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_balancer${bms_id}

--- a/packages/bms/bms_combine_modbus_client.yaml
+++ b/packages/bms/bms_combine_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.06
-# Version : 1.2.8
+# Updated : 2026.02.19
+# Version : 1.2.9
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -74,6 +74,9 @@ modbus_controller:
             id(bms${bms_id}_charging_power).publish_state(0);
             id(bms${bms_id}_discharging_power).publish_state(0);
             id(bms${bms_id}_battery_soh).publish_state(0);
+        - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, 1);
 
 # +--------------------------------------+
 # | Component entities                   |
@@ -89,6 +92,12 @@ binary_sensor:
     trigger_on_initial_state: true
     register_type: read
     address: 1
+    on_state:
+      then:
+        - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_BMS}, ${bms_id}, !x);
+              
   # charging_allowed
   - platform: modbus_controller
     modbus_controller_id: modbus_controller_bms${bms_id}

--- a/packages/shunt/shunt_combine_modbus_client.yaml
+++ b/packages/shunt/shunt_combine_modbus_client.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.13
-# Version : 1.2.0
+# Updated : 2026.02.19
+# Version : 1.2.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -41,6 +41,9 @@ modbus_controller:
       then:
         - logger.log: "Shunt ${shunt_id} modbus server goes offline !"
         - lambda: id(shunt${shunt_id}_online_status).publish_state(false);
+        - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, 1);
 
 # +--------------------------------------+
 # | Component entities                   |
@@ -56,6 +59,11 @@ binary_sensor:
     trigger_on_initial_state: true
     register_type: read
     address: 1
+    on_state:
+      then:
+        - lambda: |-
+              // Pass the current state to the update function
+              id(global_update_fault)(${CAT_SHUNT}, ${shunt_id}, !x);
 
 sensor:
   # total_voltage


### PR DESCRIPTION
Adds fault registry calls for Modbus clients so the status is correctly displayed on a Modbus client:

<img width="774" height="442" alt="image" src="https://github.com/user-attachments/assets/fd707477-c78e-4df7-8580-e1d637607884" />

See also https://github.com/Sleeper85/esphome-yambms/issues/201