### PR TITLE
Throttle/filter BMS sensors

### DIFF
--- a/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.4
+# Updated : 2026.03.15
+# Version : 1.1.5
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -118,10 +118,18 @@ sensor:
       id: balancer${bms_id}_delta_cell_voltage
       device_id: balancer_${bms_id}
       name: "delta cell voltage"
+      filters:
+        - throttle_average: 30s
+        - round: 3
     average_cell_voltage:
       id: balancer${bms_id}_average_cell_voltage
       device_id: balancer_${bms_id}
       name: "average cell voltage"
+      filters:
+        - sliding_window_moving_average:
+            window_size: 9
+            send_every: 4
+        - round: 3
     cell_voltage_1:
       id: balancer${bms_id}_cell_v_01
       device_id: balancer_${bms_id}
@@ -238,6 +246,11 @@ sensor:
       id: balancer${bms_id}_total_voltage
       device_id: balancer_${bms_id}
       name: "total voltage"
+      filters:
+        - sliding_window_moving_average:
+            window_size: 9
+            send_every: 4
+        - round: 2
     temperature_sensor_1:
       id: balancer${bms_id}_temperature_sensor_1
       device_id: balancer_${bms_id}

--- a/packages/bms/bms_sensors_BASEN_RS485_full.yaml
+++ b/packages/bms/bms_sensors_BASEN_RS485_full.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.03.15
-# Version : 1.1.14
+# Version : 1.2.5
 # GitHub  : https://github.com/GHswitt/esphome-basen
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/packages/bms/bms_sensors_BASEN_RS485_full.yaml
+++ b/packages/bms/bms_sensors_BASEN_RS485_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.16
-# Version : 1.1.13
+# Updated : 2026.03.15
+# Version : 1.1.14
 # GitHub  : https://github.com/GHswitt/esphome-basen
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -126,37 +126,41 @@ sensor:
       device_id: bms_${bms_id}
       name: "temperature sensor 1"
       filters:
-        - exponential_moving_average:
-            alpha: 0.1
-            send_every: 4
-        - delta: 1
+        - median:
+            window_size: 25
+            send_every: 12
+            send_first_at: 3
+        - delta: 0.5
     temperature2:
       id: bms${bms_id}_temperature_sensor_2
       device_id: bms_${bms_id}
       name: "temperature sensor 2"
       filters:
-        - exponential_moving_average:
-            alpha: 0.1
-            send_every: 4
-        - delta: 1
+        - median:
+            window_size: 25
+            send_every: 12
+            send_first_at: 3
+        - delta: 0.5
     temperature3:
       id: bms${bms_id}_temperature_sensor_3
       device_id: bms_${bms_id}
       name: "temperature sensor 3"
       filters:
-        - exponential_moving_average:
-            alpha: 0.1
-            send_every: 4
-        - delta: 1
+        - median:
+            window_size: 25
+            send_every: 12
+            send_first_at: 3
+        - delta: 0.5
     temperature4: 
       id: bms${bms_id}_temperature_sensor_4
       device_id: bms_${bms_id}
       name: "temperature sensor 4"
       filters:
-        - exponential_moving_average:
-            alpha: 0.1
-            send_every: 4
-        - delta: 1
+        - median:
+            window_size: 25
+            send_every: 12
+            send_first_at: 3
+        - delta: 0.5
     temperature_mos:
       device_id: bms_${bms_id}
       name: "temperature MOSFET"
@@ -167,6 +171,10 @@ sensor:
       id: bms${bms_id}_average_cell_voltage
       device_id: bms_${bms_id}
       name: "cell average voltage"
+      filters:
+        - throttle_average: 20s
+        - round: 3
+        - delta: 0.0015
     min_cell_voltage:
       id: bms${bms_id}_min_cell_voltage
       device_id: bms_${bms_id}
@@ -187,54 +195,90 @@ sensor:
       id: bms${bms_id}_delta_voltage_cell
       device_id: bms_${bms_id}
       name: "cell delta voltage"
+      filters:
+        - throttle_average: 20s
+        - round: 3
+        - delta: 0.0015
     cell_voltage_01:
       device_id: bms_${bms_id}
       name: "cell voltage 01"
+      filters:
+        - delta: 0.0015
     cell_voltage_02:
       device_id: bms_${bms_id}
       name: "cell voltage 02"
