### PR TITLE
Board configuration for Lilygo T-Connect Pro Lite

### DIFF
--- a/packages/bms/bms_sensors_EG4_LLV2_RS485_bms_full.yaml
+++ b/packages/bms/bms_sensors_EG4_LLV2_RS485_bms_full.yaml
@@ -361,9 +361,36 @@ text_sensor:
     model:
       device_id: bms_${bms_id}
       name: "model"
+      filters:
+      - lambda: |-
+          std::string filtered_str = "";
+          for (char c : x) {
+            if (c >= 32 && c <= 126) {
+              filtered_str += c;
+            }
+          }
+          return filtered_str;
     firmware_version:
       device_id: bms_${bms_id}
       name: "version"
+      filters:
+      - lambda: |-
+          std::string filtered_str = "";
+          for (char c : x) {
+            if (c >= 32 && c <= 126) {
+              filtered_str += c;
+            }
+          }
+          return filtered_str;
     serial_number:
       device_id: bms_${bms_id}
       name: "firmware date"
+      filters:
+      - lambda: |-
+          std::string filtered_str = "";
+          for (char c : x) {
+            if (c >= 32 && c <= 126) {
+              filtered_str += c;
+            }
+          }
+          return filtered_str;

--- a/packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro-Lite.yaml
+++ b/packages/board/board_ESP32-S3_LilyGo-T-Connect-Pro-Lite.yaml
@@ -1,0 +1,217 @@
+# Updated : 2026.01.14
+# Version : 1.1.3
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+# https://wiki.lilygo.cc/get_started/en/High_speed/T-Connect-Pro/T-Connect-Pro.html
+
+substitutions:
+  board_chip: "ESP32-S3"
+  board_name: "LilyGo T-Connect Pro"
+  # Interfaces GPIOs
+  # uart_esp_1: RS232
+  tx_pin_1: '4'
+  rx_pin_1: '5'
+  # uart_esp_2: RS485
+  tx_pin_2: '17'
+  rx_pin_2: '18'
+  # canbus_esp32_can: CAN
+  tx_pin_4: '6'
+  rx_pin_4: '7'
+
+  lilygo_led_1: '46'
+  lilygo_led_2: '3'
+  lilygo_led_3: '21'
+  lilygo_led_4: '41'
+
+  lilygo_btn_a: '39'
+  lilygo_btn_b: '40'
+
+  lilygo_rly: '8'
+
+packages:
+  device_base: !include ../base/device_base.yaml
+  device_base_ethernet: !include ../base/device_base_ethernet.yaml
+  board_rgb_led: !include board_options_rgb_leds_status.yaml
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  flash_size: 16MB # ajust according to your ESP32-S3 version
+  cpu_frequency: 240MHz
+  framework:
+    type: esp-idf
+
+esphome:
+  platformio_options:
+    board_build.flash_mode: dio             # use Dual IO (dio) instead of Quad IO (qio) to prevent boot loop after flashing
+
+#wifi:
+#  id: my_network
+#  ssid: !secret wifi_ssid
+#  password: !secret wifi_password
+#  domain: !secret domain
+#  reboot_timeout: 0s
+
+# ESPHome does not support W5500 and other SPI devices at the same SPI bus:
+# https://github.com/esphome/esphome/discussions/6720
+ethernet:
+  id: my_network
+  type: W5500
+  clk_pin: 12
+  mosi_pin: 11
+  miso_pin: 13
+  cs_pin: 10
+  interrupt_pin: 9
+  reset_pin: 48
+  clock_speed: 40MHz
+
+logger:
+  baud_rate: 0 # frees the 3rd UART and avoids some bugs like "WK2168 with canbus" or "BLE client with RS485 modbus"
+
+output:
+# ESP32 board without LED
+  - platform: template
+    id: esp_output
+    type: binary
+    write_action:
+      - lambda: |-
+          if (id(${canbus_id}_status).state == true) {
+            if(state == false) {
+              id(esp_light_2).turn_on().set_brightness(0.2).set_rgb(0.0, 0.0, 1.0).perform();
+            } else {
+              id(esp_light_2).turn_on().set_brightness(0.5).set_rgb(0.0, 0.0, 1.0).perform();
+            }
+          } else {
+            id(esp_light_2).turn_on().set_brightness(0.5).set_rgb(1.0, 0.0, 0.0).perform();
+          }
+
+light:
+
+  - platform: binary
+    id: esp_light
+    output: esp_output
+
+  # RGB LED for API Status
+  - platform: esp32_rmt_led_strip
+    id: esp_light_1
+    rgb_order: GRB
+    pin: ${lilygo_led_1}
+    num_leds: 1
+    chipset: ws2812
+    rmt_symbols: 48
+    restore_mode: ALWAYS_OFF
+    default_transition_length: 0.2s
+  # RGB LED for CAN/Inverter Status
+  - platform: esp32_rmt_led_strip
+    id: esp_light_2
+    rgb_order: GRB
+    pin: ${lilygo_led_2}
+    num_leds: 1
+    chipset: ws2812
+    rmt_symbols: 48
+    restore_mode: ALWAYS_OFF
+    default_transition_length: 0.2s
+  # RGB LED for BMS Status
+  - platform: esp32_rmt_led_strip
+    id: esp_light_3
+    rgb_order: GRB
+    pin: ${lilygo_led_3}
+    num_leds: 1
+    chipset: ws2812
+    rmt_symbols: 48
+    restore_mode: ALWAYS_OFF
+    default_transition_length: 0.2s
+  # RGB LED for SoC
+  - platform: esp32_rmt_led_strip
+    id: esp_light_4
+    rgb_order: GRB
+    pin: ${lilygo_led_4}
+    num_leds: 1
+    chipset: ws2812
+    rmt_symbols: 48
+    restore_mode: ALWAYS_OFF
+    default_transition_length: 0.2s
+
+# Relay: IO8
+switch:
+  - platform: gpio
+    name: "Relay"
+    icon: "mdi:electric-switch"
+    pin:
+      number: ${lilygo_rly}
+      inverted: true
+      mode: OUTPUT_OPEN_DRAIN
+    restore_mode: RESTORE_DEFAULT_OFF
+
+# LED 1 - API
+# - Green Connected, Red not connected
+# LED 2 - CAN
+# - Green Connected, Blue for traffic, Red not connected
+# LED 3 - BMS Status
+# - 100% batteries online = Green, 0% = Red, anythingelse = Yellow
+# LED 4 - SOC
+# - 100-75 Green, 75-50 Yellow, 50-25 Orange, 25-0 Red
+interval:    
+  - interval: 1s
+    then:
+      - lambda: |-
+          auto call = id(esp_light_1).turn_on();
+          call.set_brightness(0.5);
+          if (id(esp32_online_status).state) {
+            call.set_rgb(0.0, 1.0, 0.0); // Green #00FF00
+          } else {
+            call.set_rgb(1.0, 0.0, 0.0); // Red #FF0000
+          }
+          call.perform();
+  - interval: 1s
+    then:
+      - lambda: |-
+          if (id(${canbus_id}_status).state == false) {
+            id(esp_light_2).turn_on().set_brightness(0.5).set_rgb(1.0, 0.0, 0.0).perform();
+          }  
+  - interval: 10s
+    then:
+      - lambda: |-
+          auto call = id(esp_light_3).turn_on();
+          call.set_brightness(0.5);
+          if (id(${yambms_id}_bms_combined).state == 0) {
+            call.set_rgb(1.0, 0.0, 0.0); // Red #FF0000
+          } else if (id(${yambms_id}_bms_count).state ==id(${yambms_id}_bms_combined).state) {
+            call.set_rgb(0.0, 1.0, 0.0); // Green #00FF00
+          } else {
+            call.set_rgb(1.0, 1.0, 0.0); // Yellow #FFFF00
+          }
+          call.perform();                    
+  - interval: 5s
+    then:
+      - lambda: |-
+          if(id(${yambms_id}_var_total_installed_battery_capacity) > 0) {
+            auto call = id(esp_light_4).make_call();
+            call.set_brightness(0.5);
+            if (id(${yambms_id}_battery_soc).state >= 75) 
+              call.set_rgb(0.0, 1.0, 0.0); // Green #00FF00
+            else if (id(${yambms_id}_battery_soc).state >=50) 
+              call.set_rgb(1.0, 1.0, 0.0); // Yellow #FFFF00:q
+            else if (id(${yambms_id}_battery_soc).state >=25 ) 
+              call.set_rgb(1.0, 0.65, 0.0);  // Orange #FFA500
+            else
+              call.set_rgb(1.0, 0.0 , 0.0);  // Red #FF0000
+            call.perform();
+          } else {
+            id(esp_light_4).turn_on().set_brightness(0.5).set_rgb(0.0, 0.0 , 1.0).perform();
+          }

