### PR TITLE
Auto CCL/DCL: Add division by zero/isnan checks

### DIFF
--- a/packages/yambms/yambms_auto_ccl.yaml
+++ b/packages/yambms/yambms_auto_ccl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.11
-# Version : 1.3.0
+# Updated : 2026.02.22
+# Version : 1.3.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -71,17 +71,21 @@ interval:
             // Define raw inputs
             float max_cell_v = id(${yambms_id}_max_cell_voltage).state;
             float cell_count = id(${yambms_id}_cell_count).state;
-
-            float cell_bulk_v = (id(${yambms_id}_bulk_voltage).state / cell_count);
-            float cell_float_v = (id(${yambms_id}_float_voltage).state / cell_count);
-            float cell_high_v = ((id(${yambms_id}_cell_ovp).state + cell_bulk_v) / 2.0f);
+            float cell_ovp_v = id(${yambms_id}_cell_ovp).state;
+            float bulk_v = id(${yambms_id}_bulk_voltage).state;
+            float float_v = id(${yambms_id}_float_voltage).state;
 
             // Exit if critical data is missing
-            if (isnan(max_current) || isnan(max_cell_v) || isnan(cell_count)) {
+            if (isnan(max_current) || isnan(max_cell_v) || isnan(cell_count) || 
+                isnan(cell_ovp_v) || isnan(bulk_v) || isnan(float_v) || cell_count <= 0.0f) {
               output_id = 0.0f;
               id(${yambms_id}_var_charge_current_step)++;
               return;
             }
+
+            float cell_bulk_v = (bulk_v / cell_count);
+            float cell_float_v = (float_v / cell_count);
+            float cell_high_v = ((cell_ovp_v + cell_bulk_v) / 2.0f);
           
             // Default target is 0.0 (No reduction in current)
             float delta = 0.0f;
@@ -92,9 +96,16 @@ interval:
                   delta = -max_current;
                 } else {
                   // Calculate curve
-                  float ratio = max(0.0f, (float)((max_cell_v - cell_float_v) / (cell_high_v - cell_float_v)));
-                  float curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
-                  delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
+                  float high_diff = cell_high_v - cell_float_v;
+                  if (high_diff <= 0.0f) {
+                    // Prevent division by zero or negative curve shape
+                    delta = -max_current;
+                    ESP_LOGW("yambms_auto_ccl", "Invalid config: cell_float_v (%.3fV) >= cell_high_v (%.3fV)", cell_float_v, cell_high_v);
+                  } else {
+                    float ratio = max(0.0f, (float)((max_cell_v - cell_float_v) / high_diff));
+                    float curve = pow(${charge_a_factor_curve_end}, pow(ratio, ${charge_a_factor_curve_shape}));
+                    delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
+                  }
                 }
             }
             // If switch is off, delta stays 0.0f. 

--- a/packages/yambms/yambms_auto_cvl.yaml
+++ b/packages/yambms/yambms_auto_cvl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.30
-# Version : 2.4.6
+# Updated : 2026.02.22
+# Version : 2.4.7
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -84,27 +84,38 @@ sensor:
     lambda: |-
       // Variables
 
-      double static integral = 0.0;                                             // Integral term initialization
-      double static prev_integral = 0.0;                                        // Prior Integral term initialization
-      double cell_bulk_v = (id(${yambms_id}_bulk_voltage).state / id(${yambms_id}_cell_count).state);
-      double balance_delta = id(${yambms_id}_balance_trigger_voltage).state;
-      double max_allowed_voltage = cell_bulk_v + balance_delta;
-      double max_cell_v = id(${yambms_id}_max_cell_voltage).state;
-      double max_CVL = id(${yambms_id}_bulk_voltage).state + id(${yambms_id}_auto_cvl_boost_charge_v).state;  // Maximum CVL
-      double min_CVL = id(${yambms_id}_float_voltage).state;                                                  // Minimum CVL
-      double CVL = id(${yambms_id}_bulk_voltage).state;                                                       // Starting CVL
-      double CVL_orig = id(${yambms_id}_bulk_voltage).state;                                                  // Starting CVL snapshot
+      static float integral = 0.0;                                             // Integral term initialization
+      static float prev_integral = 0.0;                                        // Prior Integral term initialization
+      float cell_count = id(${yambms_id}_cell_count).state;
+      float bulk_voltage = id(${yambms_id}_bulk_voltage).state;
+      float balance_delta = id(${yambms_id}_balance_trigger_voltage).state;
+      float max_cell_v = id(${yambms_id}_max_cell_voltage).state;
+      float min_CVL = id(${yambms_id}_float_voltage).state;                    // Minimum CVL
+      float CVL = bulk_voltage;                                                // Starting CVL
+      float CVL_orig = bulk_voltage;                                           // Starting CVL snapshot
 