+      filters:
+        - delta: 0.0015
     cell_voltage_03:
       device_id: bms_${bms_id}
       name: "cell voltage 03"
+      filters:
+        - delta: 0.0015
     cell_voltage_04:
       device_id: bms_${bms_id}
       name: "cell voltage 04"
+      filters:
+        - delta: 0.0015
     cell_voltage_05:
       device_id: bms_${bms_id}
       name: "cell voltage 05"
+      filters:
+        - delta: 0.0015
     cell_voltage_06:
       device_id: bms_${bms_id}
       name: "cell voltage 06"
+      filters:
+        - delta: 0.0015
     cell_voltage_07:
       device_id: bms_${bms_id}
       name: "cell voltage 07"
+      filters:
+        - delta: 0.0015
     cell_voltage_08:
       device_id: bms_${bms_id}
       name: "cell voltage 08"
+      filters:
+        - delta: 0.0015
     cell_voltage_09:
       device_id: bms_${bms_id}
       name: "cell voltage 09"
+      filters:
+        - delta: 0.0015
     cell_voltage_10:
       device_id: bms_${bms_id}
       name: "cell voltage 10"
+      filters:
+        - delta: 0.0015
     cell_voltage_11:
       device_id: bms_${bms_id}
       name: "cell voltage 11"
+      filters:
+        - delta: 0.0015
     cell_voltage_12:
       device_id: bms_${bms_id}
       name: "cell voltage 12"
+      filters:
+        - delta: 0.0015
     cell_voltage_13:
       device_id: bms_${bms_id}
       name: "cell voltage 13"
+      filters:
+        - delta: 0.0015
     cell_voltage_14:
       device_id: bms_${bms_id}
       name: "cell voltage 14"
+      filters:
+        - delta: 0.0015
     cell_voltage_15:
       device_id: bms_${bms_id}
       name: "cell voltage 15"
+      filters:
+        - delta: 0.0015
     cell_voltage_16:
       device_id: bms_${bms_id}
       name: "cell voltage 16"
+      filters:
+        - delta: 0.0015
 
     # Protection parameters
     CELL_OV_Start:

--- a/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.21
-# Version : 1.1.11
+# Version : 1.2.2
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.10
+# Updated : 2026.02.21
+# Version : 1.1.11
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -309,9 +309,12 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 2
     filters:
-    - timeout:
-        timeout: 60s
-        value: !lambda return 0;
+      - timeout:
+          timeout: 60s
+          value: !lambda return 0;
+      - throttle_average: ${bms_update_interval}
+      - round: 2
+      - delta: 0.01
 
   # Current
   - platform: template
@@ -322,6 +325,10 @@ sensor:
     device_class: 'current'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 1
+      - delta: 0.1
 
   # Battery power (calculated)
   - platform: template
@@ -334,6 +341,10 @@ sensor:
     accuracy_decimals: 0
     lambda: |-
       return id(bms${bms_id}_total_voltage).state * id(bms${bms_id}_current).state;
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 0
+      - delta: 1
 
   # Charging power: Calculated from voltage and current
   - platform: template
@@ -347,6 +358,10 @@ sensor:
     lambda: |-
       if (id(bms${bms_id}_current).state > 0) return id(bms${bms_id}_total_voltage).state * id(bms${bms_id}_current).state;
       else return 0;
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 0
+      - delta: 1
 
   # Discharging power: Calculated from voltage and current
   - platform: template
@@ -360,6 +375,10 @@ sensor:
     lambda: |-
       if (id(bms${bms_id}_current).state < 0) return id(bms${bms_id}_total_voltage).state * -id(bms${bms_id}_current).state;
       else return 0;
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 0
+      - delta: 1
 
   # SoC
   - platform: template
@@ -370,6 +389,9 @@ sensor:
     device_class: 'battery'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - round: 1
+      - throttle: ${bms_update_interval}
 
   # Battery capacity
   - platform: template
@@ -384,6 +406,8 @@ sensor:
       uint8_t module_count = id(deye${deye_id}_module_amount).state;
       if (module_count < 1) module_count = 1;
       return id(deye${deye_id}_battery_capacity).state / module_count;
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Remaining capacity - Calculated from SoC and battery capacity
   - platform: template
@@ -396,8 +420,9 @@ sensor:
     accuracy_decimals: 0
     filters:
       - or:
-        - throttle: 10s
+        - throttle: ${bms_update_interval}
         - delta: 1
+      - round: 0
     lambda: |-
       return (id(bms${bms_id}_state_of_charge).state * id(bms${bms_id}_battery_capacity).state) / 100;
 
@@ -418,7 +443,6 @@ sensor:
     # name: "charging cycle capacity"
     id: "bms${bms_id}_cycle_capacity_raw"
     device_id: bms_${bms_id}
-    update_interval: ${bms_update_interval}
     unit_of_measurement: Ah
     state_class: 'measurement'
     accuracy_decimals: 0
@@ -429,7 +453,7 @@ sensor:
         - delta: 1
     lambda: |-
       return id(bms${bms_id}_charging_cycles_raw).state * id(bms${bms_id}_battery_capacity).state;
-  
+
   # Max. charge current
   - platform: template
     name: "max charge current"
@@ -439,6 +463,8 @@ sensor:
     device_class: 'current'
     state_class: 'measurement'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Max. discharge current
   - platform: template
@@ -449,6 +475,8 @@ sensor:
     device_class: 'current'
     state_class: 'measurement'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Max. cell voltage
   - platform: template
@@ -459,6 +487,10 @@ sensor:
     device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 3
+    filters:
+      - throttle_average: 20s
+      - round: 3
+      - delta: 0.0015
 
   # Max. voltage cell: Only with InterCAN enabled
   - platform: template
@@ -481,6 +513,10 @@ sensor:
     on_value:
       then:
         - component.update: bms${bms_id}_imbalance
+    filters:
+      - throttle_average: 20s
+      - round: 3
+      - delta: 0.0015
 
   # Min. voltage cell: Only with InterCAN enabled
   - platform: template
@@ -499,18 +535,26 @@ sensor:
     unit_of_measurement: '°C'
     device_class: 'temperature'
     state_class: 'measurement'
-    accuracy_decimals: 1
+    accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
+      - median:
+          window_size: 25
+          send_every: 12
+          send_first_at: 3
+      - delta: 0.5
 
   # Min. temperature sensor (fixed)
   - platform: template
     id: bms${bms_id}_min_temperature_sensor
     device_id: bms_${bms_id}
     name: "min temperature sensor"
-    update_interval: ${bms_update_interval}
     accuracy_decimals: 0
     icon: mdi:numeric
     lambda: |-
       return (1 + ${bms_id} * 100 + ${deye_module_id}1);
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Max. temperature
   - platform: template
@@ -520,18 +564,26 @@ sensor:
     unit_of_measurement: '°C'
     device_class: 'temperature'
     state_class: 'measurement'
-    accuracy_decimals: 1
-
+    accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
+      - median:
+          window_size: 25
+          send_every: 12
+          send_first_at: 3
+      - delta: 0.5
+  
   # Max. temperature sensor (fixed)
   - platform: template
     id: bms${bms_id}_max_temperature_sensor
     device_id: bms_${bms_id}
     name: "max temperature sensor"
-    update_interval: ${bms_update_interval}
     accuracy_decimals: 0
     icon: mdi:numeric
     lambda: |-
       return (1 + ${bms_id} * 100 + ${deye_module_id}1);
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Cell OVP: Unsupported
   - platform: template
@@ -645,6 +697,8 @@ sensor:
     accuracy_decimals: 0
     lambda: |-
       return ((id(bms${bms_id}_max_cell_voltage).state - id(bms${bms_id}_min_cell_voltage).state)) * 1000;
+    filters:
+      - throttle_average: ${bms_update_interval}
 
   - platform: template
     name: "MosMax"
@@ -654,6 +708,8 @@ sensor:
     device_class: 'temperature'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - throttle: ${bms_update_interval}
 
   - platform: template
     name: "HeatMem"
@@ -663,6 +719,8 @@ sensor:
     device_class: 'temperature'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - throttle: ${bms_update_interval}
 
   - platform: template
     name: "charged"
@@ -671,9 +729,10 @@ sensor:
     unit_of_measurement: 'kWh'
     device_class: 'energy'
     state_class: 'total_increasing'
-    accuracy_decimals: 3
+    accuracy_decimals: 1
     filters:
-      - throttle: 1s
+      - round: 1
+      - throttle: ${bms_update_interval}
 
   - platform: template
     name: "discharged"
