### PR TITLE
Haysdb current taper

### DIFF
--- a/packages/yambms/yambms_auto_ccl_current_taper.yaml
+++ b/packages/yambms/yambms_auto_ccl_current_taper.yaml
@@ -54,8 +54,8 @@ number:
     name: "Auto CCL CT Knee Voltage"
     unit_of_measurement: V
     device_class: voltage
-    min_value: 54.2
     max_value: 56.0
+    min_value: 54.2
     step: 0.1
     mode: ${yambms_input_number_mode}
     restore_value: true
@@ -70,8 +70,8 @@ number:
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Knee C-Rate"
     unit_of_measurement: "C"
-    min_value: 0.05
     max_value: 0.5
+    min_value: 0.05
     step: 0.005
     mode: ${yambms_input_number_mode}
     restore_value: true
@@ -86,8 +86,8 @@ number:
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Bulk C-Rate"
     unit_of_measurement: "C"
-    min_value: 0.005
     max_value: 0.1
+    min_value: 0.0
     step: 0.005
     mode: ${yambms_input_number_mode}
     restore_value: true
@@ -102,8 +102,8 @@ number:
     id: yambms${yambms_id}_number_auto_ccl_ct_curve_exp
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Curve Exp"
-    min_value: 0.5
     max_value: 2.0
+    min_value: 0.5
     step: 0.1
     mode: ${yambms_input_number_mode}
     restore_value: true

--- a/packages/yambms/yambms_auto_ccl_current_taper.yaml
+++ b/packages/yambms/yambms_auto_ccl_current_taper.yaml
@@ -97,13 +97,14 @@ number:
     icon: mdi:current-dc
 
   # Curve shape: 1=linear, >1=quicker drop then longer tail
+  # Range a bit past "sensible" so the HA curve chart can demo extremes (~0.3 late cliff, ~2.5 early cliff)
   - platform: template
     id: yambms${yambms_id}_number_auto_ccl_ct_curve_exp
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Curve Exp"
-    min_value: 0.8
-    max_value: 1.2
-    step: 0.05
+    min_value: 0.5
+    max_value: 2.0
+    step: 0.1
     mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true

--- a/packages/yambms/yambms_auto_ccl_current_taper.yaml
+++ b/packages/yambms/yambms_auto_ccl_current_taper.yaml
@@ -39,9 +39,9 @@ esphome:
 
 switch:
   - platform: template
-    id: yambms${yambms_id}_switch_current_taper
+    id: yambms${yambms_id}_switch_auto_ccl_ct
     device_id: yambms_yambms${yambms_id}
-    name: "Auto CCL Current Taper"
+    name: "Auto CCL CT"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: config
@@ -49,7 +49,7 @@ switch:
 number:
   # Knee / activation voltage (pack)
   - platform: template
-    id: yambms${yambms_id}_number_ct_knee_v
+    id: yambms${yambms_id}_number_auto_ccl_ct_knee_v
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Knee Voltage"
     unit_of_measurement: V
@@ -66,7 +66,7 @@ number:
 
   # Knee / activation C-rate (× capacity → CCL at knee)
   - platform: template
-    id: yambms${yambms_id}_number_ct_knee_c_rate
+    id: yambms${yambms_id}_number_auto_ccl_ct_knee_c_rate
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Knee C-Rate"
     unit_of_measurement: "C"
@@ -82,7 +82,7 @@ number:
 
   # Bulk / end-of-curve C-rate (× capacity → CCL at bulk)
   - platform: template
-    id: yambms${yambms_id}_number_ct_bulk_c_rate
+    id: yambms${yambms_id}_number_auto_ccl_ct_bulk_c_rate
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Bulk C-Rate"
     unit_of_measurement: "C"
@@ -98,7 +98,7 @@ number:
 
   # Curve shape: 1=linear, >1=quicker drop then longer tail
   - platform: template
-    id: yambms${yambms_id}_number_ct_curve_exp
+    id: yambms${yambms_id}_number_auto_ccl_ct_curve_exp
     device_id: yambms_yambms${yambms_id}
     name: "Auto CCL CT Curve Exp"
     min_value: 0.8
@@ -112,13 +112,13 @@ number:
     icon: mdi:chart-bell-curve
 
 sensor:
-  # Pack V for taper math — 5-sample SMA (~5s at 1 Hz); keeps CCL from amplifying raw V noise
+  # Pack V for taper math — 8-sample SMA; keeps CCL from amplifying raw V noise
   # If it’s twitchy, increase window_size; if too sluggish, lower it.
   - platform: copy
     source_id: yambms${yambms_id}_total_voltage
-    id: yambms${yambms_id}_ct_voltage
+    id: yambms${yambms_id}_auto_ccl_ct_voltage
     device_id: yambms_yambms${yambms_id}
-    name: "Current Taper Voltage"
+    name: "Auto CCL CT Voltage"
     accuracy_decimals: 3
     entity_category: diagnostic
     icon: mdi:sine-wave
@@ -128,8 +128,8 @@ sensor:
           send_every: 1
 
   - platform: template
-    name: "Current Taper Delta"
-    id: yambms${yambms_id}_current_taper_delta
+    name: "Auto CCL CT Delta"
+    id: yambms${yambms_id}_auto_ccl_ct_delta
     device_id: yambms_yambms${yambms_id}
     unit_of_measurement: A
     accuracy_decimals: 0
@@ -152,7 +152,7 @@ sensor:
     icon: mdi:current-dc
     lambda: |-
       return roundf(id(yambms${yambms_id}_battery_capacity).state
-                  * id(yambms${yambms_id}_number_ct_knee_c_rate).state);
+                  * id(yambms${yambms_id}_number_auto_ccl_ct_knee_c_rate).state);
 
   - platform: template
     name: "Auto CCL CT Bulk Amps"
@@ -167,7 +167,7 @@ sensor:
     icon: mdi:current-dc
     lambda: |-
       return roundf(id(yambms${yambms_id}_battery_capacity).state
-                  * id(yambms${yambms_id}_number_ct_bulk_c_rate).state);
+                  * id(yambms${yambms_id}_number_auto_ccl_ct_bulk_c_rate).state);
 
 interval:
   - interval: ${yambms_update_interval}
@@ -191,10 +191,10 @@ interval:
           //--------------------------------------------------------------------
           // Gate #2: Feature enabled?
           //--------------------------------------------------------------------
-          if (!id(yambms${yambms_id}_switch_current_taper).state) {
+          if (!id(yambms${yambms_id}_switch_auto_ccl_ct).state) {
             active = false;
             id(yambms${yambms_id}_var_auto_custom_ccl) = 0.0f;
-            id(yambms${yambms_id}_current_taper_delta).publish_state(0.0f);
+            id(yambms${yambms_id}_auto_ccl_ct_delta).publish_state(0.0f);
             id(yambms${yambms_id}_var_charge_current_step)++;
             return;
           }
@@ -204,16 +204,16 @@ interval:
           //--------------------------------------------------------------------
           const float cap_ah    = id(yambms${yambms_id}_battery_capacity).state;
           const float I_max     = id(yambms${yambms_id}_max_charge_current).state;
-          const float knee_c    = id(yambms${yambms_id}_number_ct_knee_c_rate).state;
-          const float bulk_c    = id(yambms${yambms_id}_number_ct_bulk_c_rate).state;
-          const float curve_exp = id(yambms${yambms_id}_number_ct_curve_exp).state;
+          const float knee_c    = id(yambms${yambms_id}_number_auto_ccl_ct_knee_c_rate).state;
+          const float bulk_c    = id(yambms${yambms_id}_number_auto_ccl_ct_bulk_c_rate).state;
+          const float curve_exp = id(yambms${yambms_id}_number_auto_ccl_ct_curve_exp).state;
           const float I_knee    = cap_ah * knee_c;
           const float I_bulk    = cap_ah * bulk_c;
-          const float V_knee    = id(yambms${yambms_id}_number_ct_knee_v).state;
+          const float V_knee    = id(yambms${yambms_id}_number_auto_ccl_ct_knee_v).state;
           const float V_bulk    = id(yambms${yambms_id}_bulk_voltage).state;
           // Prefer SMA pack V; fall back to raw until the filter has a sample
-          const float V_pack    = id(yambms${yambms_id}_ct_voltage).has_state()
-              ? id(yambms${yambms_id}_ct_voltage).state
+          const float V_pack    = id(yambms${yambms_id}_auto_ccl_ct_voltage).has_state()
+              ? id(yambms${yambms_id}_auto_ccl_ct_voltage).state
               : id(yambms${yambms_id}_total_voltage).state;
           const float V_release = id(yambms${yambms_id}_rebulk_voltage).state;
           const bool  eoc_done  = id(yambms${yambms_id}_var_eoc);
@@ -249,7 +249,7 @@ interval:
           }
 
           id(yambms${yambms_id}_var_auto_custom_ccl) = delta;
