### PR TITLE
Value checks

### DIFF
--- a/packages/yambms/yambms_auto_float.yaml
+++ b/packages/yambms/yambms_auto_float.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.30
-# Version : 1.1.4
+# Updated : 2026.02.22
+# Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -88,12 +88,12 @@ sensor:
     lambda: |-
       // Variables
       const auto mode = id(${yambms_id}_auto_float_mode).active_index();        // Mode: 0 - Disabled, 1 - Follow, 2 - Immediately
-      const double bulk_v = id(${yambms_id}_bulk_voltage).state;                // Bulk voltage
-      const double target_float_v = id(${yambms_id}_float_voltage).state;       // Target float voltage
-      const double step_v = id(${yambms_id}_auto_float_step_v).state;           // Voltage step for each decrement
-      const double max_total_v = id(${yambms_id}_auto_float_total_v).state;     // Total voltage (mean and max)
+      const float  bulk_v = id(${yambms_id}_bulk_voltage).state;                // Bulk voltage
+      const float  target_float_v = id(${yambms_id}_float_voltage).state;       // Target float voltage
+      const float  step_v = id(${yambms_id}_auto_float_step_v).state;           // Voltage step for each decrement
+      const float  max_total_v = id(${yambms_id}_auto_float_total_v).state;     // Total voltage (mean and max)
       const auto update_interval = id(${yambms_id}_auto_float_interval).state;  // Update interval in minutes
-      static double float_v = bulk_v;                                           // Initialize float voltage
+      static float  float_v = bulk_v;                                           // Initialize float voltage
       static uint8_t time_count = 0;                                            // Interval counter
       bool decrement = false;
       
@@ -108,7 +108,7 @@ sensor:
       else if (id(${yambms_id}_var_charge_status) == "Float")
       {
         // Check update interval
-        if (++time_count >= update_interval)
+        if (++time_count >= (uint8_t)update_interval)
         {
           // Follow mode : Wait for battery to drop below current float voltage
           if (mode == 1)
@@ -132,7 +132,6 @@ sensor:
       else
       {
         // Reset values
-        id(${yambms_id}_var_auto_float) = 0;
         float_v = bulk_v;
         time_count = 0;
       }

--- a/packages/yambms/yambms_auto_temp_ccl_dcl.yaml
+++ b/packages/yambms/yambms_auto_temp_ccl_dcl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.09
-# Version : 1.1.5
+# Updated : 2026.02.22
+# Version : 1.1.6
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -81,7 +81,7 @@ interval:
             float batt_capacity = id(${yambms_id}_battery_capacity).state;
 
             // Exit if critical data is missing
-            if (isnan(raw_min) || isnan(raw_max) || isnan(batt_capacity)) {
+            if (isnan(raw_min) || isnan(raw_max) || isnan(batt_capacity) || batt_capacity <= 0.0f) {
               output_id = 0.0f;
               id(${yambms_id}_var_charge_current_step)++;
               ESP_LOGD("yambms_debug", "Auto Temp. CCL : Critical data is missing => Exit");
@@ -160,7 +160,7 @@ interval:
             float batt_capacity = id(${yambms_id}_battery_capacity).state;
 
             // Exit if critical data is missing
-            if (isnan(raw_min) || isnan(raw_max) || isnan(batt_capacity)) {
+            if (isnan(raw_min) || isnan(raw_max) || isnan(batt_capacity) || batt_capacity <= 0.0f) {
               output_id = 0.0f;
               id(${yambms_id}_var_discharge_current_step)++;
               ESP_LOGD("yambms_debug", "Auto Temp. DCL : Critical data is missing => Exit");

--- a/packages/yambms/yambms_canbus.yaml
+++ b/packages/yambms/yambms_canbus.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.16
-# Version : 2.5.3
+# Updated : 2026.02.22
+# Version : 2.5.4
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -216,7 +216,7 @@ interval:
                 int index = id(canbus${canbus_id}_can_frame_index);
 
                 // PYLON 1.2 / LuxPower CAN frames
-                if ((id(canbus${canbus_id}_protocol).active_index() == 1) | (id(canbus${canbus_id}_protocol).active_index() == 5))
+                if ((id(canbus${canbus_id}_protocol).active_index() == 1) || (id(canbus${canbus_id}_protocol).active_index() == 5))
                 {
                     int can_frame[] = {1, 2, 3, 4, 5, 6};
                     int max_index = 5;
@@ -289,27 +289,27 @@ interval:
                         else id(canbus${canbus_id}_auto_bms_name) = 0;  // YamBMS
 
                         // Manual BMS name selection
-                        if ((id(canbus${canbus_id}_bms_name).active_index() == 1) | (id(canbus${canbus_id}_auto_bms_name) == 1))
+                        if ((id(canbus${canbus_id}_bms_name).active_index() == 1) || (id(canbus${canbus_id}_auto_bms_name) == 1))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : PYLON");
                           return {0x50, 0x59, 0x4C, 0x4F, 0x4E, 0x20, 0x20, 0x20}; // PYLON (recognized by Deye, add SOH info)
                         }
-                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 2) | (id(canbus${canbus_id}_auto_bms_name) == 2))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 2) || (id(canbus${canbus_id}_auto_bms_name) == 2))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : GOODWE");
                           return {0x47, 0x4F, 0x4F, 0x44, 0x57, 0x45, 0x20, 0x20}; // GOODWE
                         }
-                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 3) | (id(canbus${canbus_id}_auto_bms_name) == 3))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 3) || (id(canbus${canbus_id}_auto_bms_name) == 3))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SHEnergy");
                           return {0x53, 0x48, 0x45, 0x6E, 0x65, 0x72, 0x67, 0x79}; // SHEnergy (SEPLOS, recognized by Deye)
                         }
