### PR TITLE
Auto EOC: Factor in Auto SoC Limit for battery capacity calculation

### DIFF
--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -182,11 +182,13 @@ The text sensor `Auto EOC Status` will show the current status of the function:
 - `Stop: Current above limit`: The required charge current is above the current charge limit.
 - `Run: Current increase stopped`: Running, but no current increase because of `Auto EOC Increase Stop Hours` or `Auto EOC Increase Stop SoC`.
 - `Run`: Working normally.
+- `Run: Auto SoC Limit xx%`: Enabled, but reduced the target capacity by the value selected for `Auto SoC Limit`.
 
 The sensor `Auto EOC Current` will show the calculated charging current. Note that it is filtered by an EWMA filter with a default 3 minute delay.
 That means that changes to the options or parameters are not immediately visible. This avoids that the `Requested Charge Current (CCL)` will fluctuate too much. It will show 0A when the function is disabled/stopped or there is no solution.
 
-The function used to calculate the required charging current is very basic. The missing battery capacity (difference between `Battery Capacity` and `Capacity Remaining`) divided by the remaining hours. It will be updated every minute, but afterwards filtered before it is used for `Requested Charge Current (CCL)`. That means it will adapt, but not take into account any special circumstances. For example if `Auto CCL` is enabled and required, the charge current may further be limited by `Auto CCL`. The target time may then not be reached exactly. To account for this, the parameter `Auto EOC Correction` can be used to increase the overall current a little to compensate for the lower end current.
+The function used to calculate the required charging current is very basic. The missing battery capacity (difference between `Battery Capacity` and `Capacity Remaining`) divided by the remaining hours. If `Auto SoC Limit` is active,
+the configured limit value will be used to calculate the target capacity. It will be updated every minute, but afterwards filtered before it is used for `Requested Charge Current (CCL)`. That means it will adapt, but not take into account any special circumstances. For example if `Auto CCL` is enabled and required, the charge current may further be limited by `Auto CCL`. The target time may then not be reached exactly. To account for this, the parameter `Auto EOC Correction` can be used to increase the overall current a little to compensate for the lower end current.
 
 Here is an example when the target time is set to 18:00. Starting at 00:00, the required current increases as the battery is discharged. When the battery starts charging as the sun is up, the required current stabilizes around 14A.
 The current is increased at the end as it does not exactly hit its required charge, but at 17:30, the required current is stable because the parameter `Auto EOC Increase Stop Hours` was set to 0.5 hours, so it will not be increased anymore.

--- a/packages/yambms/yambms_auto_eoc.yaml
+++ b/packages/yambms/yambms_auto_eoc.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.02.22
-# Version : 1.1.7
+# Updated : 2026.03.13
+# Version : 1.1.8
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -235,6 +235,20 @@ interval:
           // Apply negative capacity modifier
           battery_capacity += (battery_capacity * (id(${yambms_id}_auto_eoc_modifier).state / 100.0));
         
+          // Check if Auto SoC Limit is active
+          int auto_soc_limit = 0;
+          if (id(${yambms_id}_switch_auto_soc_limit).state && 
+              id(${yambms_id}_auto_soc_limit_status).has_state()) {
+            // Check status, if Run, remove Auto SoC limit difference from battery capacity
+            if (id(${yambms_id}_auto_soc_limit_status).state.starts_with("Run")) {
+              auto_soc_limit = id(${yambms_id}_auto_soc_limit).state;
+              battery_capacity = (battery_capacity * auto_soc_limit) / 100.0;
+              ESP_LOGD("yambms_auto_eoc", "Auto SoC Limit is active, adjusted battery capacity");
+            } else {
+              ESP_LOGD("yambms_auto_eoc", "Auto SoC Limit is active but not running, not adjusting battery capacity");
+            }
+          }
+
           // Calculate missing capacity
           auto capacity_required = battery_capacity - id(${yambms_id}_battery_capacity_remaining).state;
           if (capacity_required < 0) {
@@ -276,6 +290,9 @@ interval:
                 // Return previous filtered charge current
                 return_value = filtered_charge_current;
                 id(${yambms_id}_auto_eoc_status).publish_state("Run: Current increase stopped");
+              } else if (auto_soc_limit) {
+                // Update status to running with Auto SoC Limit
+                id(${yambms_id}_auto_eoc_status).publish_state("Run: Auto SoC Limit " + std::to_string(auto_soc_limit) + "%");
               } else {
                 // Update status to running
                 id(${yambms_id}_auto_eoc_status).publish_state("Run");


### PR DESCRIPTION
With this commit, `Auto EOC` will consider the limit set by `Auto SoC Limit`. That means it will not calculate the required current for a 100% charge, but for a `SoC` configured from `Auto SoC Limit`.

This will be visible in the `Auto EOC Status`.