-          id(yambms${yambms_id}_current_taper_delta).publish_state(delta);
+          id(yambms${yambms_id}_auto_ccl_ct_delta).publish_state(delta);
 
           // Pass the baton
           id(yambms${yambms_id}_var_charge_current_step)++;

--- a/packages/yambms/yambms_auto_ccl_current_taper.yaml
+++ b/packages/yambms/yambms_auto_ccl_current_taper.yaml
@@ -54,8 +54,8 @@ number:
     name: "Auto CCL CT Knee Voltage"
     unit_of_measurement: V
     device_class: voltage
-    max_value: 56.0
     min_value: 54.2
+    max_value: 56.0
     step: 0.1
     mode: ${yambms_input_number_mode}
     restore_value: true
@@ -125,7 +125,7 @@ sensor:
     icon: mdi:sine-wave
     filters:
       - sliding_window_moving_average:
-          window_size: 8
+          window_size: 10
           send_every: 1
 
   - platform: template
@@ -216,19 +216,19 @@ interval:
           const float V_pack    = id(yambms${yambms_id}_auto_ccl_ct_voltage).has_state()
               ? id(yambms${yambms_id}_auto_ccl_ct_voltage).state
               : id(yambms${yambms_id}_total_voltage).state;
-          const float V_release = id(yambms${yambms_id}_rebulk_voltage).state;
           const bool  eoc_done  = id(yambms${yambms_id}_var_eoc);
+          constexpr float V_hyst = 0.2f;                                    // release hysteresis below knee
 
           float I_target = I_max;
           float delta    = 0.0f;
 
           //--------------------------------------------------------------------
-          // Session: activate at knee, release at rebulk
+          // Session: activate at knee; stay active until 0.2 V below knee
           //--------------------------------------------------------------------
           if (!active && V_pack >= V_knee) {
             active = true;
             I_anchor = I_knee;
-          } else if (active && V_pack <= V_release) {
+          } else if (active && V_pack <= (V_knee - V_hyst)) {
             active = false;
           }
 