--- a/packages/yambms/yambms_canbus.yaml
+++ b/packages/yambms/yambms_canbus.yaml
@@ -158,7 +158,7 @@ canbus:
               uint32_t inverter_ack_interval_ms = (inverter_ack_ms_current - id(${canbus_id}_inverter_ack_ms_previous));
               id(${canbus_id}_inverter_ack_ms_previous) = inverter_ack_ms_current;
               id(${canbus_id}_inverter_heartbeat).publish_state(inverter_ack_interval_ms);
-              ESP_LOGI("canbus", "received can_id: 0x305 ack_interval %d ms", inverter_ack_interval_ms);
+              ESP_LOGD("canbus", "received can_id: 0x305 ack_interval %d ms", inverter_ack_interval_ms);
             }
 
 interval:
@@ -263,27 +263,27 @@ interval:
                         // Manual BMS name selection
                         if ((id(${canbus_id}_bms_name).active_index() == 1) | (id(${canbus_id}_auto_bms_name) == 1))
                         {
-                          ESP_LOGI("canbus", "send can_id: 0x35E ASCII : PYLON");
+                          ESP_LOGD("canbus", "send can_id: 0x35E ASCII : PYLON");
                           return {0x50, 0x59, 0x4C, 0x4F, 0x4E, 0x20, 0x20, 0x20}; // PYLON (recognized by Deye, add SOH info)
                         }
                         else if ((id(${canbus_id}_bms_name).active_index() == 2) | (id(${canbus_id}_auto_bms_name) == 2))
                         {
-                          ESP_LOGI("canbus", "send can_id: 0x35E ASCII : GOODWE");
+                          ESP_LOGD("canbus", "send can_id: 0x35E ASCII : GOODWE");
                           return {0x47, 0x4F, 0x4F, 0x44, 0x57, 0x45, 0x20, 0x20}; // GOODWE
                         }
                         else if ((id(${canbus_id}_bms_name).active_index() == 3) | (id(${canbus_id}_auto_bms_name) == 3))
                         {
-                          ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SHEnergy");
+                          ESP_LOGD("canbus", "send can_id: 0x35E ASCII : SHEnergy");
                           return {0x53, 0x48, 0x45, 0x6E, 0x65, 0x72, 0x67, 0x79}; // SHEnergy (SEPLOS, recognized by Deye)
                         }
                         else if ((id(${canbus_id}_bms_name).active_index() == 4) | (id(${canbus_id}_auto_bms_name) == 4))
                         {
-                          ESP_LOGI("canbus", "send can_id: 0x35E ASCII : SMA");
+                          ESP_LOGD("canbus", "send can_id: 0x35E ASCII : SMA");
                           return {0x53, 0x4D, 0x41, 0x20, 0x20, 0x20, 0x20, 0x20}; // SMA
                         }
                         else if ((id(${canbus_id}_bms_name).active_index() == 5) | (id(${canbus_id}_auto_bms_name) == 5))
                         {
-                          ESP_LOGI("canbus", "send can_id: 0x35E ASCII : BYD");
+                          ESP_LOGD("canbus", "send can_id: 0x35E ASCII : BYD");
                           return {0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00}; // BYD (recognized by Deye)
                         }
                         //
