### PR TITLE
Tab5: ESPHome 2026.6 / LVGL 9.x compatibility

### DIFF
--- a/packages/board/board_ESP32-P4_M5Stack-Tab5.yaml
+++ b/packages/board/board_ESP32-P4_M5Stack-Tab5.yaml
@@ -328,17 +328,18 @@ touchscreen:
     id: my_touchscreen
     interrupt_pin: 23
     update_interval: never
-    transform:
-      swap_xy: true
-      mirror_y: true
+    # No transform here: rotation is handled in the lvgl: config (rotation: 90),
+    # and ESPHome 2026.6 LVGL auto-transforms touch coords via rotate_coordinates().
+    # Adding swap_xy/mirror here would double-rotate. Calibration is in panel-native
+    # (unrotated) orientation: x over 0..720 (width), y over 0..1280 (height).
     reset_pin:
       pi4ioe5v6408: pi4ioe1
       number: 5
     calibration:
-      y_min: 0
-      y_max: 720
       x_min: 0
-      x_max: 1280
+      x_max: 720
+      y_min: 0
+      y_max: 1280
 
 # +--------------------------------------+
 # | Display (MIPI DSI 1280x720)          |
@@ -347,7 +348,8 @@ touchscreen:
 display:
   - platform: mipi_dsi
     id: my_display
-    rotation: 90
+    # rotation is set in the lvgl: config, not here — ESPHome 2026.6+ rejects
+    # 'rotation' under display when LVGL is used.
     dimensions:
       height: 1280
       width: 720

--- a/packages/board/board_options_display_lvgl_1280x720_Tab5.yaml
+++ b/packages/board/board_options_display_lvgl_1280x720_Tab5.yaml
@@ -402,8 +402,6 @@ lvgl:
                       - range_from: -400
                         range_to: 400
                         angle_range: 180
-                        ticks:
-                          count: 0
                         indicators:
                           - line:
                               id: current_needle
@@ -464,8 +462,6 @@ lvgl:
                       - range_from: -24
                         range_to: 24
                         angle_range: 180
-                        ticks:
-                          count: 0
                         indicators:
                           - line:
                               id: power_needle

--- a/packages/board/board_options_display_lvgl_1280x720_Tab5.yaml
+++ b/packages/board/board_options_display_lvgl_1280x720_Tab5.yaml
@@ -94,6 +94,10 @@ font:
 # +--------------------------------------+
 
 lvgl:
+  # Rotation lives here (not under display:) — required by ESPHome 2026.6+ with LVGL.
+  # mipi_dsi has no hardware rotation, so LVGL rotates in software (PPA-accelerated on
+  # P4) and auto-transforms touch coords. The gt911 therefore has NO transform block.
+  rotation: 90
   byte_order: little_endian
   color_depth: 16
   buffer_size: 100%

--- a/packages/board/board_options_display_lvgl_1280x720_Tab5.yaml
+++ b/packages/board/board_options_display_lvgl_1280x720_Tab5.yaml
@@ -410,18 +410,16 @@ lvgl:
                           - line:
                               id: current_needle
                               width: 5
-                              r_mod: 25
+                              length: -25
                               value: 0
                               color: 0xFFFFFF
                           - arc:
                               color: 0xFF3000
-                              r_mod: 10
                               width: 40
                               start_value: -400
                               end_value: 0
                           - arc:
                               color: 0x00FF00
-                              r_mod: 10
                               width: 40
                               start_value: 0
                               end_value: 400
@@ -470,18 +468,16 @@ lvgl:
                           - line:
                               id: power_needle
                               width: 5
-                              r_mod: 25
+                              length: -25
                               value: 0
                               color: 0xFFFFFF
                           - arc:
                               color: 0xFF3000
-                              r_mod: 10
                               width: 40
                               start_value: -24
                               end_value: 0
                           - arc:
                               color: 0x00FF00
-                              r_mod: 10
                               width: 40
                               start_value: 0
                               end_value: 24