-                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 4) | (id(canbus${canbus_id}_auto_bms_name) == 4))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 4) || (id(canbus${canbus_id}_auto_bms_name) == 4))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SMA");
                           return {0x53, 0x4D, 0x41, 0x20, 0x20, 0x20, 0x20, 0x20}; // SMA
                         }
-                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 5) | (id(canbus${canbus_id}_auto_bms_name) == 5))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 5) || (id(canbus${canbus_id}_auto_bms_name) == 5))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : BYD");
                           return {0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00}; // BYD (recognized by Deye)
@@ -317,7 +317,7 @@ interval:
                         //
                         // YamBMS = 6 = DON'T USE !
                         //
-                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 7) | (id(canbus${canbus_id}_auto_bms_name) == 7))
+                        else if ((id(canbus${canbus_id}_bms_name).active_index() == 7) || (id(canbus${canbus_id}_auto_bms_name) == 7))
                         {
                           ESP_LOGI("canbus", "send can_id: 0x35E ASCII : Deye PCS infos");
                           // Byte [00:01]    : BMS name (ASCII) [DY]
@@ -535,7 +535,7 @@ interval:
                         // Bit 6 : Discharge enable
                         if (id(${yambms_id}_discharging_instruction).state == true) can_mesg[0] |= 0x40;
                         // Bit 7 : Charge enable
-                        if ((id(${yambms_id}_charging_instruction).state == "Bulk") | (id(${yambms_id}_charging_instruction).state == "Float")) can_mesg[0] |= 0x80;
+                        if ((id(${yambms_id}_charging_instruction).state == "Bulk") || (id(${yambms_id}_charging_instruction).state == "Float")) can_mesg[0] |= 0x80;
 
                         // LuxPower
                         // Byte [02:03] : Cycle count     (1 cycle)

--- a/packages/yambms/yambms_core.yaml
+++ b/packages/yambms/yambms_core.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.19
-# Version : 1.7.0
+# Updated : 2026.02.22
+# Version : 1.7.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -430,7 +430,7 @@ interval:
               // MEAN Battery SOC (Shunt/BMS)
               if (id(${yambms_id}_var_shunt_use) == true)
                 soc = round(id(${yambms_id}_var_shunt_total_soc) / id(${yambms_id}_var_to_combine_shunt_counter));
-              else
+              else if (id(${yambms_id}_var_total_battery_capacity) > 0)
                 soc = round(id(${yambms_id}_var_total_battery_capacity_remaining) / id(${yambms_id}_var_total_battery_capacity) * 100);
 
               // SOC manipulation
@@ -1901,7 +1901,7 @@ text_sensor:
       int eb_counter = id(${yambms_id}_errors_bitmask_counter).state;
 
       // At least one BMS in alarm
-      if ((eb_counter > 0) & (eb_counter < id(${yambms_id}_var_bms_counter))) return {"Warning"};
+      if ((eb_counter > 0) && (eb_counter < id(${yambms_id}_var_bms_counter))) return {"Warning"};
       // All BMS are in alarm
       else if (errors_bitmask > 0)
       {


### PR DESCRIPTION
Three commits with some minor fixes:
- Auto float: Cleanup code, no need for `double`
- Auto CCL/DCL: Check that `batt_capacity` is > 0 (startup/resets etc.)
- Core: Check variable to avoid division by zero
- Canbus: Replaced | with || in if clause