@@ -291,7 +291,7 @@ interval:
                         //
                         else if ((id(${canbus_id}_bms_name).active_index() == 7) | (id(${canbus_id}_auto_bms_name) == 7))
                         {
-                          ESP_LOGI("canbus", "send can_id: 0x35E ASCII : Deye PCS infos");
+                          ESP_LOGD("canbus", "send can_id: 0x35E ASCII : Deye PCS infos");
                           // Byte [00:01]    : BMS name (ASCII) [DY]
                           // Byte [02:03:04] : Battery pack number (ASCII) [001]
                           // Byte [05]       : Battery manufacturer [1:GOTION 96Ah, 2:CATL 100Ah, 3:EVE 100Ah, 4:PH 100Ah, 5:EVE 120Ah, 6:PH 100Ah(214R), 7:ZENERGY 104Ah]
@@ -301,7 +301,7 @@ interval:
                         }
                         else
                         {
-                          ESP_LOGI("canbus", "send can_id: 0x35E ASCII : YamBMS"); // Auto BMS name 0
+                          ESP_LOGD("canbus", "send can_id: 0x35E ASCII : YamBMS"); // Auto BMS name 0
                           return {0x59, 0x61, 0x6D, 0x42, 0x4D, 0x53, 0x00, 0x00}; // YamBMS
                         }
 