@@ -682,9 +741,10 @@ sensor:
     unit_of_measurement: 'kWh'
     device_class: 'energy'
     state_class: 'total_increasing'
-    accuracy_decimals: 3
+    accuracy_decimals: 1
     filters:
-      - throttle: 1s
+      - round: 1
+      - throttle: ${bms_update_interval}
 
   - platform: template
     id: "bms${bms_id}_operation_mode_internal"

--- a/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.02.21
-# Version : 1.1.11
+# Version : 1.2.2
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_module_minimal.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.10
+# Updated : 2026.02.21
+# Version : 1.1.11
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -166,9 +166,12 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 2
     filters:
-    - timeout:
-        timeout: 60s
-        value: !lambda return 0;
+      - timeout:
+          timeout: 60s
+          value: !lambda return 0;
+      - throttle_average: ${bms_update_interval}
+      - round: 2
+      - delta: 0.01
 
   # Current
   - platform: template
@@ -179,6 +182,10 @@ sensor:
     device_class: 'current'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 1
+      - delta: 0.1
 
   # Battery power (calculated)
   - platform: template
@@ -191,6 +198,10 @@ sensor:
     accuracy_decimals: 0
     lambda: |-
       return id(bms${bms_id}_total_voltage).state * id(bms${bms_id}_current).state;
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 0
+      - delta: 1
 
   # Charging power: Calculated from voltage and current
   - platform: template
@@ -204,6 +215,10 @@ sensor:
     lambda: |-
       if (id(bms${bms_id}_current).state > 0) return id(bms${bms_id}_total_voltage).state * id(bms${bms_id}_current).state;
       else return 0;
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 0
+      - delta: 1
 
   # Discharging power: Calculated from voltage and current
   - platform: template
@@ -217,6 +232,10 @@ sensor:
     lambda: |-
       if (id(bms${bms_id}_current).state < 0) return id(bms${bms_id}_total_voltage).state * -id(bms${bms_id}_current).state;
       else return 0;
+    filters:
+      - throttle_average: ${bms_update_interval}
+      - round: 0
+      - delta: 1
 
   # SoC
   - platform: template
@@ -227,6 +246,9 @@ sensor:
     device_class: 'battery'
     state_class: 'measurement'
     accuracy_decimals: 1
+    filters:
+      - round: 1
+      - throttle: ${bms_update_interval}
 
   # Battery capacity
   - platform: template
@@ -241,22 +263,25 @@ sensor:
       uint8_t module_count = id(deye${deye_id}_module_amount).state;
       if (module_count < 1) module_count = 1;
       return id(deye${deye_id}_battery_capacity).state / module_count;
+    filters:
+      - throttle: ${bms_update_interval}
 
-  # Remaining capacity: Calculated from capacity and SoC
+  # Remaining capacity - Calculated from SoC and battery capacity
   - platform: template
+    # name: "battery capacity remaining"
+    id: bms${bms_id}_capacity_remaining_ah
+    device_id: bms_${bms_id}
     unit_of_measurement: 'Ah'
     device_class: 'battery'
     state_class: 'measurement'
     accuracy_decimals: 0
-    id: bms${bms_id}_capacity_remaining_ah
-    device_id: bms_${bms_id}
-    # name: "battery capacity remaining"
-    lambda: |-
-      return (id(bms${bms_id}_state_of_charge).state * id(bms${bms_id}_battery_capacity).state) / 100;
     filters:
       - or:
-        - throttle: 10s
+        - throttle: ${bms_update_interval}
         - delta: 1
+      - round: 0
+    lambda: |-
+      return (id(bms${bms_id}_state_of_charge).state * id(bms${bms_id}_battery_capacity).state) / 100;
 
   # Charging cycles
   - platform: template
@@ -275,7 +300,6 @@ sensor:
     # name: "charging cycle capacity"
     id: "bms${bms_id}_cycle_capacity_raw"
     device_id: bms_${bms_id}
-    update_interval: ${bms_update_interval}
     unit_of_measurement: Ah
     state_class: 'measurement'
     accuracy_decimals: 0
@@ -296,6 +320,8 @@ sensor:
     device_class: 'current'
     state_class: 'measurement'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Max. discharge current
   - platform: template
@@ -306,6 +332,8 @@ sensor:
     device_class: 'current'
     state_class: 'measurement'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Max. cell voltage
   - platform: template