-      double kp = id(${yambms_id}_auto_cvl_kp).state;                           // Proportional gain, adjust as needed
-      double ki = id(${yambms_id}_auto_cvl_ki).state;                           // Integral gain, adjust as needed
-      double dt = 1.0;                                                          // Time step, adjust based on update_interval
-      double error = 0.0;                                                       // Starting error
-      double output = 0.0;                                                      // Starting output
+      float kp = id(${yambms_id}_auto_cvl_kp).state;                           // Proportional gain, adjust as needed
+      float ki = id(${yambms_id}_auto_cvl_ki).state;                           // Integral gain, adjust as needed
+      float dt = 1.0;                                                          // Time step, adjust based on update_interval
+      float error = 0.0;                                                       // Starting error
+      float output = 0.0;                                                      // Starting output
+
+      // Check if values are available, if not return bulk voltage as CVL
+      if (isnan(cell_count) || isnan(bulk_voltage) || isnan(balance_delta) || isnan(max_cell_v) ||
+          isnan(min_CVL) || cell_count <= 0) {
+        id(${yambms_id}_var_auto_cvl) = 0.0;
+        return bulk_voltage;
+      }
+
+      float max_CVL = bulk_voltage + id(${yambms_id}_auto_cvl_boost_charge_v).state;  // Maximum CVL
+      float cell_bulk_v = (bulk_voltage / cell_count);
+      float max_allowed_voltage = cell_bulk_v + balance_delta;
 
       // Check feature enabled
       if (!id(${yambms_id}_switch_auto_cvl).state){
         id(${yambms_id}_var_auto_cvl) = 0.0;
-        return id(${yambms_id}_bulk_voltage).state;
+        prev_integral = 0.0;
+        return bulk_voltage;
       } else {
         // PI Algorithm
         error = cell_bulk_v - max_cell_v;

--- a/packages/yambms/yambms_auto_dcl.yaml
+++ b/packages/yambms/yambms_auto_dcl.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.11
-# Version : 1.3.0
+# Updated : 2026.02.22
+# Version : 1.3.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -32,9 +32,9 @@ substitutions:
   # If unsure, leave the below settings as default, this will ensure discharge current will taper correctly.
   # Factor to control the end of the discharge current curve. A setting below 2 will extend the curve, above 2 will shorten the curve.
   discharge_a_factor_curve_end: '2.0'
-  # Factor to adjust the shape of the charge current curve.
-  # A setting above 1 will reduce current at a slow rate after the float voltage is reached, then increase as a cell approaches the BMS "cell_voltage_undervoltage_protection" value.
-  # A factor below 1 will reduce current at a fast rate after the float voltage is reached, then slow as a cell approaches the BMS "cell_voltage_undervoltage_protection" value.
+  # Factor to adjust the shape of the discharge current curve.
+  # A setting above 1 will reduce current at a slow rate after the knee voltage is reached, then increase as a cell approaches the BMS "cell_voltage_undervoltage_protection" value.
+  # A factor below 1 will reduce current at a fast rate after the knee voltage is reached, then slow as a cell approaches the BMS "cell_voltage_undervoltage_protection" value.
   discharge_a_factor_curve_shape: '1.8'
   # Discharge knee voltage, the point at which a cell will reduce in voltage more rapidly. For LiFePO4 cells, this is generally considered to be 3.1v.
   discharge_knee_v: '3.1'
@@ -71,29 +71,38 @@ interval:
 
             // Define raw inputs
             float min_cell_v = id(${yambms_id}_min_cell_voltage).state;
-            float cell_low_v = id(${yambms_id}_cell_uvp).state + 0.2f;
+            float cell_uvp_v = id(${yambms_id}_cell_uvp).state;
 
             // Exit if critical data is missing
-            if (isnan(max_current) || isnan(min_cell_v) || isnan(cell_low_v)) {
+            if (isnan(max_current) || isnan(min_cell_v) || isnan(cell_uvp_v)) {
               output_id = 0.0f;
               id(${yambms_id}_var_discharge_current_step)++;
               return;
             }
           
+            float cell_low_v = cell_uvp_v + 0.2f;
+
             // Default target is 0.0 (No reduction in current)
             float delta = 0.0f;
 
             // Only calculate a reduction if the switch is on
             if (id(${yambms_id}_switch_auto_dcl).state) {
-                if (min_cell_v < cell_low_v) {
-                  delta = -max_current;
-                } else {
-                  // Calculate a curve based on the cell voltage.
-                  float ratio = max(0.0f, (float)((min_cell_v - ${discharge_knee_v}) / (cell_low_v - ${discharge_knee_v})));
-                  float curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
-                  delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
-                }
+              float knee_v = ${discharge_knee_v};
+              float low_diff = cell_low_v - knee_v;
+
+              if (min_cell_v < cell_low_v) {
+                delta = -max_current;
+              } else if (low_diff >= 0.0f) {
+                  delta = -max_current; // fallback: full cutoff, config is invalid
+                  ESP_LOGW("yambms_auto_dcl", "Invalid config: cell_low_v (%.3fV) >= discharge_knee_v (%.3fV)", cell_low_v, knee_v);
+              } else {
+                // Calculate a curve based on the cell voltage.
+                float ratio = max(0.0f, (float)((min_cell_v - knee_v) / low_diff));
+                float curve = pow(${discharge_a_factor_curve_end}, pow(ratio, ${discharge_a_factor_curve_shape}));
+                delta = max(0.0f, (-curve + 2.0f) * max_current) - max_current;
+              }
             }
+
             // If switch is off, delta stays 0.0f. 
             // Smoothly ramp from the old negative value back to 0 if required
 


### PR DESCRIPTION
@MrPabloUK Please check if this change is ok. I moved the `Exit if critical data is missing` check before the usage/division.

For the second check I'm not sure if `delta = -max_current;` is fine, the thought was if something is that wrong (cell_high_v - cell_float_v <= 0) then maybe stop charging.