@@ -329,7 +329,7 @@ interval:
                         can_mesg[6] = uint16_t(id(${yambms_id}_requested_discharge_voltage).state * 10) & 0xff;
                         can_mesg[7] = uint16_t(id(${yambms_id}_requested_discharge_voltage).state * 10) >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x351 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x351 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x355 - Actual State of Charge (SOC), State of Health (SOH), Remaining total capacity
@@ -369,7 +369,7 @@ interval:
                           can_mesg[7] = min_cell_voltage_i >> 8 & 0xff;
                         }
 
-                        ESP_LOGI("canbus", "send can_id: 0x355 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x355 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x356 - Actual Voltage / Current / Temperature / Cycles (Deye 0x305 ACK)
@@ -409,7 +409,7 @@ interval:
                           can_mesg[7] = int16_t(id(${yambms_id}_min_temperature).state * 10) >> 8 & 0xff;
                         }
 
-                        ESP_LOGI("canbus", "send can_id: 0x356 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x356 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x359 - Protection Alarms, Warning and Flags ( PYLON / PYLON V2 )
@@ -479,7 +479,7 @@ interval:
                           can_mesg[6] = uint16_t(id(${yambms_id}_battery_capacity).state) >> 8 & 0xff;
                         }
 
-                        ESP_LOGI("canbus", "send can_id: 0x359 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x359 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x35C - Request flag to Enable/Disable: Charge, Discharge ( PYLON / PYLON V2 )
@@ -516,7 +516,7 @@ interval:
                           can_mesg[3] = uint16_t(id(${yambms_id}_charging_cycles).state) >> 8 & 0xff;
                         }
 
-                        ESP_LOGI("canbus", "send can_id: 0x35C hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x35C hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x35A - Protection Alarms and Warning ( SMA / Victron / PYLON V2 )
@@ -578,7 +578,7 @@ interval:
                           if (errors_bitmask_warning & 0x1000) can_mesg[7] |= 0x0001;    // Cell imbalance warning
                         }
 