@@ -316,6 +344,10 @@ sensor:
     device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 3
+    filters:
+      - throttle_average: 20s
+      - round: 3
+      - delta: 0.0015
 
   # Max. voltage cell: Only with InterCAN enabled
   - platform: template
@@ -324,8 +356,7 @@ sensor:
     id: bms${bms_id}_max_voltage_cell
     device_id: bms_${bms_id}
     name: "cell voltage max cell number"
-    filters:
-      - lambda: return 0;
+    lambda: return 0;
 
   # Min. cell voltage
   - platform: template
@@ -339,6 +370,10 @@ sensor:
     on_value:
       then:
         - component.update: bms${bms_id}_imbalance
+    filters:
+      - throttle_average: 20s
+      - round: 3
+      - delta: 0.0015
 
   # Min. voltage cell: Only with InterCAN enabled
   - platform: template
@@ -347,8 +382,7 @@ sensor:
     id: bms${bms_id}_min_voltage_cell
     device_id: bms_${bms_id}
     name: "cell voltage min cell number"
-    filters:
-      - lambda: return 0;
+    lambda: return 0;
 
   # Min. temperature
   - platform: template
@@ -358,18 +392,26 @@ sensor:
     unit_of_measurement: '°C'
     device_class: 'temperature'
     state_class: 'measurement'
-    accuracy_decimals: 1
+    accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
+      - median:
+          window_size: 25
+          send_every: 12
+          send_first_at: 3
+      - delta: 0.5
 
   # Min. temperature sensor (fixed)
   - platform: template
     id: bms${bms_id}_min_temperature_sensor
     device_id: bms_${bms_id}
     name: "min temperature sensor"
-    update_interval: ${bms_update_interval}
     accuracy_decimals: 0
     icon: mdi:numeric
     lambda: |-
       return (1 + ${bms_id} * 100 + ${deye_module_id}1);
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Max. temperature
   - platform: template
@@ -379,22 +421,31 @@ sensor:
     unit_of_measurement: '°C'
     device_class: 'temperature'
     state_class: 'measurement'
-    accuracy_decimals: 1
-
+    accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
+      - median:
+          window_size: 25
+          send_every: 12
+          send_first_at: 3
+      - delta: 0.5
+  
   # Max. temperature sensor (fixed)
   - platform: template
     id: bms${bms_id}_max_temperature_sensor
     device_id: bms_${bms_id}
     name: "max temperature sensor"
-    update_interval: ${bms_update_interval}
     accuracy_decimals: 0
     icon: mdi:numeric
     lambda: |-
       return (1 + ${bms_id} * 100 + ${deye_module_id}1);
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Cell OVP: Unsupported
   - platform: template
     unit_of_measurement: 'V'
+    device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
     id: bms${bms_id}_cell_ovp
@@ -406,6 +457,7 @@ sensor:
   # Cell UVP: Unsupported
   - platform: template
     unit_of_measurement: 'V'
+    device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
     id: bms${bms_id}_cell_uvp
@@ -417,6 +469,7 @@ sensor:
   # Cell balance trigger voltage: Unsupported
   - platform: template
     unit_of_measurement: 'V'
+    device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
     id: bms${bms_id}_bms_balance_trigger_voltage
@@ -445,6 +498,8 @@ sensor:
     accuracy_decimals: 0
     lambda: |-
       return ((id(bms${bms_id}_max_cell_voltage).state - id(bms${bms_id}_min_cell_voltage).state)) * 1000;
+    filters:
+      - throttle_average: ${bms_update_interval}
 
   - platform: template
     name: "charged"
@@ -453,9 +508,10 @@ sensor:
     unit_of_measurement: 'kWh'
     device_class: 'energy'
     state_class: 'total_increasing'
-    accuracy_decimals: 3
+    accuracy_decimals: 1
     filters:
-      - throttle: 1s
+      - round: 1
+      - throttle: ${bms_update_interval}
 
   - platform: template
     name: "discharged"
@@ -464,9 +520,10 @@ sensor:
     unit_of_measurement: 'kWh'
     device_class: 'energy'
     state_class: 'total_increasing'
-    accuracy_decimals: 3
+    accuracy_decimals: 1
     filters:
-      - throttle: 1s
+      - round: 1
+      - throttle: ${bms_update_interval}
 
 text_sensor:
   - platform: template