--- a/packages/board/board_options_display_lvgl_1280x720_Tab5_esphome_sensors.yaml
+++ b/packages/board/board_options_display_lvgl_1280x720_Tab5_esphome_sensors.yaml
@@ -79,7 +79,8 @@ interval:
           // Update current gauge and text
           float current = id(${yambms_id}_current).state;
           if (!isnan(current)) {
-            lv_meter_set_indicator_value(id(current_meter), id(current_needle), (int32_t)current);
+            // LVGL 9.4 removed lv_meter; the needle is now an ESPHome IndicatorLine.
+            id(current_needle)->set_value((int32_t)current);
             char buf[32];
             snprintf(buf, sizeof(buf), "%.1f A", current);
             lv_label_set_text(id(current_text), buf);
@@ -97,7 +98,7 @@ interval:
           // Update power gauge and text
           float power = id(${yambms_id}_power).state / 1000.0f;  // Convert to kW
           if (!isnan(power)) {
-            lv_meter_set_indicator_value(id(power_meter), id(power_needle), (int32_t)(power));
+            id(power_needle)->set_value((int32_t)(power));
             char buf[32];
             snprintf(buf, sizeof(buf), "%.2f kW", power);
             lv_label_set_text(id(power_text), buf);


### PR DESCRIPTION
Four fixes required to make the M5Stack Tab5 (ESP32-P4) layout compile and run on ESPHome 2026.6 / LVGL 9.x. Verified with `esphome config` (valid) and a full `esphome compile` (SUCCESS, ESP32-P4 image built).

## 1. Invalid `ticks: count: 0` on the gauges

`current_meter`/`power_meter` set `ticks.count: 0`, but the LVGL meter-scale schema requires `count >= 2` ("value must be at least 2"). Both gauges are intentionally tick-less (needle + colored arcs), so the `ticks:` block is removed. No visual change.

## 2. `rotation` must move from `display:` to `lvgl:`

ESPHome 2026.6 rejects display-level rotation under LVGL ("use of 'rotation' in the display config is not compatible with LVGL, please set rotation in the LVGL config instead"). `rotation: 90` moves into the `lvgl:` block.

`mipi_dsi` has no hardware rotation, so LVGL rotates in software and now auto-transforms touch via `LvglComponent::rotate_coordinates()`. The previous manual gt911 `transform: {swap_xy, mirror_y}` would double-rotate, so it is removed and the touchscreen `calibration` is set to panel-native orientation (`x: 0..720`, `y: 0..1280`). Net touch mapping is unchanged.

## 3. Deprecated meter `r_mod` indicator property

LVGL 9.4 removed `lv_meter`; ESPHome emulates it with `lv_scale`, which dropped `r_mod`:

```
WARNING Property 'r_mod' is deprecated, use 'length' instead
WARNING The 'r_mod' indicator property is not supported in LVGL 9.x and will be ignored
```

- **Needle** (line indicator): `r_mod: 25` -> `length: -25`. ESPHome converts `r_mod` to `length = -abs(r_mod)` internally, so a *negative* length reproduces the identical needle (positive `25` would not).
- **Arcs**: `r_mod` has no `lv_scale` equivalent and was already ignored, so it is removed.

No visual change; clears the warnings.

## 4. `lv_meter_set_indicator_value()` removed (compile error)

With `lv_meter` gone, the `_esphome_sensors` interval lambda no longer compiles:

```
error: 'lv_meter_set_indicator_value' was not declared in this scope
```

Needles are now the `IndicatorLine` compound, so the value is set via `id(<needle>)->set_value((int32_t)v)` — the same codegen the `lvgl.indicator.update` action (already used by the `_ha_sensors` variant) produces. The `_esphome` variant simply hadn't been migrated.

## Testing

- `esphome config` passes.
- Full `esphome compile` succeeds: "Successfully created ESP32-P4 image" (RAM 23.9%, Flash 30.7%).
- Gauges render identically; touch handled by LVGL software rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