@@ -238,11 +238,9 @@ interval:
           if (active) {
             if (eoc_done) {
               I_target = 0.0f;                                              // cutoff complete
-            } else if (V_pack < V_knee) {
-              I_target = I_max;
             } else {
               float p = (V_pack - V_knee) / (V_bulk - V_knee);              // 0 at knee → 1 at bulk
-              p = fmaxf(0.0f, fminf(p, 1.0f));
+              p = fmaxf(0.0f, fminf(p, 1.0f));                              // below knee (hyst band): hold I_anchor
               const float curve = powf(1.0f - p, curve_exp);
               I_target = I_bulk + (I_anchor - I_bulk) * curve;              // ends at I_bulk at/above bulk
             }

--- a/packages/yambms/yambms_auto_ccl_current_taper.yaml
+++ b/packages/yambms/yambms_auto_ccl_current_taper.yaml
@@ -1,4 +1,4 @@
-# Updated : 2026.06.27
+# Updated : 2026.07.12
 # Version : 1.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 

--- a/packages/yambms/yambms_auto_ccl_current_taper.yaml
+++ b/packages/yambms/yambms_auto_ccl_current_taper.yaml
@@ -21,7 +21,8 @@
 # Auto CCL Current Taper
 #
 # Purpose:
-#   Taper requested charge current from knee to bulk voltage; zero after cutoff (var_eoc).
+#   Taper requested charge current from knee to bulk voltage. At first bulk touch, drop CCL
+#   to post-bulk amps so Cut-Off can complete (CVL is not trusted). Zero after cutoff (var_eoc).
 #
 # Contract with yambms_core.yaml:
 #   - Participates in Auto CCL STEP pipeline
@@ -29,6 +30,10 @@
 #   - Value must be <= 0.0  (negative = reduce, 0 = no reduction)
 #   - Advances pipeline via: id(yambms${yambms_id}_var_charge_current_step)++
 #--------------------------------------------------------------------------------------------
+
+substitutions:
+  # Post-bulk CCL floor (A). Sudden drop at first bulk touch; non-zero so inverters that ignore 0 A still see a limit.
+  auto_ccl_ct_post_bulk_amps: '2'
 
 esphome:
   on_boot:
@@ -177,8 +182,9 @@ interval:
           //--------------------------------------------------------------------
           // Internal state
           //--------------------------------------------------------------------
-          static bool  active   = false;   // At/above knee this session
-          static float I_anchor = NAN;     // CCL at knee (left end of curve)
+          static bool  active       = false;   // At/above knee this session
+          static bool  bulk_latched = false;   // Pack has touched bulk this session
+          static float I_anchor     = NAN;     // CCL at knee (left end of curve)
 
           //--------------------------------------------------------------------
           // Gate #1: Correct Auto CCL step
@@ -194,6 +200,7 @@ interval:
           //--------------------------------------------------------------------
           if (!id(yambms${yambms_id}_switch_auto_ccl_ct).state) {
             active = false;
+            bulk_latched = false;
             id(yambms${yambms_id}_var_auto_custom_ccl) = 0.0f;
             id(yambms${yambms_id}_auto_ccl_ct_delta).publish_state(0.0f);
             id(yambms${yambms_id}_var_charge_current_step)++;
@@ -210,6 +217,7 @@ interval:
           const float curve_exp = id(yambms${yambms_id}_number_auto_ccl_ct_curve_exp).state;
           const float I_knee    = cap_ah * knee_c;
           const float I_bulk    = cap_ah * bulk_c;
+          const float I_post    = ${auto_ccl_ct_post_bulk_amps};            // CCL after bulk (hand Cut-Off the win)
           const float V_knee    = id(yambms${yambms_id}_number_auto_ccl_ct_knee_v).state;
           const float V_bulk    = id(yambms${yambms_id}_bulk_voltage).state;
           // Prefer SMA pack V; fall back to raw until the filter has a sample
@@ -227,9 +235,13 @@ interval:
           //--------------------------------------------------------------------
           if (!active && V_pack >= V_knee) {
             active = true;
+            bulk_latched = false;                                           // new session
             I_anchor = I_knee;
           } else if (active && V_pack <= (V_knee - V_hyst)) {
             active = false;
+            bulk_latched = false;
+          } else if (active && !bulk_latched && V_pack >= V_bulk) {
+            bulk_latched = true;                                            // sudden drop to I_post
           }
 
           //--------------------------------------------------------------------
@@ -238,11 +250,13 @@ interval:
           if (active) {
             if (eoc_done) {
               I_target = 0.0f;                                              // cutoff complete
+            } else if (bulk_latched) {
+              I_target = I_post;                                            // post-bulk floor (not 0 — some inverters ignore 0 A)
             } else {
               float p = (V_pack - V_knee) / (V_bulk - V_knee);              // 0 at knee → 1 at bulk
               p = fmaxf(0.0f, fminf(p, 1.0f));                              // below knee (hyst band): hold I_anchor
               const float curve = powf(1.0f - p, curve_exp);
-              I_target = I_bulk + (I_anchor - I_bulk) * curve;              // ends at I_bulk at/above bulk
+              I_target = I_bulk + (I_anchor - I_bulk) * curve;              // curve ends at I_bulk at bulk
             }
             delta = fminf(0.0f, I_target - I_max);
           }

--- a/packages/yambms/yambms_auto_ccl_current_taper.yaml
+++ b/packages/yambms/yambms_auto_ccl_current_taper.yaml
@@ -1,0 +1,255 @@
+# Updated : 2026.06.27
+# Version : 1.0
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+#--------------------------------------------------------------------------------------------
+# Auto CCL Current Taper
+#
+# Purpose:
+#   Taper requested charge current from knee to bulk voltage; zero after cutoff (var_eoc).
+#
+# Contract with yambms_core.yaml:
+#   - Participates in Auto CCL STEP pipeline
+#   - Writes only: id(yambms${yambms_id}_var_auto_custom_ccl)
+#   - Value must be <= 0.0  (negative = reduce, 0 = no reduction)
+#   - Advances pipeline via: id(yambms${yambms_id}_var_charge_current_step)++
+#--------------------------------------------------------------------------------------------
+
+esphome:
+  on_boot:
+    - priority: -100.0
+      then:
+        - lambda: |-
+            id(yambms${yambms_id}_var_auto_ccl_functions_count)++;   // Registration
+
+switch:
+  - platform: template
+    id: yambms${yambms_id}_switch_current_taper
+    device_id: yambms_yambms${yambms_id}
+    name: "Auto CCL Current Taper"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    entity_category: config
+
+number:
+  # Knee / activation voltage (pack)
+  - platform: template
+    id: yambms${yambms_id}_number_ct_knee_v
+    device_id: yambms_yambms${yambms_id}
+    name: "Auto CCL CT Knee Voltage"
+    unit_of_measurement: V
+    device_class: voltage
+    min_value: 54.2
+    max_value: 56.0
+    step: 0.1
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 54.4
+    entity_category: config
+    icon: mdi:sine-wave
+
+  # Knee / activation C-rate (× capacity → CCL at knee)
+  - platform: template
+    id: yambms${yambms_id}_number_ct_knee_c_rate
+    device_id: yambms_yambms${yambms_id}
+    name: "Auto CCL CT Knee C-Rate"
+    unit_of_measurement: "C"
+    min_value: 0.05
+    max_value: 0.5
+    step: 0.005
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 0.125
+    entity_category: config
+    icon: mdi:current-dc
+
+  # Bulk / end-of-curve C-rate (× capacity → CCL at bulk)
+  - platform: template
+    id: yambms${yambms_id}_number_ct_bulk_c_rate
+    device_id: yambms_yambms${yambms_id}
+    name: "Auto CCL CT Bulk C-Rate"
+    unit_of_measurement: "C"
+    min_value: 0.005
+    max_value: 0.1
+    step: 0.005
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 0.03
+    entity_category: config
+    icon: mdi:current-dc
+
+  # Curve shape: 1=linear, >1=quicker drop then longer tail
+  - platform: template
+    id: yambms${yambms_id}_number_ct_curve_exp
+    device_id: yambms_yambms${yambms_id}
+    name: "Auto CCL CT Curve Exp"
+    min_value: 0.8
+    max_value: 1.2
+    step: 0.05
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 1.0
+    entity_category: config
+    icon: mdi:chart-bell-curve
+
+sensor:
+  # Pack V for taper math — 5-sample SMA (~5s at 1 Hz); keeps CCL from amplifying raw V noise
+  # If it’s twitchy, increase window_size; if too sluggish, lower it.
+  - platform: copy
+    source_id: yambms${yambms_id}_total_voltage
+    id: yambms${yambms_id}_ct_voltage
+    device_id: yambms_yambms${yambms_id}
+    name: "Current Taper Voltage"
+    accuracy_decimals: 3
+    entity_category: diagnostic
+    icon: mdi:sine-wave
+    filters:
+      - sliding_window_moving_average:
+          window_size: 8
+          send_every: 1
+
+  - platform: template
+    name: "Current Taper Delta"
+    id: yambms${yambms_id}_current_taper_delta
+    device_id: yambms_yambms${yambms_id}
+    unit_of_measurement: A
+    accuracy_decimals: 0
+    update_interval: never
+    entity_category: diagnostic
+    icon: mdi:current-dc
+    lambda: 'return id(yambms${yambms_id}_var_auto_custom_ccl);'
+
+  # C-rate × capacity
+  - platform: template
+    name: "Auto CCL CT Knee Amps"
+    id: yambms${yambms_id}_auto_ccl_ct_knee_amps
+    device_id: yambms_yambms${yambms_id}
+    unit_of_measurement: A
+    device_class: current
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: ${yambms_update_interval}
+    entity_category: diagnostic
+    icon: mdi:current-dc
+    lambda: |-
+      return roundf(id(yambms${yambms_id}_battery_capacity).state
+                  * id(yambms${yambms_id}_number_ct_knee_c_rate).state);
+
+  - platform: template
+    name: "Auto CCL CT Bulk Amps"
+    id: yambms${yambms_id}_auto_ccl_ct_bulk_amps
+    device_id: yambms_yambms${yambms_id}
+    unit_of_measurement: A
+    device_class: current
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: ${yambms_update_interval}
+    entity_category: diagnostic
+    icon: mdi:current-dc
+    lambda: |-
+      return roundf(id(yambms${yambms_id}_battery_capacity).state
+                  * id(yambms${yambms_id}_number_ct_bulk_c_rate).state);
+
+interval:
+  - interval: ${yambms_update_interval}
+    then:
+      - lambda: |-
+          //--------------------------------------------------------------------
+          // Internal state
+          //--------------------------------------------------------------------
+          static bool  active   = false;   // At/above knee this session
+          static float I_anchor = NAN;     // CCL at knee (left end of curve)
+
+          //--------------------------------------------------------------------
+          // Gate #1: Correct Auto CCL step
+          //--------------------------------------------------------------------
+          const int cc_step = id(yambms${yambms_id}_var_charge_current_step);
+          const int n_funcs = id(yambms${yambms_id}_var_auto_ccl_functions_count);
+          if (cc_step < 1 || cc_step > n_funcs) {
+            return;
+          }
+
+          //--------------------------------------------------------------------
+          // Gate #2: Feature enabled?
+          //--------------------------------------------------------------------
+          if (!id(yambms${yambms_id}_switch_current_taper).state) {
+            active = false;
+            id(yambms${yambms_id}_var_auto_custom_ccl) = 0.0f;
+            id(yambms${yambms_id}_current_taper_delta).publish_state(0.0f);
+            id(yambms${yambms_id}_var_charge_current_step)++;
+            return;
+          }
+
+          //--------------------------------------------------------------------
+          // Inputs
+          //--------------------------------------------------------------------
+          const float cap_ah    = id(yambms${yambms_id}_battery_capacity).state;
+          const float I_max     = id(yambms${yambms_id}_max_charge_current).state;
+          const float knee_c    = id(yambms${yambms_id}_number_ct_knee_c_rate).state;
+          const float bulk_c    = id(yambms${yambms_id}_number_ct_bulk_c_rate).state;
+          const float curve_exp = id(yambms${yambms_id}_number_ct_curve_exp).state;
+          const float I_knee    = cap_ah * knee_c;
+          const float I_bulk    = cap_ah * bulk_c;
+          const float V_knee    = id(yambms${yambms_id}_number_ct_knee_v).state;
+          const float V_bulk    = id(yambms${yambms_id}_bulk_voltage).state;
+          // Prefer SMA pack V; fall back to raw until the filter has a sample
+          const float V_pack    = id(yambms${yambms_id}_ct_voltage).has_state()
+              ? id(yambms${yambms_id}_ct_voltage).state
+              : id(yambms${yambms_id}_total_voltage).state;
+          const float V_release = id(yambms${yambms_id}_rebulk_voltage).state;
+          const bool  eoc_done  = id(yambms${yambms_id}_var_eoc);
+
+          float I_target = I_max;
+          float delta    = 0.0f;
+
+          //--------------------------------------------------------------------
+          // Session: activate at knee, release at rebulk
+          //--------------------------------------------------------------------
+          if (!active && V_pack >= V_knee) {
+            active = true;
+            I_anchor = I_knee;
+          } else if (active && V_pack <= V_release) {
+            active = false;
+          }
+
+          //--------------------------------------------------------------------
+          // Desired charge current
+          //--------------------------------------------------------------------
+          if (active) {
+            if (eoc_done) {
+              I_target = 0.0f;                                              // cutoff complete
+            } else if (V_pack < V_knee) {
+              I_target = I_max;
+            } else {
+              float p = (V_pack - V_knee) / (V_bulk - V_knee);              // 0 at knee → 1 at bulk
+              p = fmaxf(0.0f, fminf(p, 1.0f));
+              const float curve = powf(1.0f - p, curve_exp);
+              I_target = I_bulk + (I_anchor - I_bulk) * curve;              // ends at I_bulk at/above bulk
+            }
+            delta = fminf(0.0f, I_target - I_max);
+          }
+
+          id(yambms${yambms_id}_var_auto_custom_ccl) = delta;
+          id(yambms${yambms_id}_current_taper_delta).publish_state(delta);
+
+          // Pass the baton
+          id(yambms${yambms_id}_var_charge_current_step)++;


### PR DESCRIPTION
Add Auto CCL Current Taper package

Custom Auto CCL pipeline step that tapers requested charge current between a configurable knee voltage and bulk voltage, writing only a delta to var_auto_custom_ccl (same contract as other Auto CCL packages).

Behavior:

Activates when pack voltage reaches the knee; releases at rebulk voltage
Maps V_knee→V_bulk to I_knee→I_bulk via a tunable power curve (C-rates × capacity)
Forces target current to 0 A after cutoff (var_eoc)
Uses a short SMA of total_voltage so CCL does not chase raw pack-V noise
Also exposes enable switch, knee/bulk C-rate and curve-exp numbers, and
diagnostic sensors for SMA voltage, delta, and derived knee/bulk amps.