--- a/packages/bms/bms_sensors_DEYE_CAN_top_full.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_top_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.5
+# Updated : 2026.02.21
+# Version : 1.1.6
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -384,6 +384,9 @@ sensor:
     device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
+    filters:
+      - round: 2
+      - throttle: ${bms_update_interval}
 
   # Discharge voltage
   - platform: template
@@ -394,6 +397,9 @@ sensor:
     device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
+    filters:
+      - round: 2
+      - throttle: ${bms_update_interval}
 
   # Maximum charging current
   - platform: template
@@ -405,6 +411,7 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 0
     filters:
+      - round: 0
       - or:
         - throttle: 30s
         - delta: 10
@@ -419,10 +426,10 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 0
     filters:
+      - round: 0
       - or:
         - throttle: 30s
         - delta: 10
-
 
   # SOC
   - platform: template
@@ -433,6 +440,8 @@ sensor:
     id: deye${deye_id}_state_of_charge
     device_id: deye_${deye_id}
     name: "battery SoC"
+    filters:
+      - throttle: ${bms_update_interval}
 
   # SOH
   - platform: template
@@ -443,6 +452,8 @@ sensor:
     device_class: 'battery'
     state_class: 'measurement'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Errors bitmask
   - platform: template
@@ -461,6 +472,8 @@ sensor:
     id: deye${deye_id}_total_voltage
     device_id: deye_${deye_id}
     name: "battery voltage"
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Battery current
   - platform: template
@@ -471,6 +484,12 @@ sensor:
     id: deye${deye_id}_current
     device_id: deye_${deye_id}
     name: "battery current"
+    filters:
+      - round: 2
+      - throttle: ${bms_update_interval}
+      - sliding_window_moving_average:
+          window_size: 8
+          send_every: 4
 
   # Battery temperature
   - platform: template
@@ -481,6 +500,13 @@ sensor:
     id: deye${deye_id}_temperature_sensor_1
     device_id: deye_${deye_id}
     name: "temperature"
+    filters:
+      - throttle: ${bms_update_interval}
+      - median:
+          window_size: 25
+          send_every: 12
+          send_first_at: 3
+      - delta: 0.5
 
   # Array charge current limit
   - platform: template
@@ -519,6 +545,10 @@ sensor:
     id: deye${deye_id}_min_cell_voltage
     device_id: deye_${deye_id}
     name: "cell voltage min"
+    filters:
+      - throttle_average: 20s
+      - round: 3
+      - delta: 0.0015
 
   # Max. cell voltage
   - platform: template
@@ -529,26 +559,42 @@ sensor:
     id: deye${deye_id}_max_cell_voltage
     device_id: deye_${deye_id}
     name: "cell voltage max"
+    filters:
+      - throttle_average: 20s
+      - round: 3
+      - delta: 0.0015
 
   # Min. temperature
   - platform: template
     id: deye${deye_id}_min_temperature
     device_id: deye_${deye_id}
     name: "min temperature"
-    update_interval: ${bms_update_interval}
-    accuracy_decimals: 1
+    accuracy_decimals: 0
     unit_of_measurement: °C
     device_class: temperature
-
+    filters:
+      - throttle: ${bms_update_interval}
+      - median:
+          window_size: 25
+          send_every: 12
+          send_first_at: 3
+      - delta: 0.5
+  
   # Max. temperature
   - platform: template
     id: deye${deye_id}_max_temperature
     device_id: deye_${deye_id}
     name: "max temperature"
-    update_interval: ${bms_update_interval}
-    accuracy_decimals: 1
+    accuracy_decimals: 0
     unit_of_measurement: °C
     device_class: temperature
+    filters:
+      - throttle: ${bms_update_interval}
+      - median:
+          window_size: 25
+          send_every: 12
+          send_first_at: 3
+      - delta: 0.5
 
   # Modules in normal state
   - platform: template
@@ -599,6 +645,8 @@ sensor:
     device_class: 'energy'
     state_class: 'total_increasing'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
 
 text_sensor:
   # Cell manufacturer

--- a/packages/bms/bms_sensors_DEYE_CAN_top_minimal.yaml
+++ b/packages/bms/bms_sensors_DEYE_CAN_top_minimal.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.12.22
-# Version : 1.1.5
+# Updated : 2026.02.23
+# Version : 1.1.6
 # GitHub  : https://github.com/GHswitt/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -16,6 +16,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+esphome:
+  # sub device
+  devices:
+    - id: deye_${deye_id}
+      name: "${deye_name}"
 
 globals:
   - id: deye${deye_id}_send_flag
@@ -90,6 +96,9 @@ sensor:
     device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
+    filters:
+      - round: 2
+      - throttle: ${bms_update_interval}
 
   # Discharge voltage
   - platform: template
@@ -100,6 +109,9 @@ sensor:
     device_class: 'voltage'
     state_class: 'measurement'
     accuracy_decimals: 2
+    filters:
+      - round: 2
+      - throttle: ${bms_update_interval}
 
   # Maximum charging current
   - platform: template
@@ -111,6 +123,7 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 0
     filters:
+      - round: 0
       - or:
         - throttle: 30s
         - delta: 10
@@ -125,10 +138,10 @@ sensor:
     state_class: 'measurement'
     accuracy_decimals: 0
     filters:
+      - round: 0
       - or:
         - throttle: 30s
         - delta: 10
-
 
   # SOC
   - platform: template
@@ -139,6 +152,8 @@ sensor:
     id: deye${deye_id}_state_of_charge
     device_id: deye_${deye_id}
     name: "battery SoC"
+    filters:
+      - throttle: ${bms_update_interval}
 
   # SOH
   - platform: template
@@ -149,6 +164,8 @@ sensor:
     device_class: 'battery'
     state_class: 'measurement'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}
 
   # Errors bitmask
   - platform: template
@@ -207,3 +224,5 @@ sensor:
     device_class: 'energy'
     state_class: 'total_increasing'
     accuracy_decimals: 0
+    filters:
+      - throttle: ${bms_update_interval}

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.03.15
-# Version : 1.1.12
+# Version : 1.2.3
 # GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_JK-B_standard.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.1.11
+# Updated : 2026.03.15
+# Version : 1.1.12
 # GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -191,6 +191,8 @@ sensor:
     battery_total_runtime:
       device_id: bms_${bms_id}
       name: "battery total runtime"
+      filters:
+        - throttle: 60s
     balancing_current:
       device_id: bms_${bms_id}
       name: "balancing current"

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_bms_full.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_bms_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.3.5
+# Updated : 2026.03.15
+# Version : 1.3.6
 # GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -457,6 +457,8 @@ sensor:
     battery_total_runtime:
       device_id: bms_${bms_id}
       name: "battery total runtime"
+      filters:
+        - throttle: 60s
     balancing_current:
       device_id: bms_${bms_id}
       name: "balancing current"

--- a/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
+++ b/packages/bms/bms_sensors_JK_RS485_Modbus_bms_standard.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.3.6
+# Updated : 2026.03.15
+# Version : 1.3.7
 # GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -223,6 +223,8 @@ sensor:
     battery_total_runtime:
       device_id: bms_${bms_id}
       name: "battery total runtime"
+      filters:
+        - throttle: 60s
     balancing_current:
       device_id: bms_${bms_id}
       name: "balancing current"

--- a/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
+++ b/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.05
-# Version : 1.3.5
+# Updated : 2026.03.15
+# Version : 1.3.6
 # GitHub  : https://github.com/syssi/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -407,6 +407,8 @@ sensor:
       device_id: bms_${bms_id}
       name: "total runtime"
       entity_category: diagnostic
+      filters:
+        - throttle: 60s
     # start_current_calibration:
     #   name: "start current calibration"
     actual_battery_capacity:


### PR DESCRIPTION
Deye sensors were updated with each CAN message. Add throttle filter using ${bms_update_interval}.
See also https://github.com/Sleeper85/esphome-yambms/pull/231

I found my HA database did really grow in the last time from ~800MB to ~3GB. I checked the state database and found these are the top sensors (from 100s) that are creating the most entries:

<img width="1164" height="856" alt="image" src="https://github.com/user-attachments/assets/6daa7a2f-b54b-4bb7-aea4-b5ff91539bf2" />

This PR:
- Filters to the Deye sensors to keep the update rate at or above `${bms_update_interval}`
- Improves some Basen filters
- Adds filters for some NEEY balancer sensors
- Adds a filter for the `total runtime` (in seconds) sensor for JK-BMS