-                        ESP_LOGI("canbus", "send can_id: 0x35A hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x35A hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x35F - Battery information ( SMA, Victron )
@@ -601,7 +601,7 @@ interval:
                         can_mesg[4] = uint16_t(id(${yambms_id}_battery_capacity_remaining).state) & 0xff;
                         can_mesg[5] = uint16_t(id(${yambms_id}_battery_capacity_remaining).state) >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x35F hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x35F hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x70  - Actual Max Cell Temp, Min Cell Temp, Max Cell V, Min Cell V ( SEPLOS V1.0 )
@@ -632,7 +632,7 @@ interval:
                         can_mesg[6] = min_cell_voltage_i & 0xff;
                         can_mesg[7] = min_cell_voltage_i >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x70 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x70 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x371 - Actual Max Cell Temp ID, Min Cell Temp ID, Max Cell V ID, Min Cell ID ( SEPLOS V1.0 )
@@ -659,7 +659,7 @@ interval:
                         can_mesg[6] = uint16_t(id(${yambms_id}_min_voltage_cell).state) & 0xff;
                         can_mesg[7] = uint16_t(id(${yambms_id}_min_voltage_cell).state) >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x371 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x371 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x372 - Battery modules information ( Victron / PYLON V2 )
@@ -681,7 +681,7 @@ interval:
                         can_mesg[4] = id(${yambms_id}_bms_blocking_discharge).state;
                         can_mesg[6] = (id(${yambms_id}_bms_count).state - id(${yambms_id}_bms_combined).state);
 
-                        ESP_LOGI("canbus", "send can_id: 0x372 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x372 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x373 - Actual Min Cell V, Max Cell V, Min Cell Temp (Kelvin), Max Cell Temp (Kelvin) ( Victron / PYLON V2 )
@@ -712,7 +712,7 @@ interval:
                         can_mesg[6] = max_temp_kelvin & 0xff;
                         can_mesg[7] = max_temp_kelvin >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x373 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x373 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x374 - Min cell voltage ID [ASCII] ( Victron / PYLON V2 )
@@ -729,8 +729,8 @@ interval:
                         // save int cell_id to 8 bytes char array
                         snprintf(can_mesg, 8, "%d", cell_id);
 
-                        ESP_LOGI("canbus", "send can_id: 0x374 [ASCII] Min cell voltage ID : %d", cell_id);
-                        ESP_LOGI("canbus", "send can_id: 0x374 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x374 [ASCII] Min cell voltage ID : %d", cell_id);
+                        ESP_LOGD("canbus", "send can_id: 0x374 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x375 - Max cell voltage ID [ASCII] ( Victron / PYLON V2 )
@@ -747,8 +747,8 @@ interval:
                         // save int cell_id to 8 bytes char array
                         snprintf(can_mesg, 8, "%d", cell_id);
 
-                        ESP_LOGI("canbus", "send can_id: 0x375 [ASCII] Max cell voltage ID : %d", cell_id);
-                        ESP_LOGI("canbus", "send can_id: 0x375 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x375 [ASCII] Max cell voltage ID : %d", cell_id);
+                        ESP_LOGD("canbus", "send can_id: 0x375 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x376 - Min cell temperature ID [ASCII] ( Victron / PYLON V2 )
@@ -765,8 +765,8 @@ interval:
                         // save int sensor_id to 8 bytes char array
                         snprintf(can_mesg, 8, "%d", sensor_id);
 
-                        ESP_LOGI("canbus", "send can_id: 0x376 [ASCII] Min temperature sensor ID : %d", sensor_id);
-                        ESP_LOGI("canbus", "send can_id: 0x376 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x376 [ASCII] Min temperature sensor ID : %d", sensor_id);
+                        ESP_LOGD("canbus", "send can_id: 0x376 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x377 - Max cell temperature ID [ASCII] ( Victron / PYLON V2 )
@@ -783,8 +783,8 @@ interval:
                         // save int sensor_id to 8 bytes char array
                         snprintf(can_mesg, 8, "%d", sensor_id);
 
-                        ESP_LOGI("canbus", "send can_id: 0x377 [ASCII] Max temperature sensor ID : %d", sensor_id);
-                        ESP_LOGI("canbus", "send can_id: 0x377 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x377 [ASCII] Max temperature sensor ID : %d", sensor_id);
+                        ESP_LOGD("canbus", "send can_id: 0x377 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x379 - Battery Installed Capacity Ah for Victron, Sol-Ark, LuxPower ( Victron / PYLON V2 )
@@ -799,7 +799,7 @@ interval:
                         can_mesg[0] = uint16_t(id(${yambms_id}_installed_battery_capacity).state) & 0xff;
                         can_mesg[1] = uint16_t(id(${yambms_id}_installed_battery_capacity).state) >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x379 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x379 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x382 - Product identification [ASCII] ( Victron )
@@ -810,7 +810,7 @@ interval:
                       canbus_id: ${canbus_node_id}
                       can_id: 0x382
                       data: !lambda |-
-                        ESP_LOGI("canbus", "send can_id: 0x382 [ASCII] Product : YamBMS");
+                        ESP_LOGD("canbus", "send can_id: 0x382 [ASCII] Product : YamBMS");
                         return {0x59, 0x61, 0x6D, 0x42, 0x4D, 0x53, 0x00, 0x00}; // YamBMS
 
             - if: # 0x360 - Force charge instruction ( Victron )
@@ -826,7 +826,7 @@ interval:
                         // Byte 0 : Force charge instruction
                         if (id(${yambms_id}_requested_force_charge).state) can_mesg[0] = 0xFF;
 
-                        ESP_LOGI("canbus", "send can_id: 0x360 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x360 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x359 - Protection and System errors ( Deye PCS )
@@ -837,7 +837,7 @@ interval:
                       canbus_id: ${canbus_node_id}
                       can_id: 0x359
                       data: !lambda |-
-                        ESP_LOGI("canbus", "send can_id: 0x359 : Protection and System errors (not yet implemented)");
+                        ESP_LOGD("canbus", "send can_id: 0x359 : Protection and System errors (not yet implemented)");
                         return {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
             - if: # 0x361 - Actual Max Cell Temp, Min Cell Temp, Max Cell V, Min Cell V ( Deye PCS )
@@ -867,7 +867,7 @@ interval:
                         can_mesg[6] = int16_t(id(${yambms_id}_min_temperature).state * 10) & 0xff;
                         can_mesg[7] = int16_t(id(${yambms_id}_min_temperature).state * 10) >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x361 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x361 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x363 - Software and Hardware version ( Deye PCS )
@@ -880,7 +880,7 @@ interval:
                       data: !lambda |-
                         // Byte [00:01] : Software version
                         // Byte [02:03] : Hardware version
-                        ESP_LOGI("canbus", "send can_id: 0x363 : Software and Hardware version");
+                        ESP_LOGD("canbus", "send can_id: 0x363 : Software and Hardware version");
                         // Deye BAT SE-G5.1 Pro-B (EVE 100Ah) reply :
                         return {0x20, 0x08, 0x21, 0x02, 0x00, 0x00, 0x00, 0x00}; // Deye PCS
 
@@ -905,7 +905,7 @@ interval:
                         can_mesg[3] = (id(${yambms_id}_bms_count).state - id(${yambms_id}_bms_combined).state);
                         can_mesg[4] = id(${yambms_id}_bms_count).state;
 
-                        ESP_LOGI("canbus", "send can_id: 0x364 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x364 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
             - if: # 0x371 - BMS instruction : [ON-GRID] Charge Amps, Discharge Amps ( Deye PCS )
@@ -926,5 +926,5 @@ interval:
                         can_mesg[2] = uint16_t(id(${yambms_id}_requested_discharge_current).state * 10) & 0xff;
                         can_mesg[3] = uint16_t(id(${yambms_id}_requested_discharge_current).state * 10) >> 8 & 0xff;
 
-                        ESP_LOGI("canbus", "send can_id: 0x371 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
+                        ESP_LOGD("canbus", "send can_id: 0x371 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};

--- a/packages/yambms/yambms_core.yaml
+++ b/packages/yambms/yambms_core.yaml
@@ -666,7 +666,7 @@ text_sensor:
             // that these are not random/erroneous/false readings of the BMS
             if (cutoff_counter > 4)
             {
-              ESP_LOGI("yambms", "Entering the Cut-Off phase...");
+              ESP_LOGD("yambms", "Entering the Cut-Off phase...");
 
               // Cut-Off : the end of charging is near
               id(${yambms_id}_charge_status) = "Cut-Off";
@@ -723,7 +723,7 @@ text_sensor:
       // Charging not allowed (BMS or YamBMS)
       else if (id(${yambms_id}_bms_charging_logic) == false) id(${yambms_id}_charge_status) = "Wait";
 
-      ESP_LOGI("yambms", "Charge Status : %s", id(${yambms_id}_charge_status).c_str());
+      ESP_LOGD("yambms", "Charge Status : %s", id(${yambms_id}_charge_status).c_str());
       return id(${yambms_id}_charge_status);
 
   # +--------------------------------------+


### PR DESCRIPTION
Created a board file for Lilygo T-Connect Pro Lite board - Basically same as T-Connect Pro but without the screen.

Couple of things I added:

- Added Ethernet support since don't need SPI for screen
- Added configuration for the 4 LEDs to monitor API/CAN/BMS/SoC
- Defined the GPIOs but the two buttons but haven't figured out what to do with them yet.

Running this with my eg4 batteries and Sol-Ark inverter. 