### PR TITLE
Add Fake Balancer package

### DIFF
--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -459,6 +459,8 @@ views:
             name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
+          - entity: number.sim_equalizing_1_max_run_time
+            name: Max Run Time
           - entity: number.sim_equalizing_1_balance_starting_voltage
             name: Start Balance V
           - entity: number.sim_equalizing_1_balance_sleep_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -451,6 +451,25 @@ views:
             name: README
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
+      - type: entities
+        title: Simulate Equalizing
+        show_header_toggle: false
+        entities:
+          - entity: switch.yambms_demo_sim_equalizing
+            name: Sim Equalizing
+          - entity: switch.yambms_demo_force_equalizing
+            name: Force Equalizing
+          - entity: number.yambms_demo_sim_eq_offset
+            name: Sim Eq Offset
+          - entity: number.yambms_demo_sim_eq_hold
+            name: Sim Eq Hold
+          - entity: binary_sensor.yambms_demo_sim_eq_active
+            name: Sim Eq Active
+          - type: weblink
+            url: >-
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+            name: README
+            icon: mdi:book-open-variant
   - title: Diagnostic
     cards:
       - type: entity-filter

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -452,25 +452,25 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Simulate Equalizing
+        title: Sim Eq
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_enable_sim_equalizing
-            name: Enable Sim Equalizing
-          - entity: switch.sim_equalizing_1_force_equalizing
-            name: Force Equalizing
-          - entity: number.sim_equalizing_1_max_run_time
+          - entity: switch.sim_eq_1_enable
+            name: Enable
+          - entity: switch.sim_eq_1_force
+            name: Force
+          - entity: number.sim_eq_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_equalizing_1_balance_starting_voltage
+          - entity: number.sim_eq_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_equalizing_1_balance_sleep_voltage
+          - entity: number.sim_eq_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_equalizing_1_balance_trigger_voltage
+          - entity: number.sim_eq_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+          - entity: number.sim_eq_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
-            name: Sim Eq Active
+          - entity: binary_sensor.sim_eq_1_active
+            name: Active
           - type: weblink
             url: >-
               https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -459,10 +459,14 @@ views:
             name: Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.sim_equalizing_1_sim_eq_offset
-            name: Sim Eq Offset
-          - entity: number.sim_equalizing_1_sim_eq_hold
-            name: Sim Eq Hold
+          - entity: number.sim_equalizing_1_balance_starting_voltage
+            name: Start Balance V
+          - entity: number.sim_equalizing_1_balance_sleep_voltage
+            name: Stop Balance V
+          - entity: number.sim_equalizing_1_balance_trigger_voltage
+            name: Start Delta V
+          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+            name: Stop Delta V
           - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -455,15 +455,15 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.yambms_demo_sim_equalizing
+          - entity: switch.sim_equalizing_1_sim_equalizing
             name: Sim Equalizing
-          - entity: switch.yambms_demo_force_equalizing
+          - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.yambms_demo_sim_eq_offset
+          - entity: number.sim_equalizing_1_sim_eq_offset
             name: Sim Eq Offset
-          - entity: number.yambms_demo_sim_eq_hold
+          - entity: number.sim_equalizing_1_sim_eq_hold
             name: Sim Eq Hold
-          - entity: binary_sensor.yambms_demo_sim_eq_active
+          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink
             url: >-

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -455,8 +455,8 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_sim_equalizing
-            name: Sim Equalizing
+          - entity: switch.sim_equalizing_1_enable_sim_equalizing
+            name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
           - entity: number.sim_equalizing_1_balance_starting_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_DEMO.yaml
@@ -452,28 +452,28 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Sim Eq
+        title: Fake Balancer
         show_header_toggle: false
         entities:
-          - entity: switch.sim_eq_1_enable
+          - entity: switch.fake_balancer_1_enable
             name: Enable
-          - entity: switch.sim_eq_1_force
+          - entity: switch.fake_balancer_1_force
             name: Force
-          - entity: number.sim_eq_1_max_run_time
+          - entity: number.fake_balancer_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_eq_1_balance_starting_voltage
+          - entity: number.fake_balancer_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_eq_1_balance_sleep_voltage
+          - entity: number.fake_balancer_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_eq_1_balance_trigger_voltage
+          - entity: number.fake_balancer_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_eq_1_balance_stop_diff_voltage
+          - entity: number.fake_balancer_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_eq_1_active
+          - entity: binary_sensor.fake_balancer_1_active
             name: Active
           - type: weblink
             url: >-
-              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#fake-balancer
             name: README
             icon: mdi:book-open-variant
   - title: Diagnostic

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -516,6 +516,25 @@ views:
             name: README
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
+      - type: entities
+        title: Simulate Equalizing
+        show_header_toggle: false
+        entities:
+          - entity: switch.yambms_1_sim_equalizing
+            name: Sim Equalizing
+          - entity: switch.yambms_1_force_equalizing
+            name: Force Equalizing
+          - entity: number.yambms_1_sim_eq_offset
+            name: Sim Eq Offset
+          - entity: number.yambms_1_sim_eq_hold
+            name: Sim Eq Hold
+          - entity: binary_sensor.yambms_1_sim_eq_active
+            name: Sim Eq Active
+          - type: weblink
+            url: >-
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+            name: README
+            icon: mdi:book-open-variant
   - title: Diagnostic
     cards:
       - type: entity-filter

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -520,15 +520,15 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.yambms_1_sim_equalizing
+          - entity: switch.sim_equalizing_1_sim_equalizing
             name: Sim Equalizing
-          - entity: switch.yambms_1_force_equalizing
+          - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.yambms_1_sim_eq_offset
+          - entity: number.sim_equalizing_1_sim_eq_offset
             name: Sim Eq Offset
-          - entity: number.yambms_1_sim_eq_hold
+          - entity: number.sim_equalizing_1_sim_eq_hold
             name: Sim Eq Hold
-          - entity: binary_sensor.yambms_1_sim_eq_active
+          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink
             url: >-

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -524,6 +524,8 @@ views:
             name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
+          - entity: number.sim_equalizing_1_max_run_time
+            name: Max Run Time
           - entity: number.sim_equalizing_1_balance_starting_voltage
             name: Start Balance V
           - entity: number.sim_equalizing_1_balance_sleep_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -517,28 +517,28 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Sim Eq
+        title: Fake Balancer
         show_header_toggle: false
         entities:
-          - entity: switch.sim_eq_1_enable
+          - entity: switch.fake_balancer_1_enable
             name: Enable
-          - entity: switch.sim_eq_1_force
+          - entity: switch.fake_balancer_1_force
             name: Force
-          - entity: number.sim_eq_1_max_run_time
+          - entity: number.fake_balancer_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_eq_1_balance_starting_voltage
+          - entity: number.fake_balancer_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_eq_1_balance_sleep_voltage
+          - entity: number.fake_balancer_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_eq_1_balance_trigger_voltage
+          - entity: number.fake_balancer_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_eq_1_balance_stop_diff_voltage
+          - entity: number.fake_balancer_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_eq_1_active
+          - entity: binary_sensor.fake_balancer_1_active
             name: Active
           - type: weblink
             url: >-
-              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#fake-balancer
             name: README
             icon: mdi:book-open-variant
   - title: Diagnostic

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -520,8 +520,8 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_sim_equalizing
-            name: Sim Equalizing
+          - entity: switch.sim_equalizing_1_enable_sim_equalizing
+            name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
           - entity: number.sim_equalizing_1_balance_starting_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -524,10 +524,14 @@ views:
             name: Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.sim_equalizing_1_sim_eq_offset
-            name: Sim Eq Offset
-          - entity: number.sim_equalizing_1_sim_eq_hold
-            name: Sim Eq Hold
+          - entity: number.sim_equalizing_1_balance_starting_voltage
+            name: Start Balance V
+          - entity: number.sim_equalizing_1_balance_sleep_voltage
+            name: Stop Balance V
+          - entity: number.sim_equalizing_1_balance_trigger_voltage
+            name: Start Delta V
+          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+            name: Stop Delta V
           - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -517,25 +517,25 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Simulate Equalizing
+        title: Sim Eq
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_enable_sim_equalizing
-            name: Enable Sim Equalizing
-          - entity: switch.sim_equalizing_1_force_equalizing
-            name: Force Equalizing
-          - entity: number.sim_equalizing_1_max_run_time
+          - entity: switch.sim_eq_1_enable
+            name: Enable
+          - entity: switch.sim_eq_1_force
+            name: Force
+          - entity: number.sim_eq_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_equalizing_1_balance_starting_voltage
+          - entity: number.sim_eq_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_equalizing_1_balance_sleep_voltage
+          - entity: number.sim_eq_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_equalizing_1_balance_trigger_voltage
+          - entity: number.sim_eq_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+          - entity: number.sim_eq_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
-            name: Sim Eq Active
+          - entity: binary_sensor.sim_eq_1_active
+            name: Active
           - type: weblink
             url: >-
               https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -516,6 +516,25 @@ views:
             name: README
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
+      - type: entities
+        title: Simulate Equalizing
+        show_header_toggle: false
+        entities:
+          - entity: switch.yambms_1_sim_equalizing
+            name: Sim Equalizing
+          - entity: switch.yambms_1_force_equalizing
+            name: Force Equalizing
+          - entity: number.yambms_1_sim_eq_offset
+            name: Sim Eq Offset
+          - entity: number.yambms_1_sim_eq_hold
+            name: Sim Eq Hold
+          - entity: binary_sensor.yambms_1_sim_eq_active
+            name: Sim Eq Active
+          - type: weblink
+            url: >-
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+            name: README
+            icon: mdi:book-open-variant
   - title: Diagnostic
     cards:
       - type: entity-filter

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -520,15 +520,15 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.yambms_1_sim_equalizing
+          - entity: switch.sim_equalizing_1_sim_equalizing
             name: Sim Equalizing
-          - entity: switch.yambms_1_force_equalizing
+          - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.yambms_1_sim_eq_offset
+          - entity: number.sim_equalizing_1_sim_eq_offset
             name: Sim Eq Offset
-          - entity: number.yambms_1_sim_eq_hold
+          - entity: number.sim_equalizing_1_sim_eq_hold
             name: Sim Eq Hold
-          - entity: binary_sensor.yambms_1_sim_eq_active
+          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink
             url: >-

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -524,6 +524,8 @@ views:
             name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
+          - entity: number.sim_equalizing_1_max_run_time
+            name: Max Run Time
           - entity: number.sim_equalizing_1_balance_starting_voltage
             name: Start Balance V
           - entity: number.sim_equalizing_1_balance_sleep_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -517,28 +517,28 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Sim Eq
+        title: Fake Balancer
         show_header_toggle: false
         entities:
-          - entity: switch.sim_eq_1_enable
+          - entity: switch.fake_balancer_1_enable
             name: Enable
-          - entity: switch.sim_eq_1_force
+          - entity: switch.fake_balancer_1_force
             name: Force
-          - entity: number.sim_eq_1_max_run_time
+          - entity: number.fake_balancer_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_eq_1_balance_starting_voltage
+          - entity: number.fake_balancer_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_eq_1_balance_sleep_voltage
+          - entity: number.fake_balancer_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_eq_1_balance_trigger_voltage
+          - entity: number.fake_balancer_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_eq_1_balance_stop_diff_voltage
+          - entity: number.fake_balancer_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_eq_1_active
+          - entity: binary_sensor.fake_balancer_1_active
             name: Active
           - type: weblink
             url: >-
-              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#fake-balancer
             name: README
             icon: mdi:book-open-variant
   - title: Diagnostic

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -520,8 +520,8 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_sim_equalizing
-            name: Sim Equalizing
+          - entity: switch.sim_equalizing_1_enable_sim_equalizing
+            name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
           - entity: number.sim_equalizing_1_balance_starting_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -524,10 +524,14 @@ views:
             name: Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.sim_equalizing_1_sim_eq_offset
-            name: Sim Eq Offset
-          - entity: number.sim_equalizing_1_sim_eq_hold
-            name: Sim Eq Hold
+          - entity: number.sim_equalizing_1_balance_starting_voltage
+            name: Start Balance V
+          - entity: number.sim_equalizing_1_balance_sleep_voltage
+            name: Stop Balance V
+          - entity: number.sim_equalizing_1_balance_trigger_voltage
+            name: Start Delta V
+          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+            name: Stop Delta V
           - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -517,25 +517,25 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Simulate Equalizing
+        title: Sim Eq
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_enable_sim_equalizing
-            name: Enable Sim Equalizing
-          - entity: switch.sim_equalizing_1_force_equalizing
-            name: Force Equalizing
-          - entity: number.sim_equalizing_1_max_run_time
+          - entity: switch.sim_eq_1_enable
+            name: Enable
+          - entity: switch.sim_eq_1_force
+            name: Force
+          - entity: number.sim_eq_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_equalizing_1_balance_starting_voltage
+          - entity: number.sim_eq_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_equalizing_1_balance_sleep_voltage
+          - entity: number.sim_eq_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_equalizing_1_balance_trigger_voltage
+          - entity: number.sim_eq_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+          - entity: number.sim_eq_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
-            name: Sim Eq Active
+          - entity: binary_sensor.sim_eq_1_active
+            name: Active
           - type: weblink
             url: >-
               https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -516,6 +516,25 @@ views:
             name: README
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
+      - type: entities
+        title: Simulate Equalizing
+        show_header_toggle: false
+        entities:
+          - entity: switch.yambms_1_sim_equalizing
+            name: Sim Equalizing
+          - entity: switch.yambms_1_force_equalizing
+            name: Force Equalizing
+          - entity: number.yambms_1_sim_eq_offset
+            name: Sim Eq Offset
+          - entity: number.yambms_1_sim_eq_hold
+            name: Sim Eq Hold
+          - entity: binary_sensor.yambms_1_sim_eq_active
+            name: Sim Eq Active
+          - type: weblink
+            url: >-
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+            name: README
+            icon: mdi:book-open-variant
   - title: Diagnostic
     cards:
       - type: entity-filter

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -520,15 +520,15 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.yambms_1_sim_equalizing
+          - entity: switch.sim_equalizing_1_sim_equalizing
             name: Sim Equalizing
-          - entity: switch.yambms_1_force_equalizing
+          - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.yambms_1_sim_eq_offset
+          - entity: number.sim_equalizing_1_sim_eq_offset
             name: Sim Eq Offset
-          - entity: number.yambms_1_sim_eq_hold
+          - entity: number.sim_equalizing_1_sim_eq_hold
             name: Sim Eq Hold
-          - entity: binary_sensor.yambms_1_sim_eq_active
+          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink
             url: >-

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -524,6 +524,8 @@ views:
             name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
+          - entity: number.sim_equalizing_1_max_run_time
+            name: Max Run Time
           - entity: number.sim_equalizing_1_balance_starting_voltage
             name: Start Balance V
           - entity: number.sim_equalizing_1_balance_sleep_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -517,28 +517,28 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Sim Eq
+        title: Fake Balancer
         show_header_toggle: false
         entities:
-          - entity: switch.sim_eq_1_enable
+          - entity: switch.fake_balancer_1_enable
             name: Enable
-          - entity: switch.sim_eq_1_force
+          - entity: switch.fake_balancer_1_force
             name: Force
-          - entity: number.sim_eq_1_max_run_time
+          - entity: number.fake_balancer_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_eq_1_balance_starting_voltage
+          - entity: number.fake_balancer_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_eq_1_balance_sleep_voltage
+          - entity: number.fake_balancer_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_eq_1_balance_trigger_voltage
+          - entity: number.fake_balancer_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_eq_1_balance_stop_diff_voltage
+          - entity: number.fake_balancer_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_eq_1_active
+          - entity: binary_sensor.fake_balancer_1_active
             name: Active
           - type: weblink
             url: >-
-              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#fake-balancer
             name: README
             icon: mdi:book-open-variant
   - title: Diagnostic

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -520,8 +520,8 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_sim_equalizing
-            name: Sim Equalizing
+          - entity: switch.sim_equalizing_1_enable_sim_equalizing
+            name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
           - entity: number.sim_equalizing_1_balance_starting_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -524,10 +524,14 @@ views:
             name: Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.sim_equalizing_1_sim_eq_offset
-            name: Sim Eq Offset
-          - entity: number.sim_equalizing_1_sim_eq_hold
-            name: Sim Eq Hold
+          - entity: number.sim_equalizing_1_balance_starting_voltage
+            name: Start Balance V
+          - entity: number.sim_equalizing_1_balance_sleep_voltage
+            name: Stop Balance V
+          - entity: number.sim_equalizing_1_balance_trigger_voltage
+            name: Start Delta V
+          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+            name: Stop Delta V
           - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml
@@ -517,25 +517,25 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Simulate Equalizing
+        title: Sim Eq
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_enable_sim_equalizing
-            name: Enable Sim Equalizing
-          - entity: switch.sim_equalizing_1_force_equalizing
-            name: Force Equalizing
-          - entity: number.sim_equalizing_1_max_run_time
+          - entity: switch.sim_eq_1_enable
+            name: Enable
+          - entity: switch.sim_eq_1_force
+            name: Force
+          - entity: number.sim_eq_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_equalizing_1_balance_starting_voltage
+          - entity: number.sim_eq_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_equalizing_1_balance_sleep_voltage
+          - entity: number.sim_eq_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_equalizing_1_balance_trigger_voltage
+          - entity: number.sim_eq_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+          - entity: number.sim_eq_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
-            name: Sim Eq Active
+          - entity: binary_sensor.sim_eq_1_active
+            name: Active
           - type: weblink
             url: >-
               https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -516,6 +516,25 @@ views:
             name: README
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
+      - type: entities
+        title: Simulate Equalizing
+        show_header_toggle: false
+        entities:
+          - entity: switch.yambms_1_sim_equalizing
+            name: Sim Equalizing
+          - entity: switch.yambms_1_force_equalizing
+            name: Force Equalizing
+          - entity: number.yambms_1_sim_eq_offset
+            name: Sim Eq Offset
+          - entity: number.yambms_1_sim_eq_hold
+            name: Sim Eq Hold
+          - entity: binary_sensor.yambms_1_sim_eq_active
+            name: Sim Eq Active
+          - type: weblink
+            url: >-
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+            name: README
+            icon: mdi:book-open-variant
   - title: Diagnostic
     cards:
       - type: entity-filter

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -520,15 +520,15 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.yambms_1_sim_equalizing
+          - entity: switch.sim_equalizing_1_sim_equalizing
             name: Sim Equalizing
-          - entity: switch.yambms_1_force_equalizing
+          - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.yambms_1_sim_eq_offset
+          - entity: number.sim_equalizing_1_sim_eq_offset
             name: Sim Eq Offset
-          - entity: number.yambms_1_sim_eq_hold
+          - entity: number.sim_equalizing_1_sim_eq_hold
             name: Sim Eq Hold
-          - entity: binary_sensor.yambms_1_sim_eq_active
+          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink
             url: >-

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -524,6 +524,8 @@ views:
             name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
+          - entity: number.sim_equalizing_1_max_run_time
+            name: Max Run Time
           - entity: number.sim_equalizing_1_balance_starting_voltage
             name: Start Balance V
           - entity: number.sim_equalizing_1_balance_sleep_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -517,28 +517,28 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Sim Eq
+        title: Fake Balancer
         show_header_toggle: false
         entities:
-          - entity: switch.sim_eq_1_enable
+          - entity: switch.fake_balancer_1_enable
             name: Enable
-          - entity: switch.sim_eq_1_force
+          - entity: switch.fake_balancer_1_force
             name: Force
-          - entity: number.sim_eq_1_max_run_time
+          - entity: number.fake_balancer_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_eq_1_balance_starting_voltage
+          - entity: number.fake_balancer_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_eq_1_balance_sleep_voltage
+          - entity: number.fake_balancer_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_eq_1_balance_trigger_voltage
+          - entity: number.fake_balancer_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_eq_1_balance_stop_diff_voltage
+          - entity: number.fake_balancer_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_eq_1_active
+          - entity: binary_sensor.fake_balancer_1_active
             name: Active
           - type: weblink
             url: >-
-              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing
+              https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#fake-balancer
             name: README
             icon: mdi:book-open-variant
   - title: Diagnostic

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -520,8 +520,8 @@ views:
         title: Simulate Equalizing
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_sim_equalizing
-            name: Sim Equalizing
+          - entity: switch.sim_equalizing_1_enable_sim_equalizing
+            name: Enable Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
           - entity: number.sim_equalizing_1_balance_starting_voltage

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -524,10 +524,14 @@ views:
             name: Sim Equalizing
           - entity: switch.sim_equalizing_1_force_equalizing
             name: Force Equalizing
-          - entity: number.sim_equalizing_1_sim_eq_offset
-            name: Sim Eq Offset
-          - entity: number.sim_equalizing_1_sim_eq_hold
-            name: Sim Eq Hold
+          - entity: number.sim_equalizing_1_balance_starting_voltage
+            name: Start Balance V
+          - entity: number.sim_equalizing_1_balance_sleep_voltage
+            name: Stop Balance V
+          - entity: number.sim_equalizing_1_balance_trigger_voltage
+            name: Start Delta V
+          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+            name: Stop Delta V
           - entity: binary_sensor.sim_equalizing_1_sim_eq_active
             name: Sim Eq Active
           - type: weblink

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_without_BMS.yaml
@@ -517,25 +517,25 @@ views:
             icon: mdi:book-open-variant
         title: YamBMS - Auto EOC
       - type: entities
-        title: Simulate Equalizing
+        title: Sim Eq
         show_header_toggle: false
         entities:
-          - entity: switch.sim_equalizing_1_enable_sim_equalizing
-            name: Enable Sim Equalizing
-          - entity: switch.sim_equalizing_1_force_equalizing
-            name: Force Equalizing
-          - entity: number.sim_equalizing_1_max_run_time
+          - entity: switch.sim_eq_1_enable
+            name: Enable
+          - entity: switch.sim_eq_1_force
+            name: Force
+          - entity: number.sim_eq_1_max_run_time
             name: Max Run Time
-          - entity: number.sim_equalizing_1_balance_starting_voltage
+          - entity: number.sim_eq_1_balance_starting_voltage
             name: Start Balance V
-          - entity: number.sim_equalizing_1_balance_sleep_voltage
+          - entity: number.sim_eq_1_balance_sleep_voltage
             name: Stop Balance V
-          - entity: number.sim_equalizing_1_balance_trigger_voltage
+          - entity: number.sim_eq_1_balance_trigger_voltage
             name: Start Delta V
-          - entity: number.sim_equalizing_1_balance_stop_diff_voltage
+          - entity: number.sim_eq_1_balance_stop_diff_voltage
             name: Stop Delta V
-          - entity: binary_sensor.sim_equalizing_1_sim_eq_active
-            name: Sim Eq Active
+          - entity: binary_sensor.sim_eq_1_active
+            name: Active
           - type: weblink
             url: >-
               https://github.com/Sleeper85/esphome-yambms/blob/main/documents/README/YamBMS_functions.md#simulate-equalizing

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -426,6 +426,52 @@ The `Deye` inverter sends an ACK `0x305` in response to the reception of a CAN f
 
 ![Image](../../images/YamBMS_CANBUS_Status.png "YamBMS_CANBUS_Status")
 
+## Auto CCL Current Taper
+
+When to use: Your inverter does not charge accurately to the configured `Bulk voltage` — it may stop short (e.g. bulk − `0.5V`) or overshoot (e.g. bulk + `0.2V` to `0.5V`). Current Taper reduces `Requested Charge Current (CCL)` so the pack reaches bulk cleanly and stays from rising much above it.
+
+For undershoot, raise `Inverter Offset V.` enough that the inverter keeps charging until pack voltage can reach bulk. Current Taper then limits current so voltage does not climb past bulk once you get there.
+
+This optional Auto CCL package (`yambms_auto_ccl_current_taper.yaml`) participates in the Auto CCL STEP pipeline. From the knee voltage to `Bulk voltage`, CCL is reduced along a curve from a starting C-rate to an ending C-rate (both × `Battery Capacity`). How early the taper starts and how low it goes at bulk are configurable — taper only enough to prevent overshoot, or continue down toward near zero. Knee Voltage min/max are set at boot from `cell count × chemistry` (same pattern as `Bulk voltage`); the 16S LFP placeholder default is `54.4V`.
+
+By default the taper is linear with pack voltage. `Auto CCL CT Curve Exp` changes the shape: higher values taper faster early and leave a longer tail; lower values delay the taper and drop more sharply near bulk. Linear or near-linear usually works best.
+
+> [!IMPORTANT]
+> Unlike stock `Auto CCL` (max cell vs BMS `OVP`), Current Taper uses **pack voltage** vs a user knee and YamBMS `Bulk voltage`.
+
+Behaviour:
+
+1. Below `Auto CCL CT Knee Voltage`: no reduction (inactive).
+2. From knee to bulk: CCL follows the curve from `Knee C-Rate × Battery Capacity` down to `Bulk C-Rate × Battery Capacity`.
+3. At first bulk touch: CCL drops to `Auto CCL CT Balance Current` (default `2A`) and holds there so pack voltage does not keep climbing; a non-zero value is used because some inverters ignore `0A`.
+4. After EOC (`var_eoc`): CCL goes to `0A`.
+5. Session ends when pack voltage falls `0.2V` below the knee (hysteresis), then the curve can start again on the next charge.
+
+If `Knee Voltage` is set within `0.2V` of `Bulk voltage` (or above it), the function is a no-op until the knee is lowered — this avoids jumping straight to the balance-current floor when the knee/bulk window is invalid.
+
+Configuration options:
+
+- `Auto CCL CT`: Enables or disables the taper function.
+- `Auto CCL CT Knee Voltage`: Pack voltage where tapering starts (boot-scaled to pack chemistry/cell count; 16S LFP placeholder default `54.4V`).
+- `Auto CCL CT Knee C-Rate`: C-rate at the knee; multiplied by `Battery Capacity` for the starting CCL (default `0.125C`).
+- `Auto CCL CT Bulk C-Rate`: C-rate at bulk (default `0.03C`).
+- `Auto CCL CT Balance Current`: CCL while latched at bulk (default `2A`). Keep this above `0.005C × Battery Capacity` (the Cut-Off current deadband) so the classic compensated Cut-Off path stays available; at or below that band, charge completion relies on the *fully charged at rest* signature only.
+- `Auto CCL CT Curve Exp`: Curve shape. `1.0` is linear; above `1` drops faster early then a longer tail; below `1` delays the taper and sharpens near bulk (range `0.5`–`2.0`, default `1.0`).
+
+Diagnostic sensors:
+
+- `Auto CCL CT Voltage`: Smoothed pack voltage used by the curve.
+- `Auto CCL CT Knee Amps` / `Auto CCL CT Bulk Amps`: Capacity × C-rate targets.
+- `Auto CCL CT Delta`: Pipeline reduction applied (≤ `0A`).
+
+Notes:
+
+- Requires a correct `Battery Capacity`.
+- Can run alongside other Auto CCL functions; the pipeline takes the most restrictive reduction.
+- Pair with `Inverter Offset V.` when the inverter undershoots bulk without an offset. If you taper CCL toward near zero, an offset is usually needed as well.
+- If you taper toward near zero, you may also need a higher cut-off voltage or a longer cut-off timer to avoid an early `Cut-Off`.
+- With Float enabled: after EOC, Current Taper holds CCL at `0A` while `var_eoc` is true and the session is still active, so Float cannot deliver current until pack voltage falls below `knee − 0.2V`. That is usually a short transient and matches the "CVL not trusted" approach, but Float users should expect it.
+
 ## Simulate Equalizing
 
 Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open while cells balance. This optional package **infers** Equalizing from that BMS's max/min cell voltage using the same threshold names as Enerkey / Heltec / JK balancers. It **cooperates** with a real balancer on the same `bms_id`:

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -508,10 +508,11 @@ Uses its own `sim_eq_${bms_id}` device/IDs so they do not collide with `balancer
 Behaviour:
 
 1. `Enable Sim Equalizing` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
-2. `Force Equalizing`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference.
-3. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when sim is idle.
+2. `Force Equalizing`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference. Cleared automatically when **Max Run Time** expires.
+3. `Max Run Time`: caps how long sim Equalizing (inferred or force) may stay asserted (default `30` min, max `360`). After expiry, sim drops Equalizing and will not re-enter until cells fall below the enter thresholds (or Force is used again after re-arm). Use this for longer weekly top-balance without changing the compile-time YamBMS **EOC timer**.
+4. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when sim is idle.
 
-While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The **EOC timer** is still the hard charge-end ceiling — no separate max-hold is needed when EOC is enabled.
+While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The YamBMS **EOC timer** remains a separate compile-time charge-end ceiling; **Max Run Time** is the runtime knob for how long *this sim* may hold Equalizing.
 
 > [!NOTE]
 > These numbers are **inference** thresholds for YamBMS, not writes to a hardware balancer. Match them to how your BMS/balancer actually behaves. This only signals Equalizing — it does not move charge between cells.
@@ -520,6 +521,7 @@ Configuration options:
 
 - `Enable Sim Equalizing`: Enables cell-threshold inference.
 - `Force Equalizing`: Forces Equalizing while on (automation-friendly).
+- `Max Run Time`: Maximum continuous sim Equalizing in minutes (slider, `1`–`360`, default `30`).
 - `Balance Starting Voltage`: Max-cell floor to enter (default `3.40V`).
 - `Balance Sleep Voltage`: Max-cell floor to exit (default `3.20V`).
 - `Balance Trigger Voltage`: Cell delta to enter (default `0.015V`).

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -437,9 +437,11 @@ packages:
   sim_equalizing: !include
     file: packages/balancer/balancer_simulate_equalizing.yaml
     vars:
-      bms_id: '1'                      # which BMS receives the override
-      balancer_name: 'Sim Equalizing 1'  # HA device / entity prefix
+      bms_id: '1'                        # which BMS override to drive
+      sim_eq_name: 'Sim Equalizing 1'    # HA device name (uses sim_eq_1_* ids)
 ```
+
+Uses its own `sim_eq_${bms_id}` device/IDs so it does not collide with a real balancer package (e.g. Enerkey) on `balancer_${bms_id}`. Do not enable it on a BMS whose external balancer is already driving `var_ext_balancer_*`.
 
 Behaviour:
 

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -428,27 +428,44 @@ The `Deye` inverter sends an ACK `0x305` in response to the reception of a CAN f
 
 ## Simulate Equalizing
 
-Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open for cell balancing. This optional package acts as a **virtual balancer** and asserts Equalizing through the standard BMS external-balancer override.
+Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open for cell balancing. This optional package acts as a **virtual balancer** and asserts Equalizing through the standard BMS external-balancer override. It **cooperates** with a real balancer (Enerkey / Heltec / modbus client) on the same `bms_id`:
+
+`Equalizing = (real balancer balancing) OR (sim auto / force)`
 
 Package: `packages/balancer/balancer_simulate_equalizing.yaml`
 
+Requires `balancer${bms_id}_equalizing` and `balancer${bms_id}_online_status` from a real balancer package, or the stub below if you have no hardware balancer on that BMS.
+
 ```YAML
 packages:
+  # Real balancer (example) — already provides the IDs sim ORs with
+  # balancer1: !include
+  #   file: packages/balancer/balancer_modbus_client.yaml
+  #   vars: { bms_id: '1', balancer_name: 'Enerkey 1', ... }
+
   sim_equalizing: !include
     file: packages/balancer/balancer_simulate_equalizing.yaml
     vars:
       bms_id: '1'                        # which BMS override to drive
       sim_eq_name: 'Sim Equalizing 1'    # HA device name (uses sim_eq_1_* ids)
+
+  # Only if there is NO real balancer package for this bms_id:
+  # balancer_stub1: !include
+  #   file: packages/balancer/balancer_equalizing_stub.yaml
+  #   vars:
+  #     bms_id: '1'
+  #     balancer_name: 'Balancer Stub 1'
 ```
 
-Uses its own `sim_eq_${bms_id}` device/IDs so it does not collide with a real balancer package (e.g. Enerkey) on `balancer_${bms_id}`. Do not enable it on a BMS whose external balancer is already driving `var_ext_balancer_*`.
+Uses its own `sim_eq_${bms_id}` device/IDs so entity IDs do not collide with `balancer_${bms_id}`. Each tick merges into `var_ext_balancer_*` and never clears online/equalizing out from under a live real balancer.
 
 Behaviour:
 
 1. `Sim Equalizing`: when pack voltage reaches `Bulk − Sim Eq Offset` (default `0.05V`), assert Equalizing for `Sim Eq Hold` minutes (default `15`). Re-arms after voltage falls `0.05V` below that threshold.
 2. `Force Equalizing`: manual / Home Assistant automation force (e.g. once a week). While on, Equalizing stays asserted.
+3. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when sim is idle.
 
-While active, YamBMS bank **Equalizing state** is true, so Cut-Off holds CVL (cut-off timer paused) the same way it would for a real balancer report. The override is released when inactive so a real external balancer on that BMS is not permanently masked.
+While Equalizing is true (sim and/or real), YamBMS bank **Equalizing state** is true, so Cut-Off holds CVL (cut-off timer paused).
 
 > [!NOTE]
 > Keep the **EOC timer** longer than `Sim Eq Hold` (or disable it) if you want the full hold window. This only signals Equalizing — it does not move charge between cells.
@@ -462,7 +479,7 @@ Configuration options:
 
 Diagnostic sensors:
 
-- `Sim Eq Active`: True while simulated / forced Equalizing is asserted.
+- `Sim Eq Active`: True while simulated / forced Equalizing is asserted (does not include real-balancer-only periods).
 
 ## Diagnostic
 

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -474,7 +474,7 @@ Notes:
 
 ## Fake Balancer
 
-Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open while cells balance. This optional package **infers** Equalizing from that BMS's max/min cell voltage using the same threshold names as Enerkey / Heltec / JK balancers. It **cooperates** with a real balancer on the same `bms_id`:
+Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open while cells balance. This optional package **infers** Equalizing from that BMS's max/min cell voltage using the same threshold names as Enerkey / Heltec / JK balancers. It is for **top-of-charge balancing only** (Start/Sleep near max cell charge voltage — never near the bottom of the SoC window). It **cooperates** with a real balancer on the same `bms_id`:
 
 `Equalizing = (real balancer balancing) OR (inferred) OR (force)`
 
@@ -507,7 +507,7 @@ Uses its own `fake_bal_${bms_id}` device/IDs so they do not collide with `balanc
 
 Behaviour:
 
-1. `Enable` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
+1. `Enable` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`. Sleep Voltage alone ends balancing immediately.
 2. `Force`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference. Cleared automatically when **Max Run Time** expires.
 3. `Max Run Time`: caps how long fake Equalizing (inferred or force) may stay asserted (default `30` min, max `360`). After expiry, Fake Balancer drops Equalizing and will not re-enter until cells fall below the enter thresholds (or Force is used again after re-arm). Use this for longer weekly top-balance without changing the compile-time YamBMS **EOC timer**.
 4. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when Fake Balancer is idle.
@@ -515,15 +515,15 @@ Behaviour:
 While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The YamBMS **EOC timer** remains a separate compile-time charge-end ceiling; **Max Run Time** is the runtime knob for how long *Fake Balancer* may hold Equalizing.
 
 > [!NOTE]
-> These numbers are **inference** thresholds for YamBMS, not writes to a hardware balancer. Match them to how your BMS/balancer actually behaves. This only signals Equalizing — it does not move charge between cells.
+> These numbers are **inference** thresholds for YamBMS, not writes to a hardware balancer. Match them to how your BMS/balancer actually behaves at the **top of charge**. This only signals Equalizing — it does not move charge between cells. Defaults are LFP (`3.45` / `3.42`); Li-ion and LTO need different top-band values, but still near max charge — not mid or low SoC.
 
 Configuration options:
 
 - `Enable`: Enables cell-threshold inference.
 - `Force`: Forces Equalizing while on (automation-friendly).
 - `Max Run Time`: Maximum continuous sim Equalizing in minutes (slider, `1`–`360`, default `30`).
-- `Balance Starting Voltage`: Max-cell floor to enter (default `3.40V`).
-- `Balance Sleep Voltage`: Max-cell floor to exit (default `3.20V`).
+- `Balance Starting Voltage`: Max-cell floor to enter (default `3.45V`, LFP top).
+- `Balance Sleep Voltage`: Max-cell floor to exit (default `3.42V`, LFP top). Must sit just below Start.
 - `Balance Trigger Voltage`: Cell delta to enter (default `0.015V`).
 - `Balance Stop Diff Voltage`: Cell delta to exit (default `0.005V`).
 

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -437,7 +437,8 @@ packages:
   sim_equalizing: !include
     file: packages/balancer/balancer_simulate_equalizing.yaml
     vars:
-      bms_id: '1'   # which BMS receives the override (YamBMS BMS ids start at 1)
+      bms_id: '1'                      # which BMS receives the override
+      balancer_name: 'Sim Equalizing 1'  # HA device / entity prefix
 ```
 
 Behaviour:

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -472,28 +472,28 @@ Notes:
 - If you taper toward near zero, you may also need a higher cut-off voltage or a longer cut-off timer to avoid an early `Cut-Off`.
 - With Float enabled: after EOC, Current Taper holds CCL at `0A` while `var_eoc` is true and the session is still active, so Float cannot deliver current until pack voltage falls below `knee − 0.2V`. That is usually a short transient and matches the "CVL not trusted" approach, but Float users should expect it.
 
-## Simulate Equalizing
+## Fake Balancer
 
 Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open while cells balance. This optional package **infers** Equalizing from that BMS's max/min cell voltage using the same threshold names as Enerkey / Heltec / JK balancers. It **cooperates** with a real balancer on the same `bms_id`:
 
 `Equalizing = (real balancer balancing) OR (inferred) OR (force)`
 
-Package: `packages/balancer/balancer_simulate_equalizing.yaml`
+Package: `packages/balancer/balancer_fake_balancer.yaml`
 
 Requires `bms${bms_id}_max_cell_voltage` / `_min_cell_voltage`, plus `balancer${bms_id}_equalizing` and `_online_status` from a real balancer package (or `balancer_equalizing_stub.yaml`).
 
 ```YAML
 packages:
-  # Real balancer (example) — already provides the IDs sim ORs with
+  # Real balancer (example) — already provides the IDs Fake Balancer ORs with
   # balancer1: !include
   #   file: packages/balancer/balancer_modbus_client.yaml
   #   vars: { bms_id: '1', balancer_name: 'Enerkey 1', ... }
 
-  sim_eq: !include
-    file: packages/balancer/balancer_simulate_equalizing.yaml
+  fake_balancer: !include
+    file: packages/balancer/balancer_fake_balancer.yaml
     vars:
-      bms_id: '1'                        # which BMS cells + override to drive
-      sim_eq_name: 'Sim Eq 1'            # HA device name → entity_id prefix sim_eq_1_
+      bms_id: '1'                              # which BMS cells + override to drive
+      fake_bal_name: 'Fake Balancer 1'         # HA device name → entity_id prefix fake_balancer_1_
 
   # Only if there is NO real balancer package for this bms_id:
   # balancer_stub1: !include
@@ -503,16 +503,16 @@ packages:
   #     balancer_name: 'Balancer Stub 1'
 ```
 
-Uses its own `sim_eq_${bms_id}` device/IDs so they do not collide with `balancer_${bms_id}`. Each tick merges into `var_ext_balancer_*` and never clears online/equalizing out from under a live real balancer.
+Uses its own `fake_bal_${bms_id}` device/IDs so they do not collide with `balancer_${bms_id}`. Each tick merges into `var_ext_balancer_*` and never clears online/equalizing out from under a live real balancer.
 
 Behaviour:
 
 1. `Enable` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
 2. `Force`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference. Cleared automatically when **Max Run Time** expires.
-3. `Max Run Time`: caps how long sim Equalizing (inferred or force) may stay asserted (default `30` min, max `360`). After expiry, sim drops Equalizing and will not re-enter until cells fall below the enter thresholds (or Force is used again after re-arm). Use this for longer weekly top-balance without changing the compile-time YamBMS **EOC timer**.
-4. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when sim is idle.
+3. `Max Run Time`: caps how long fake Equalizing (inferred or force) may stay asserted (default `30` min, max `360`). After expiry, Fake Balancer drops Equalizing and will not re-enter until cells fall below the enter thresholds (or Force is used again after re-arm). Use this for longer weekly top-balance without changing the compile-time YamBMS **EOC timer**.
+4. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when Fake Balancer is idle.
 
-While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The YamBMS **EOC timer** remains a separate compile-time charge-end ceiling; **Max Run Time** is the runtime knob for how long *this sim* may hold Equalizing.
+While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The YamBMS **EOC timer** remains a separate compile-time charge-end ceiling; **Max Run Time** is the runtime knob for how long *Fake Balancer* may hold Equalizing.
 
 > [!NOTE]
 > These numbers are **inference** thresholds for YamBMS, not writes to a hardware balancer. Match them to how your BMS/balancer actually behaves. This only signals Equalizing — it does not move charge between cells.

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -520,8 +520,8 @@ Configuration options:
 
 - `Enable Sim Equalizing`: Enables cell-threshold inference.
 - `Force Equalizing`: Forces Equalizing while on (automation-friendly).
-- `Balance Starting Voltage`: Max-cell floor to enter (default `3.400V`).
-- `Balance Sleep Voltage`: Max-cell floor to exit (default `3.200V`).
+- `Balance Starting Voltage`: Max-cell floor to enter (default `3.40V`).
+- `Balance Sleep Voltage`: Max-cell floor to exit (default `3.20V`).
 - `Balance Trigger Voltage`: Cell delta to enter (default `0.015V`).
 - `Balance Stop Diff Voltage`: Cell delta to exit (default `0.005V`).
 

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -426,6 +426,41 @@ The `Deye` inverter sends an ACK `0x305` in response to the reception of a CAN f
 
 ![Image](../../images/YamBMS_CANBUS_Status.png "YamBMS_CANBUS_Status")
 
+## Simulate Equalizing
+
+Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open for cell balancing. This optional package acts as a **virtual balancer** and asserts Equalizing through the standard BMS external-balancer override.
+
+Package: `packages/balancer/balancer_simulate_equalizing.yaml`
+
+```YAML
+packages:
+  sim_equalizing: !include
+    file: packages/balancer/balancer_simulate_equalizing.yaml
+    vars:
+      bms_id: '1'   # which BMS receives the override (YamBMS BMS ids start at 1)
+```
+
+Behaviour:
+
+1. `Sim Equalizing`: when pack voltage reaches `Bulk − Sim Eq Offset` (default `0.05V`), assert Equalizing for `Sim Eq Hold` minutes (default `15`). Re-arms after voltage falls `0.05V` below that threshold.
+2. `Force Equalizing`: manual / Home Assistant automation force (e.g. once a week). While on, Equalizing stays asserted.
+
+While active, YamBMS bank **Equalizing state** is true, so Cut-Off holds CVL (cut-off timer paused) the same way it would for a real balancer report. The override is released when inactive so a real external balancer on that BMS is not permanently masked.
+
+> [!NOTE]
+> Keep the **EOC timer** longer than `Sim Eq Hold` (or disable it) if you want the full hold window. This only signals Equalizing — it does not move charge between cells.
+
+Configuration options:
+
+- `Sim Equalizing`: Enables automatic Equalizing near bulk.
+- `Force Equalizing`: Forces Equalizing while on (automation-friendly).
+- `Sim Eq Offset`: Volts below `Bulk` where auto Equalizing starts (default `0.05V`).
+- `Sim Eq Hold`: Minutes to hold auto Equalizing (default `15`).
+
+Diagnostic sensors:
+
+- `Sim Eq Active`: True while simulated / forced Equalizing is asserted.
+
 ## Diagnostic
 
 Useful information for troubleshooting.

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -428,13 +428,13 @@ The `Deye` inverter sends an ACK `0x305` in response to the reception of a CAN f
 
 ## Simulate Equalizing
 
-Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open for cell balancing. This optional package acts as a **virtual balancer** and asserts Equalizing through the standard BMS external-balancer override. It **cooperates** with a real balancer (Enerkey / Heltec / modbus client) on the same `bms_id`:
+Some BMS (e.g. Seplos) never report a balancing/equalizing flag, so YamBMS cannot hold **Cut-Off** open while cells balance. This optional package **infers** Equalizing from that BMS's max/min cell voltage using the same threshold names as Enerkey / Heltec / JK balancers. It **cooperates** with a real balancer on the same `bms_id`:
 
-`Equalizing = (real balancer balancing) OR (sim auto / force)`
+`Equalizing = (real balancer balancing) OR (inferred) OR (force)`
 
 Package: `packages/balancer/balancer_simulate_equalizing.yaml`
 
-Requires `balancer${bms_id}_equalizing` and `balancer${bms_id}_online_status` from a real balancer package, or the stub below if you have no hardware balancer on that BMS.
+Requires `bms${bms_id}_max_cell_voltage` / `_min_cell_voltage`, plus `balancer${bms_id}_equalizing` and `_online_status` from a real balancer package (or `balancer_equalizing_stub.yaml`).
 
 ```YAML
 packages:
@@ -446,7 +446,7 @@ packages:
   sim_equalizing: !include
     file: packages/balancer/balancer_simulate_equalizing.yaml
     vars:
-      bms_id: '1'                        # which BMS override to drive
+      bms_id: '1'                        # which BMS cells + override to drive
       sim_eq_name: 'Sim Equalizing 1'    # HA device name (uses sim_eq_1_* ids)
 
   # Only if there is NO real balancer package for this bms_id:
@@ -457,29 +457,31 @@ packages:
   #     balancer_name: 'Balancer Stub 1'
 ```
 
-Uses its own `sim_eq_${bms_id}` device/IDs so entity IDs do not collide with `balancer_${bms_id}`. Each tick merges into `var_ext_balancer_*` and never clears online/equalizing out from under a live real balancer.
+Uses its own `sim_eq_${bms_id}` device/IDs so they do not collide with `balancer_${bms_id}`. Each tick merges into `var_ext_balancer_*` and never clears online/equalizing out from under a live real balancer.
 
 Behaviour:
 
-1. `Sim Equalizing`: when pack voltage reaches `Bulk − Sim Eq Offset` (default `0.05V`), assert Equalizing for `Sim Eq Hold` minutes (default `15`). Re-arms after voltage falls `0.05V` below that threshold.
-2. `Force Equalizing`: manual / Home Assistant automation force (e.g. once a week). While on, Equalizing stays asserted.
+1. `Sim Equalizing` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
+2. `Force Equalizing`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference.
 3. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when sim is idle.
 
-While Equalizing is true (sim and/or real), YamBMS bank **Equalizing state** is true, so Cut-Off holds CVL (cut-off timer paused).
+While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The **EOC timer** is still the hard charge-end ceiling — no separate max-hold is needed when EOC is enabled.
 
 > [!NOTE]
-> Keep the **EOC timer** longer than `Sim Eq Hold` (or disable it) if you want the full hold window. This only signals Equalizing — it does not move charge between cells.
+> These numbers are **inference** thresholds for YamBMS, not writes to a hardware balancer. Match them to how your BMS/balancer actually behaves. This only signals Equalizing — it does not move charge between cells.
 
 Configuration options:
 
-- `Sim Equalizing`: Enables automatic Equalizing near bulk.
+- `Sim Equalizing`: Enables cell-threshold inference.
 - `Force Equalizing`: Forces Equalizing while on (automation-friendly).
-- `Sim Eq Offset`: Volts below `Bulk` where auto Equalizing starts (default `0.05V`).
-- `Sim Eq Hold`: Minutes to hold auto Equalizing (default `15`).
+- `Balance Starting Voltage`: Max-cell floor to enter (default `3.400V`).
+- `Balance Sleep Voltage`: Max-cell floor to exit (default `3.200V`).
+- `Balance Trigger Voltage`: Cell delta to enter (default `0.015V`).
+- `Balance Stop Diff Voltage`: Cell delta to exit (default `0.005V`).
 
 Diagnostic sensors:
 
-- `Sim Eq Active`: True while simulated / forced Equalizing is asserted (does not include real-balancer-only periods).
+- `Sim Eq Active`: True while inferred / forced Equalizing is asserted (does not include real-balancer-only periods).
 
 ## Diagnostic
 

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -489,11 +489,11 @@ packages:
   #   file: packages/balancer/balancer_modbus_client.yaml
   #   vars: { bms_id: '1', balancer_name: 'Enerkey 1', ... }
 
-  sim_equalizing: !include
+  sim_eq: !include
     file: packages/balancer/balancer_simulate_equalizing.yaml
     vars:
       bms_id: '1'                        # which BMS cells + override to drive
-      sim_eq_name: 'Sim Equalizing 1'    # HA device name (uses sim_eq_1_* ids)
+      sim_eq_name: 'Sim Eq 1'            # HA device name → entity_id prefix sim_eq_1_
 
   # Only if there is NO real balancer package for this bms_id:
   # balancer_stub1: !include
@@ -507,8 +507,8 @@ Uses its own `sim_eq_${bms_id}` device/IDs so they do not collide with `balancer
 
 Behaviour:
 
-1. `Enable Sim Equalizing` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
-2. `Force Equalizing`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference. Cleared automatically when **Max Run Time** expires.
+1. `Enable` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
+2. `Force`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference. Cleared automatically when **Max Run Time** expires.
 3. `Max Run Time`: caps how long sim Equalizing (inferred or force) may stay asserted (default `30` min, max `360`). After expiry, sim drops Equalizing and will not re-enter until cells fall below the enter thresholds (or Force is used again after re-arm). Use this for longer weekly top-balance without changing the compile-time YamBMS **EOC timer**.
 4. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when sim is idle.
 
@@ -519,8 +519,8 @@ While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The YamBMS *
 
 Configuration options:
 
-- `Enable Sim Equalizing`: Enables cell-threshold inference.
-- `Force Equalizing`: Forces Equalizing while on (automation-friendly).
+- `Enable`: Enables cell-threshold inference.
+- `Force`: Forces Equalizing while on (automation-friendly).
 - `Max Run Time`: Maximum continuous sim Equalizing in minutes (slider, `1`–`360`, default `30`).
 - `Balance Starting Voltage`: Max-cell floor to enter (default `3.40V`).
 - `Balance Sleep Voltage`: Max-cell floor to exit (default `3.20V`).
@@ -529,7 +529,7 @@ Configuration options:
 
 Diagnostic sensors:
 
-- `Sim Eq Active`: True while inferred / forced Equalizing is asserted (does not include real-balancer-only periods).
+- `Active`: True while inferred / forced Equalizing is asserted (does not include real-balancer-only periods).
 
 ## Diagnostic
 

--- a/documents/README/YamBMS_functions.md
+++ b/documents/README/YamBMS_functions.md
@@ -507,7 +507,7 @@ Uses its own `sim_eq_${bms_id}` device/IDs so they do not collide with `balancer
 
 Behaviour:
 
-1. `Sim Equalizing` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
+1. `Enable Sim Equalizing` (auto): enter when `max_cell >= Balance Starting Voltage` **and** `(max − min) >= Balance Trigger Voltage`. Exit when `max_cell < Balance Sleep Voltage` **or** `(max − min) <= Balance Stop Diff Voltage`.
 2. `Force Equalizing`: manual / HA automation force (e.g. weekly top-balance) when cell conditions would not yet trigger inference.
 3. Real balancer: if `balancer${bms_id}_equalizing` is true, Equalizing stays asserted even when sim is idle.
 
@@ -518,7 +518,7 @@ While Equalizing is true, Cut-Off holds CVL (cut-off timer paused). The **EOC ti
 
 Configuration options:
 
-- `Sim Equalizing`: Enables cell-threshold inference.
+- `Enable Sim Equalizing`: Enables cell-threshold inference.
 - `Force Equalizing`: Forces Equalizing while on (automation-friendly).
 - `Balance Starting Voltage`: Max-cell floor to enter (default `3.400V`).
 - `Balance Sleep Voltage`: Max-cell floor to exit (default `3.200V`).

--- a/packages/balancer/balancer_equalizing_stub.yaml
+++ b/packages/balancer/balancer_equalizing_stub.yaml
@@ -1,0 +1,40 @@
+# Updated : 2026.07.17
+# Version : 1.0.0
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# Minimal stub so balancer_simulate_equalizing.yaml can compile/OR when no real
+# external balancer package is included for this bms_id.
+# Do NOT include this together with Enerkey/Heltec/modbus balancer on the same bms_id.
+
+# Include:
+#   balancer_stub: !include
+#     file: packages/balancer/balancer_equalizing_stub.yaml
+#     vars:
+#       bms_id: '1'
+#       balancer_name: 'Balancer Stub 1'
+
+packages:
+  sub_device: !include balancer_base_sub_device.yaml
+
+binary_sensor:
+  - platform: template
+    id: balancer${bms_id}_online_status
+    device_id: balancer_${bms_id}
+    name: "Online status"
+    trigger_on_initial_state: true
+    lambda: return false;
+    on_state:
+      then:
+        - lambda: id(bms${bms_id}_var_ext_balancer_online) = x;
+
+  - platform: template
+    id: balancer${bms_id}_equalizing
+    device_id: balancer_${bms_id}
+    name: "balancing"
+    trigger_on_initial_state: true
+    lambda: return false;
+    on_state:
+      then:
+        - lambda: id(bms${bms_id}_var_ext_balancer_equalizing) = x;

--- a/packages/balancer/balancer_equalizing_stub.yaml
+++ b/packages/balancer/balancer_equalizing_stub.yaml
@@ -4,7 +4,7 @@
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
-# Minimal stub so balancer_simulate_equalizing.yaml can compile/OR when no real
+# Minimal stub so balancer_fake_balancer.yaml can compile/OR when no real
 # external balancer package is included for this bms_id.
 # Do NOT include this together with Enerkey/Heltec/modbus balancer on the same bms_id.
 

--- a/packages/balancer/balancer_fake_balancer.yaml
+++ b/packages/balancer/balancer_fake_balancer.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.07.17
-# Version : 1.2.3
+# Updated : 2026.07.19
+# Version : 1.3.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
 
 #--------------------------------------------------------------------------------------------
-# Simulate Equalizing (virtual balancer)
+# Fake Balancer (virtual Equalizing)
 #
 # Purpose:
 #   Infer Equalizing for a BMS that balances but never reports a balancing flag.
@@ -27,36 +27,36 @@
 #   Equalizing = (real balancer balancing) OR (inferred / force).
 #
 # Include (one BMS id — YamBMS BMS ids start at 1):
-#   sim_eq: !include
-#     file: packages/balancer/balancer_simulate_equalizing.yaml
+#   fake_balancer: !include
+#     file: packages/balancer/balancer_fake_balancer.yaml
 #     vars:
 #       bms_id: '1'
-#       sim_eq_name: 'Sim Eq 1'
+#       fake_bal_name: 'Fake Balancer 1'
 #
 # Requires:
 #   - bms${bms_id}_max_cell_voltage / _min_cell_voltage
 #   - balancer${bms_id}_equalizing and balancer${bms_id}_online_status
 #     (Enerkey/Heltec/modbus balancer package, or balancer_equalizing_stub.yaml)
 #
-# IDs use sim_eq_${bms_id} / sim_eq${bms_id}_* so they do not collide with
+# IDs use fake_bal_${bms_id} / fake_bal${bms_id}_* so they do not collide with
 # balancer_${bms_id} used by real balancer packages.
 #
 # Contract:
-#   - Sets sim_eq${bms_id}_var_asserting; !extends bms equalizing to OR it in
+#   - Sets fake_bal${bms_id}_var_asserting; !extends bms equalizing to OR it in
 #     (Enerkey modbus also writes var_ext_balancer_* and would wipe a plain write)
 #   - Still updates var_ext_balancer_* for stub / no-hardware-balancer setups
-#   - Max Run Time caps how long sim (inferred/force) may assert Equalizing;
+#   - Max Run Time caps how long fake (inferred/force) may assert Equalizing;
 #     YamBMS EOC timer is a separate compile-time charge-end ceiling
 #--------------------------------------------------------------------------------------------
 
 esphome:
   devices:
-    - id: sim_eq_${bms_id}
-      name: "${sim_eq_name}"
+    - id: fake_bal_${bms_id}
+      name: "${fake_bal_name}"
 
 globals:
-  # Sim wants Equalizing this tick (survives Enerkey overwriting var_ext_balancer_equalizing)
-  - id: sim_eq${bms_id}_var_asserting
+  # Fake Balancer wants Equalizing this tick (survives Enerkey overwriting var_ext_balancer_equalizing)
+  - id: fake_bal${bms_id}_var_asserting
     type: bool
     restore_value: no
     initial_value: 'false'
@@ -64,8 +64,8 @@ globals:
 switch:
   # Auto: infer Equalizing from this BMS's cell voltage + delta vs thresholds
   - platform: template
-    id: sim_eq${bms_id}_switch_sim_eq
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_switch_enable
+    device_id: fake_bal_${bms_id}
     name: "Enable"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
@@ -73,19 +73,19 @@ switch:
 
   # Manual / HA automation: force Equalizing while on (e.g. weekly top-balance)
   - platform: template
-    id: sim_eq${bms_id}_switch_force_eq
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_switch_force
+    device_id: fake_bal_${bms_id}
     name: "Force"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: config
 
 number:
-  # Cap continuous sim Equalizing (inferred or force). Runtime alternative to
+  # Cap continuous fake Equalizing (inferred or force). Runtime alternative to
   # raising the compile-time YamBMS EOC timer for longer weekly top-balance.
   - platform: template
-    id: sim_eq${bms_id}_max_run_time
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_max_run_time
+    device_id: fake_bal_${bms_id}
     name: "Max Run Time"
     unit_of_measurement: min
     min_value: 1
@@ -100,8 +100,8 @@ number:
 
   # Enter when max cell >= this (Enerkey: Balance Starting Voltage)
   - platform: template
-    id: sim_eq${bms_id}_balance_starting_voltage
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_balance_starting_voltage
+    device_id: fake_bal_${bms_id}
     name: "Balance Starting Voltage"
     unit_of_measurement: V
     device_class: voltage
@@ -117,8 +117,8 @@ number:
 
   # Exit when max cell < this (Enerkey: Balance Sleep Voltage)
   - platform: template
-    id: sim_eq${bms_id}_balance_sleep_voltage
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_balance_sleep_voltage
+    device_id: fake_bal_${bms_id}
     name: "Balance Sleep Voltage"
     unit_of_measurement: V
     device_class: voltage
@@ -134,8 +134,8 @@ number:
 
   # Enter when (max − min) >= this (Enerkey: Balance Trigger Voltage)
   - platform: template
-    id: sim_eq${bms_id}_balance_trigger_voltage
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_balance_trigger_voltage
+    device_id: fake_bal_${bms_id}
     name: "Balance Trigger Voltage"
     unit_of_measurement: V
     device_class: voltage
@@ -151,8 +151,8 @@ number:
 
   # Exit when (max − min) <= this (Enerkey: Balance Stop Diff Voltage)
   - platform: template
-    id: sim_eq${bms_id}_balance_stop_diff_voltage
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_balance_stop_diff_voltage
+    device_id: fake_bal_${bms_id}
     name: "Balance Stop Diff Voltage"
     unit_of_measurement: V
     device_class: voltage
@@ -167,17 +167,17 @@ number:
     icon: mdi:delta
 
 binary_sensor:
-  # OR sim into the BMS equalizing sensor (Enerkey on_state would otherwise clear it)
+  # OR fake into the BMS equalizing sensor (Enerkey on_state would otherwise clear it)
   - id: !extend bms${bms_id}_equalizing
     lambda: |-
-      const bool sim = id(sim_eq${bms_id}_var_asserting);
+      const bool fake = id(fake_bal${bms_id}_var_asserting);
       if (id(bms${bms_id}_var_ext_balancer_online))
-        return id(bms${bms_id}_var_ext_balancer_equalizing) || sim;
-      return id(bms${bms_id}_bms_equalizing).state || sim;
+        return id(bms${bms_id}_var_ext_balancer_equalizing) || fake;
+      return id(bms${bms_id}_bms_equalizing).state || fake;
 
   - platform: template
-    id: sim_eq${bms_id}_sim_eq_active
-    device_id: sim_eq_${bms_id}
+    id: fake_bal${bms_id}_active
+    device_id: fake_bal_${bms_id}
     name: "Active"
     entity_category: diagnostic
     icon: mdi:scale-balance
@@ -189,10 +189,10 @@ interval:
           static bool inferred = false;
           static bool run_expired = false;   // latched after Max Run Time until re-arm
           static bool prev_force = false;
-          static uint32_t started_ms = 0;    // when this sim assertion session began
+          static uint32_t started_ms = 0;    // when this fake assertion session began
 
-          const bool sim_en = id(sim_eq${bms_id}_switch_sim_eq).state;
-          bool force = id(sim_eq${bms_id}_switch_force_eq).state;
+          const bool fake_en = id(fake_bal${bms_id}_switch_enable).state;
+          bool force = id(fake_bal${bms_id}_switch_force).state;
 
           // Force rising edge starts a new timed session (weekly top-balance)
           if (force && !prev_force) {
@@ -203,11 +203,11 @@ interval:
 
           const float max_cell = id(bms${bms_id}_max_cell_voltage).state;
           const float min_cell = id(bms${bms_id}_min_cell_voltage).state;
-          const float start_v  = id(sim_eq${bms_id}_balance_starting_voltage).state;
-          const float sleep_v  = id(sim_eq${bms_id}_balance_sleep_voltage).state;
-          const float trig_v   = id(sim_eq${bms_id}_balance_trigger_voltage).state;
-          const float stop_dv  = id(sim_eq${bms_id}_balance_stop_diff_voltage).state;
-          const float max_run_min = id(sim_eq${bms_id}_max_run_time).state;
+          const float start_v  = id(fake_bal${bms_id}_balance_starting_voltage).state;
+          const float sleep_v  = id(fake_bal${bms_id}_balance_sleep_voltage).state;
+          const float trig_v   = id(fake_bal${bms_id}_balance_trigger_voltage).state;
+          const float stop_dv  = id(fake_bal${bms_id}_balance_stop_diff_voltage).state;
+          const float max_run_min = id(fake_bal${bms_id}_max_run_time).state;
 
           // Real balancer on this bms_id (Enerkey/Heltec/modbus client, or stub)
           const bool real_online = id(balancer${bms_id}_online_status).has_state()
@@ -221,7 +221,7 @@ interval:
           const bool below_enter = cells_ok
               && ((max_cell < start_v) || (delta < trig_v));
 
-          if (!sim_en) {
+          if (!fake_en) {
             inferred = false;
           } else if (cells_ok) {
             if (!inferred) {
@@ -233,15 +233,15 @@ interval:
             }
           }
 
-          bool sim_eq = force || inferred;
+          bool fake_eq = force || inferred;
 
-          // Max Run Time: cap continuous sim Equalizing (inferred or force)
-          if (!sim_eq) {
+          // Max Run Time: cap continuous fake Equalizing (inferred or force)
+          if (!fake_eq) {
             started_ms = 0;
             if (!force && below_enter)
               run_expired = false;
           } else if (run_expired) {
-            sim_eq = false;
+            fake_eq = false;
           } else {
             const uint32_t now = millis();
             if (started_ms == 0)
@@ -252,20 +252,20 @@ interval:
               inferred = false;
               started_ms = 0;
               if (force) {
-                id(sim_eq${bms_id}_switch_force_eq).publish_state(false);
+                id(fake_bal${bms_id}_switch_force).publish_state(false);
                 force = false;
               }
-              sim_eq = false;
+              fake_eq = false;
             }
           }
 
-          const bool want_eq = sim_eq || real_eq;
+          const bool want_eq = fake_eq || real_eq;
 
-          // Sticky sim bit — bms equalizing lambda ORs this (Enerkey must not be able to clear it)
-          id(sim_eq${bms_id}_var_asserting) = sim_eq;
+          // Sticky fake bit — bms equalizing lambda ORs this (Enerkey must not be able to clear it)
+          id(fake_bal${bms_id}_var_asserting) = fake_eq;
 
           // Also write ext vars for stub / offline-balancer setups (may be overwritten by Enerkey)
-          id(bms${bms_id}_var_ext_balancer_online) = real_online || sim_eq;
+          id(bms${bms_id}_var_ext_balancer_online) = real_online || fake_eq;
           id(bms${bms_id}_var_ext_balancer_equalizing) = want_eq;
 
-          id(sim_eq${bms_id}_sim_eq_active).publish_state(sim_eq);
+          id(fake_bal${bms_id}_active).publish_state(fake_eq);

--- a/packages/balancer/balancer_fake_balancer.yaml
+++ b/packages/balancer/balancer_fake_balancer.yaml
@@ -22,9 +22,20 @@
 #
 # Purpose:
 #   Infer Equalizing for a BMS that balances but never reports a balancing flag.
+#   Top-of-charge only — Start/Sleep sit near max charge voltage, never near the
+#   bottom of the SoC window. Defaults are LFP (3.45 / 3.42); raise for Li-ion
+#   (~4.0+) or lower slightly for LTO (~2.7+), but keep them at the top.
 #   Uses the same threshold names as Enerkey/Heltec/JK balancers, driven by this
 #   BMS's max/min cell voltage. Cooperates with a real balancer on the same bms_id:
 #   Equalizing = (real balancer balancing) OR (inferred / force).
+#
+#   Inferred latch (Enable):
+#     START only when BOTH are true AND no stop condition is already true:
+#       max_cell >= Balance Starting Voltage
+#       AND (max − min) >= Balance Trigger Voltage
+#     STOP when EITHER is true:
+#       max_cell < Balance Sleep Voltage  (absolute — ends balancing immediately)
+#       OR (max − min) <= Balance Stop Diff Voltage
 #
 # Include (one BMS id — YamBMS BMS ids start at 1):
 #   fake_balancer: !include
@@ -98,41 +109,41 @@ number:
     entity_category: config
     icon: mdi:timer-outline
 
-  # Enter when max cell >= this (Enerkey: Balance Starting Voltage)
+  # Enter ONLY with Trigger Voltage (AND): max cell >= this (top of charge)
   - platform: template
     id: fake_bal${bms_id}_balance_starting_voltage
     device_id: fake_bal_${bms_id}
     name: "Balance Starting Voltage"
     unit_of_measurement: V
     device_class: voltage
-    min_value: 2.0
+    min_value: 2.5
     max_value: 4.5
     step: 0.01
     mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true
-    initial_value: 3.40
+    initial_value: 3.45
     entity_category: config
     icon: mdi:battery-arrow-up
 
-  # Exit when max cell < this (Enerkey: Balance Sleep Voltage)
+  # Exit when max cell < this (OR with Stop Diff) — still top of charge, just below Start
   - platform: template
     id: fake_bal${bms_id}_balance_sleep_voltage
     device_id: fake_bal_${bms_id}
     name: "Balance Sleep Voltage"
     unit_of_measurement: V
     device_class: voltage
-    min_value: 2.0
+    min_value: 2.5
     max_value: 4.5
     step: 0.01
     mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true
-    initial_value: 3.20
+    initial_value: 3.42
     entity_category: config
     icon: mdi:battery-arrow-down
 
-  # Enter when (max − min) >= this (Enerkey: Balance Trigger Voltage)
+  # Enter ONLY with Starting Voltage (AND): (max − min) >= this
   - platform: template
     id: fake_bal${bms_id}_balance_trigger_voltage
     device_id: fake_bal_${bms_id}
@@ -149,7 +160,7 @@ number:
     entity_category: config
     icon: mdi:delta
 
-  # Exit when (max − min) <= this (Enerkey: Balance Stop Diff Voltage)
+  # Exit when (max − min) <= this (OR with Sleep Voltage)
   - platform: template
     id: fake_bal${bms_id}_balance_stop_diff_voltage
     device_id: fake_bal_${bms_id}
@@ -217,19 +228,30 @@ interval:
 
           const bool cells_ok = !isnan(max_cell) && !isnan(min_cell);
           const float delta = cells_ok ? (max_cell - min_cell) : NAN;
-          // Below enter thresholds → safe to re-arm after a Max Run Time expiry
-          const bool below_enter = cells_ok
-              && ((max_cell < start_v) || (delta < trig_v));
+
+          // Start: BOTH must be true (and not already in a stop condition).
+          // Stop: EITHER is enough — Sleep Voltage alone ends balancing. Period.
+          const bool start_hi_v  = cells_ok && (max_cell >= start_v);   // high cell at/above start V
+          const bool start_delta = cells_ok && (delta >= trig_v);       // spread at/above trigger
+          const bool stop_lo_v   = cells_ok && (max_cell < sleep_v);    // high cell below sleep V
+          const bool stop_delta  = cells_ok && (delta <= stop_dv);      // spread at/below stop diff
+          const bool should_stop = stop_lo_v || stop_delta;
+          const bool can_start   = start_hi_v && start_delta && !should_stop;
+
+          // Left the start zone (either start gate false) → re-arm after Max Run Time
+          const bool below_enter = cells_ok && (!start_hi_v || !start_delta);
 
           if (!fake_en) {
             inferred = false;
           } else if (cells_ok) {
-            if (!inferred) {
-              if (!run_expired && (max_cell >= start_v) && (delta >= trig_v))
+            // Sleep Voltage is absolute: high cell below sleep → off, no other gates
+            if (stop_lo_v) {
+              inferred = false;
+            } else if (!inferred) {
+              if (!run_expired && can_start)
                 inferred = true;
-            } else {
-              if ((max_cell < sleep_v) || (delta <= stop_dv))
-                inferred = false;
+            } else if (should_stop) {
+              inferred = false;                                            // stop diff (or sleep)
             }
           }
 

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.0.2
+# Version : 1.0.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -22,7 +22,8 @@
 #
 # Purpose:
 #   Assert YamBMS Equalizing via the BMS external-balancer override so Cut-Off holds
-#   CVL while cells balance. For BMS that never report balancing (e.g. Seplos).
+#   CVL while cells balance. Cooperates with a real balancer on the same bms_id:
+#   Equalizing = (real balancer balancing) OR (sim auto/force).
 #
 # Include (one BMS id — YamBMS BMS ids start at 1):
 #   sim_equalizing: !include
@@ -31,15 +32,15 @@
 #       bms_id: '1'
 #       sim_eq_name: 'Sim Equalizing 1'
 #
-# IDs use sim_eq_${bms_id} / sim_eq${bms_id}_* so this can coexist with a real
-# external balancer package (e.g. Enerkey) that already owns balancer_${bms_id}.
+# Requires balancer${bms_id}_equalizing and balancer${bms_id}_online_status
+# (from Enerkey/Heltec/modbus balancer package, or balancer_equalizing_stub.yaml).
 #
-# Do not enable this on a BMS that already has a live external balancer driving
-# bms${bms_id}_var_ext_balancer_* — both would fight over the same override.
+# IDs use sim_eq_${bms_id} / sim_eq${bms_id}_* so they do not collide with
+# balancer_${bms_id} used by real balancer packages.
 #
 # Contract:
-#   - Writes: bms${bms_id}_var_ext_balancer_online / _equalizing
-#   - Only asserts the override while active; releases it afterward
+#   - Merges into: bms${bms_id}_var_ext_balancer_online / _equalizing every tick
+#   - Never clears online/equalizing out from under a live real balancer
 #--------------------------------------------------------------------------------------------
 
 esphome:
@@ -112,7 +113,6 @@ interval:
       - lambda: |-
           static bool auto_active = false;
           static bool armed = true;          // re-arm after voltage falls below threshold
-          static bool owns_override = false;
           static uint32_t t0 = 0;
 
           const bool sim_en = id(sim_eq${bms_id}_switch_sim_eq).state;
@@ -124,6 +124,12 @@ interval:
               (uint32_t)(id(sim_eq${bms_id}_number_sim_eq_hold_min).state * 60000.0f);
           const float thresh = V_bulk - offset;
           constexpr float rearm_hyst = 0.05f;
+
+          // Real balancer on this bms_id (Enerkey/Heltec/modbus client, or stub)
+          const bool real_online = id(balancer${bms_id}_online_status).has_state()
+              && id(balancer${bms_id}_online_status).state;
+          const bool real_eq = id(balancer${bms_id}_equalizing).has_state()
+              && id(balancer${bms_id}_equalizing).state;
 
           if (sim_en) {
             if (armed && !isnan(V_pack) && !isnan(V_bulk) && (V_pack >= thresh)) {
@@ -140,16 +146,11 @@ interval:
             armed = true;
           }
 
-          const bool want_eq = force || auto_active;
+          const bool sim_eq = force || auto_active;
+          const bool want_eq = sim_eq || real_eq;
 
-          if (want_eq) {
-            id(bms${bms_id}_var_ext_balancer_online) = true;
-            id(bms${bms_id}_var_ext_balancer_equalizing) = true;
-            owns_override = true;
-          } else if (owns_override) {
-            id(bms${bms_id}_var_ext_balancer_online) = false;
-            id(bms${bms_id}_var_ext_balancer_equalizing) = false;
-            owns_override = false;
-          }
+          // Merge: keep override path alive if real balancer is online OR sim wants eq
+          id(bms${bms_id}_var_ext_balancer_online) = real_online || sim_eq;
+          id(bms${bms_id}_var_ext_balancer_equalizing) = want_eq;
 
-          id(sim_eq${bms_id}_sim_eq_active).publish_state(want_eq);
+          id(sim_eq${bms_id}_sim_eq_active).publish_state(sim_eq);

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.0.1
+# Version : 1.0.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -29,22 +29,29 @@
 #     file: packages/balancer/balancer_simulate_equalizing.yaml
 #     vars:
 #       bms_id: '1'
-#       balancer_name: 'Sim Equalizing 1'
+#       sim_eq_name: 'Sim Equalizing 1'
+#
+# IDs use sim_eq_${bms_id} / sim_eq${bms_id}_* so this can coexist with a real
+# external balancer package (e.g. Enerkey) that already owns balancer_${bms_id}.
+#
+# Do not enable this on a BMS that already has a live external balancer driving
+# bms${bms_id}_var_ext_balancer_* — both would fight over the same override.
 #
 # Contract:
 #   - Writes: bms${bms_id}_var_ext_balancer_online / _equalizing
-#   - Only asserts the override while active; releases it afterward so a real
-#     external balancer on that BMS is not permanently masked
+#   - Only asserts the override while active; releases it afterward
 #--------------------------------------------------------------------------------------------
 
-packages:
-  sub_device: !include balancer_base_sub_device.yaml
+esphome:
+  devices:
+    - id: sim_eq_${bms_id}
+      name: "${sim_eq_name}"
 
 switch:
   # Auto: assert Equalizing when pack reaches Bulk − offset, hold for N minutes
   - platform: template
-    id: balancer${bms_id}_switch_sim_eq
-    device_id: balancer_${bms_id}
+    id: sim_eq${bms_id}_switch_sim_eq
+    device_id: sim_eq_${bms_id}
     name: "Sim Equalizing"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
@@ -52,8 +59,8 @@ switch:
 
   # Manual / HA automation: force Equalizing while on (e.g. weekly top-balance)
   - platform: template
-    id: balancer${bms_id}_switch_force_eq
-    device_id: balancer_${bms_id}
+    id: sim_eq${bms_id}_switch_force_eq
+    device_id: sim_eq_${bms_id}
     name: "Force Equalizing"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
@@ -61,8 +68,8 @@ switch:
 
 number:
   - platform: template
-    id: balancer${bms_id}_number_sim_eq_offset_v
-    device_id: balancer_${bms_id}
+    id: sim_eq${bms_id}_number_sim_eq_offset_v
+    device_id: sim_eq_${bms_id}
     name: "Sim Eq Offset"
     unit_of_measurement: V
     device_class: voltage
@@ -77,8 +84,8 @@ number:
     icon: mdi:delta
 
   - platform: template
-    id: balancer${bms_id}_number_sim_eq_hold_min
-    device_id: balancer_${bms_id}
+    id: sim_eq${bms_id}_number_sim_eq_hold_min
+    device_id: sim_eq_${bms_id}
     name: "Sim Eq Hold"
     unit_of_measurement: min
     min_value: 1
@@ -93,8 +100,8 @@ number:
 
 binary_sensor:
   - platform: template
-    id: balancer${bms_id}_sim_eq_active
-    device_id: balancer_${bms_id}
+    id: sim_eq${bms_id}_sim_eq_active
+    device_id: sim_eq_${bms_id}
     name: "Sim Eq Active"
     entity_category: diagnostic
     icon: mdi:scale-balance
@@ -108,13 +115,13 @@ interval:
           static bool owns_override = false;
           static uint32_t t0 = 0;
 
-          const bool sim_en = id(balancer${bms_id}_switch_sim_eq).state;
-          const bool force  = id(balancer${bms_id}_switch_force_eq).state;
+          const bool sim_en = id(sim_eq${bms_id}_switch_sim_eq).state;
+          const bool force  = id(sim_eq${bms_id}_switch_force_eq).state;
           const float V_pack = id(yambms${yambms_id}_total_voltage).state;
           const float V_bulk = id(yambms${yambms_id}_bulk_voltage).state;
-          const float offset = id(balancer${bms_id}_number_sim_eq_offset_v).state;
+          const float offset = id(sim_eq${bms_id}_number_sim_eq_offset_v).state;
           const uint32_t hold_ms =
-              (uint32_t)(id(balancer${bms_id}_number_sim_eq_hold_min).state * 60000.0f);
+              (uint32_t)(id(sim_eq${bms_id}_number_sim_eq_hold_min).state * 60000.0f);
           const float thresh = V_bulk - offset;
           constexpr float rearm_hyst = 0.05f;
 
@@ -145,4 +152,4 @@ interval:
             owns_override = false;
           }
 
-          id(balancer${bms_id}_sim_eq_active).publish_state(want_eq);
+          id(sim_eq${bms_id}_sim_eq_active).publish_state(want_eq);

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.1.2
+# Version : 1.1.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -105,11 +105,11 @@ number:
     device_class: voltage
     min_value: 2.0
     max_value: 4.5
-    step: 0.001
+    step: 0.01
     mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true
-    initial_value: 3.400
+    initial_value: 3.40
     entity_category: config
     icon: mdi:battery-arrow-up
 
@@ -122,11 +122,11 @@ number:
     device_class: voltage
     min_value: 2.0
     max_value: 4.5
-    step: 0.001
+    step: 0.01
     mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true
-    initial_value: 3.200
+    initial_value: 3.20
     entity_category: config
     icon: mdi:battery-arrow-down
 

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.0.3
+# Version : 1.1.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -21,9 +21,10 @@
 # Simulate Equalizing (virtual balancer)
 #
 # Purpose:
-#   Assert YamBMS Equalizing via the BMS external-balancer override so Cut-Off holds
-#   CVL while cells balance. Cooperates with a real balancer on the same bms_id:
-#   Equalizing = (real balancer balancing) OR (sim auto/force).
+#   Infer Equalizing for a BMS that balances but never reports a balancing flag.
+#   Uses the same threshold names as Enerkey/Heltec/JK balancers, driven by this
+#   BMS's max/min cell voltage. Cooperates with a real balancer on the same bms_id:
+#   Equalizing = (real balancer balancing) OR (inferred / force).
 #
 # Include (one BMS id — YamBMS BMS ids start at 1):
 #   sim_equalizing: !include
@@ -32,8 +33,10 @@
 #       bms_id: '1'
 #       sim_eq_name: 'Sim Equalizing 1'
 #
-# Requires balancer${bms_id}_equalizing and balancer${bms_id}_online_status
-# (from Enerkey/Heltec/modbus balancer package, or balancer_equalizing_stub.yaml).
+# Requires:
+#   - bms${bms_id}_max_cell_voltage / _min_cell_voltage
+#   - balancer${bms_id}_equalizing and balancer${bms_id}_online_status
+#     (Enerkey/Heltec/modbus balancer package, or balancer_equalizing_stub.yaml)
 #
 # IDs use sim_eq_${bms_id} / sim_eq${bms_id}_* so they do not collide with
 # balancer_${bms_id} used by real balancer packages.
@@ -41,6 +44,7 @@
 # Contract:
 #   - Merges into: bms${bms_id}_var_ext_balancer_online / _equalizing every tick
 #   - Never clears online/equalizing out from under a live real balancer
+#   - Charge-end ceiling while Equalizing holds Cut-Off open: YamBMS EOC timer
 #--------------------------------------------------------------------------------------------
 
 esphome:
@@ -49,7 +53,7 @@ esphome:
       name: "${sim_eq_name}"
 
 switch:
-  # Auto: assert Equalizing when pack reaches Bulk − offset, hold for N minutes
+  # Auto: infer Equalizing from this BMS's cell voltage + delta vs thresholds
   - platform: template
     id: sim_eq${bms_id}_switch_sim_eq
     device_id: sim_eq_${bms_id}
@@ -68,36 +72,73 @@ switch:
     entity_category: config
 
 number:
+  # Enter when max cell >= this (Enerkey: Balance Starting Voltage)
   - platform: template
-    id: sim_eq${bms_id}_number_sim_eq_offset_v
+    id: sim_eq${bms_id}_balance_starting_voltage
     device_id: sim_eq_${bms_id}
-    name: "Sim Eq Offset"
+    name: "Balance Starting Voltage"
     unit_of_measurement: V
     device_class: voltage
-    min_value: 0.0
-    max_value: 0.5
-    step: 0.01
+    min_value: 2.0
+    max_value: 4.5
+    step: 0.001
     mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true
-    initial_value: 0.05
+    initial_value: 3.400
+    entity_category: config
+    icon: mdi:battery-arrow-up
+
+  # Exit when max cell < this (Enerkey: Balance Sleep Voltage)
+  - platform: template
+    id: sim_eq${bms_id}_balance_sleep_voltage
+    device_id: sim_eq_${bms_id}
+    name: "Balance Sleep Voltage"
+    unit_of_measurement: V
+    device_class: voltage
+    min_value: 2.0
+    max_value: 4.5
+    step: 0.001
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 3.200
+    entity_category: config
+    icon: mdi:battery-arrow-down
+
+  # Enter when (max − min) >= this (Enerkey: Balance Trigger Voltage)
+  - platform: template
+    id: sim_eq${bms_id}_balance_trigger_voltage
+    device_id: sim_eq_${bms_id}
+    name: "Balance Trigger Voltage"
+    unit_of_measurement: V
+    device_class: voltage
+    min_value: 0.001
+    max_value: 0.500
+    step: 0.001
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 0.015
     entity_category: config
     icon: mdi:delta
 
+  # Exit when (max − min) <= this (Enerkey: Balance Stop Diff Voltage)
   - platform: template
-    id: sim_eq${bms_id}_number_sim_eq_hold_min
+    id: sim_eq${bms_id}_balance_stop_diff_voltage
     device_id: sim_eq_${bms_id}
-    name: "Sim Eq Hold"
-    unit_of_measurement: min
-    min_value: 1
-    max_value: 120
-    step: 1
+    name: "Balance Stop Diff Voltage"
+    unit_of_measurement: V
+    device_class: voltage
+    min_value: 0.001
+    max_value: 0.500
+    step: 0.001
     mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true
-    initial_value: 15
+    initial_value: 0.005
     entity_category: config
-    icon: mdi:timer-outline
+    icon: mdi:delta
 
 binary_sensor:
   - platform: template
@@ -111,19 +152,17 @@ interval:
   - interval: ${yambms_update_interval}
     then:
       - lambda: |-
-          static bool auto_active = false;
-          static bool armed = true;          // re-arm after voltage falls below threshold
-          static uint32_t t0 = 0;
+          static bool inferred = false;
 
           const bool sim_en = id(sim_eq${bms_id}_switch_sim_eq).state;
           const bool force  = id(sim_eq${bms_id}_switch_force_eq).state;
-          const float V_pack = id(yambms${yambms_id}_total_voltage).state;
-          const float V_bulk = id(yambms${yambms_id}_bulk_voltage).state;
-          const float offset = id(sim_eq${bms_id}_number_sim_eq_offset_v).state;
-          const uint32_t hold_ms =
-              (uint32_t)(id(sim_eq${bms_id}_number_sim_eq_hold_min).state * 60000.0f);
-          const float thresh = V_bulk - offset;
-          constexpr float rearm_hyst = 0.05f;
+
+          const float max_cell = id(bms${bms_id}_max_cell_voltage).state;
+          const float min_cell = id(bms${bms_id}_min_cell_voltage).state;
+          const float start_v  = id(sim_eq${bms_id}_balance_starting_voltage).state;
+          const float sleep_v  = id(sim_eq${bms_id}_balance_sleep_voltage).state;
+          const float trig_v   = id(sim_eq${bms_id}_balance_trigger_voltage).state;
+          const float stop_dv  = id(sim_eq${bms_id}_balance_stop_diff_voltage).state;
 
           // Real balancer on this bms_id (Enerkey/Heltec/modbus client, or stub)
           const bool real_online = id(balancer${bms_id}_online_status).has_state()
@@ -131,22 +170,20 @@ interval:
           const bool real_eq = id(balancer${bms_id}_equalizing).has_state()
               && id(balancer${bms_id}_equalizing).state;
 
-          if (sim_en) {
-            if (armed && !isnan(V_pack) && !isnan(V_bulk) && (V_pack >= thresh)) {
-              auto_active = true;
-              armed = false;
-              t0 = millis();
+          if (!sim_en) {
+            inferred = false;
+          } else if (!isnan(max_cell) && !isnan(min_cell)) {
+            const float delta = max_cell - min_cell;
+            if (!inferred) {
+              if ((max_cell >= start_v) && (delta >= trig_v))
+                inferred = true;
+            } else {
+              if ((max_cell < sleep_v) || (delta <= stop_dv))
+                inferred = false;
             }
-            if (auto_active && ((millis() - t0) >= hold_ms))
-              auto_active = false;
-            if (!auto_active && !isnan(V_pack) && (V_pack < (thresh - rearm_hyst)))
-              armed = true;
-          } else {
-            auto_active = false;
-            armed = true;
           }
 
-          const bool sim_eq = force || auto_active;
+          const bool sim_eq = force || inferred;
           const bool want_eq = sim_eq || real_eq;
 
           // Merge: keep override path alive if real balancer is online OR sim wants eq

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -107,7 +107,7 @@ number:
     min_value: 1
     max_value: 360
     step: 1
-    mode: slider
+    mode: ${yambms_input_number_mode}
     restore_value: true
     optimistic: true
     initial_value: 30

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.2.1
+# Version : 1.2.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -53,56 +53,24 @@ esphome:
     - id: sim_eq_${bms_id}
       name: "${sim_eq_name}"
 
-  # Globals restore before this; template switches need an explicit publish or HA shows OFF.
-  on_boot:
-    - priority: -100.0
-      then:
-        - lambda: |-
-            id(sim_eq${bms_id}_switch_sim_eq).publish_state(id(sim_eq${bms_id}_var_enable));
-            id(sim_eq${bms_id}_switch_force_eq).publish_state(id(sim_eq${bms_id}_var_force));
-
-globals:
-  - id: sim_eq${bms_id}_var_enable
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-  - id: sim_eq${bms_id}_var_force
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
 switch:
   # Auto: infer Equalizing from this BMS's cell voltage + delta vs thresholds
   - platform: template
     id: sim_eq${bms_id}_switch_sim_eq
     device_id: sim_eq_${bms_id}
     name: "Enable"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
     entity_category: config
-    lambda: return id(sim_eq${bms_id}_var_enable);
-    turn_on_action:
-      - lambda: |-
-          id(sim_eq${bms_id}_var_enable) = true;
-          id(sim_eq${bms_id}_switch_sim_eq).publish_state(true);
-    turn_off_action:
-      - lambda: |-
-          id(sim_eq${bms_id}_var_enable) = false;
-          id(sim_eq${bms_id}_switch_sim_eq).publish_state(false);
 
   # Manual / HA automation: force Equalizing while on (e.g. weekly top-balance)
   - platform: template
     id: sim_eq${bms_id}_switch_force_eq
     device_id: sim_eq_${bms_id}
     name: "Force"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
     entity_category: config
-    lambda: return id(sim_eq${bms_id}_var_force);
-    turn_on_action:
-      - lambda: |-
-          id(sim_eq${bms_id}_var_force) = true;
-          id(sim_eq${bms_id}_switch_force_eq).publish_state(true);
-    turn_off_action:
-      - lambda: |-
-          id(sim_eq${bms_id}_var_force) = false;
-          id(sim_eq${bms_id}_switch_force_eq).publish_state(false);
 
 number:
   # Cap continuous sim Equalizing (inferred or force). Runtime alternative to
@@ -207,8 +175,8 @@ interval:
           static bool prev_force = false;
           static uint32_t started_ms = 0;    // when this sim assertion session began
 
-          const bool sim_en = id(sim_eq${bms_id}_var_enable);
-          bool force = id(sim_eq${bms_id}_var_force);
+          const bool sim_en = id(sim_eq${bms_id}_switch_sim_eq).state;
+          bool force = id(sim_eq${bms_id}_switch_force_eq).state;
 
           // Force rising edge starts a new timed session (weekly top-balance)
           if (force && !prev_force) {
@@ -268,7 +236,6 @@ interval:
               inferred = false;
               started_ms = 0;
               if (force) {
-                id(sim_eq${bms_id}_var_force) = false;
                 id(sim_eq${bms_id}_switch_force_eq).publish_state(false);
                 force = false;
               }

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.2.2
+# Version : 1.2.3
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -42,8 +42,9 @@
 # balancer_${bms_id} used by real balancer packages.
 #
 # Contract:
-#   - Merges into: bms${bms_id}_var_ext_balancer_online / _equalizing every tick
-#   - Never clears online/equalizing out from under a live real balancer
+#   - Sets sim_eq${bms_id}_var_asserting; !extends bms equalizing to OR it in
+#     (Enerkey modbus also writes var_ext_balancer_* and would wipe a plain write)
+#   - Still updates var_ext_balancer_* for stub / no-hardware-balancer setups
 #   - Max Run Time caps how long sim (inferred/force) may assert Equalizing;
 #     YamBMS EOC timer is a separate compile-time charge-end ceiling
 #--------------------------------------------------------------------------------------------
@@ -52,6 +53,13 @@ esphome:
   devices:
     - id: sim_eq_${bms_id}
       name: "${sim_eq_name}"
+
+globals:
+  # Sim wants Equalizing this tick (survives Enerkey overwriting var_ext_balancer_equalizing)
+  - id: sim_eq${bms_id}_var_asserting
+    type: bool
+    restore_value: no
+    initial_value: 'false'
 
 switch:
   # Auto: infer Equalizing from this BMS's cell voltage + delta vs thresholds
@@ -159,6 +167,14 @@ number:
     icon: mdi:delta
 
 binary_sensor:
+  # OR sim into the BMS equalizing sensor (Enerkey on_state would otherwise clear it)
+  - id: !extend bms${bms_id}_equalizing
+    lambda: |-
+      const bool sim = id(sim_eq${bms_id}_var_asserting);
+      if (id(bms${bms_id}_var_ext_balancer_online))
+        return id(bms${bms_id}_var_ext_balancer_equalizing) || sim;
+      return id(bms${bms_id}_bms_equalizing).state || sim;
+
   - platform: template
     id: sim_eq${bms_id}_sim_eq_active
     device_id: sim_eq_${bms_id}
@@ -245,7 +261,10 @@ interval:
 
           const bool want_eq = sim_eq || real_eq;
 
-          // Merge: keep override path alive if real balancer is online OR sim wants eq
+          // Sticky sim bit — bms equalizing lambda ORs this (Enerkey must not be able to clear it)
+          id(sim_eq${bms_id}_var_asserting) = sim_eq;
+
+          // Also write ext vars for stub / offline-balancer setups (may be overwritten by Enerkey)
           id(bms${bms_id}_var_ext_balancer_online) = real_online || sim_eq;
           id(bms${bms_id}_var_ext_balancer_equalizing) = want_eq;
 

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,0 +1,144 @@
+# Updated : 2026.07.17
+# Version : 1.0.0
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+#--------------------------------------------------------------------------------------------
+# Simulate Equalizing (virtual balancer)
+#
+# Purpose:
+#   Assert YamBMS Equalizing via the BMS external-balancer override so Cut-Off holds
+#   CVL while cells balance. For BMS that never report balancing (e.g. Seplos).
+#
+# Include (one BMS id — YamBMS BMS ids start at 1):
+#   sim_equalizing: !include
+#     file: packages/balancer/balancer_simulate_equalizing.yaml
+#     vars:
+#       bms_id: '1'
+#
+# Contract:
+#   - Writes: bms${bms_id}_var_ext_balancer_online / _equalizing
+#   - Only asserts the override while active; releases it afterward so a real
+#     external balancer on that BMS is not permanently masked
+#--------------------------------------------------------------------------------------------
+
+switch:
+  # Auto: assert Equalizing when pack reaches Bulk − offset, hold for N minutes
+  - platform: template
+    id: yambms${yambms_id}_switch_sim_eq
+    device_id: yambms_yambms${yambms_id}
+    name: "Sim Equalizing"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    entity_category: config
+
+  # Manual / HA automation: force Equalizing while on (e.g. weekly top-balance)
+  - platform: template
+    id: yambms${yambms_id}_switch_force_eq
+    device_id: yambms_yambms${yambms_id}
+    name: "Force Equalizing"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    entity_category: config
+
+number:
+  - platform: template
+    id: yambms${yambms_id}_number_sim_eq_offset_v
+    device_id: yambms_yambms${yambms_id}
+    name: "Sim Eq Offset"
+    unit_of_measurement: V
+    device_class: voltage
+    min_value: 0.0
+    max_value: 0.5
+    step: 0.01
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 0.05
+    entity_category: config
+    icon: mdi:delta
+
+  - platform: template
+    id: yambms${yambms_id}_number_sim_eq_hold_min
+    device_id: yambms_yambms${yambms_id}
+    name: "Sim Eq Hold"
+    unit_of_measurement: min
+    min_value: 1
+    max_value: 120
+    step: 1
+    mode: ${yambms_input_number_mode}
+    restore_value: true
+    optimistic: true
+    initial_value: 15
+    entity_category: config
+    icon: mdi:timer-outline
+
+binary_sensor:
+  - platform: template
+    id: yambms${yambms_id}_sim_eq_active
+    device_id: yambms_yambms${yambms_id}
+    name: "Sim Eq Active"
+    entity_category: diagnostic
+    icon: mdi:scale-balance
+
+interval:
+  - interval: ${yambms_update_interval}
+    then:
+      - lambda: |-
+          static bool auto_active = false;
+          static bool armed = true;          // re-arm after voltage falls below threshold
+          static bool owns_override = false;
+          static uint32_t t0 = 0;
+
+          const bool sim_en = id(yambms${yambms_id}_switch_sim_eq).state;
+          const bool force  = id(yambms${yambms_id}_switch_force_eq).state;
+          const float V_pack = id(yambms${yambms_id}_total_voltage).state;
+          const float V_bulk = id(yambms${yambms_id}_bulk_voltage).state;
+          const float offset = id(yambms${yambms_id}_number_sim_eq_offset_v).state;
+          const uint32_t hold_ms =
+              (uint32_t)(id(yambms${yambms_id}_number_sim_eq_hold_min).state * 60000.0f);
+          const float thresh = V_bulk - offset;
+          constexpr float rearm_hyst = 0.05f;
+
+          if (sim_en) {
+            if (armed && !isnan(V_pack) && !isnan(V_bulk) && (V_pack >= thresh)) {
+              auto_active = true;
+              armed = false;
+              t0 = millis();
+            }
+            if (auto_active && ((millis() - t0) >= hold_ms))
+              auto_active = false;
+            if (!auto_active && !isnan(V_pack) && (V_pack < (thresh - rearm_hyst)))
+              armed = true;
+          } else {
+            auto_active = false;
+            armed = true;
+          }
+
+          const bool want_eq = force || auto_active;
+
+          if (want_eq) {
+            id(bms${bms_id}_var_ext_balancer_online) = true;
+            id(bms${bms_id}_var_ext_balancer_equalizing) = true;
+            owns_override = true;
+          } else if (owns_override) {
+            id(bms${bms_id}_var_ext_balancer_online) = false;
+            id(bms${bms_id}_var_ext_balancer_equalizing) = false;
+            owns_override = false;
+          }
+
+          id(yambms${yambms_id}_sim_eq_active).publish_state(want_eq);

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.1.1
+# Version : 1.1.2
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -52,24 +52,48 @@ esphome:
     - id: sim_eq_${bms_id}
       name: "${sim_eq_name}"
 
+globals:
+  - id: sim_eq${bms_id}_var_enable
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: sim_eq${bms_id}_var_force
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
 switch:
   # Auto: infer Equalizing from this BMS's cell voltage + delta vs thresholds
   - platform: template
     id: sim_eq${bms_id}_switch_sim_eq
     device_id: sim_eq_${bms_id}
     name: "Enable Sim Equalizing"
-    restore_mode: RESTORE_DEFAULT_OFF
-    optimistic: true
     entity_category: config
+    lambda: return id(sim_eq${bms_id}_var_enable);
+    turn_on_action:
+      - lambda: |-
+          id(sim_eq${bms_id}_var_enable) = true;
+          id(sim_eq${bms_id}_switch_sim_eq).publish_state(true);
+    turn_off_action:
+      - lambda: |-
+          id(sim_eq${bms_id}_var_enable) = false;
+          id(sim_eq${bms_id}_switch_sim_eq).publish_state(false);
 
   # Manual / HA automation: force Equalizing while on (e.g. weekly top-balance)
   - platform: template
     id: sim_eq${bms_id}_switch_force_eq
     device_id: sim_eq_${bms_id}
     name: "Force Equalizing"
-    restore_mode: RESTORE_DEFAULT_OFF
-    optimistic: true
     entity_category: config
+    lambda: return id(sim_eq${bms_id}_var_force);
+    turn_on_action:
+      - lambda: |-
+          id(sim_eq${bms_id}_var_force) = true;
+          id(sim_eq${bms_id}_switch_force_eq).publish_state(true);
+    turn_off_action:
+      - lambda: |-
+          id(sim_eq${bms_id}_var_force) = false;
+          id(sim_eq${bms_id}_switch_force_eq).publish_state(false);
 
 number:
   # Enter when max cell >= this (Enerkey: Balance Starting Voltage)
@@ -154,8 +178,8 @@ interval:
       - lambda: |-
           static bool inferred = false;
 
-          const bool sim_en = id(sim_eq${bms_id}_switch_sim_eq).state;
-          const bool force  = id(sim_eq${bms_id}_switch_force_eq).state;
+          const bool sim_en = id(sim_eq${bms_id}_var_enable);
+          const bool force  = id(sim_eq${bms_id}_var_force);
 
           const float max_cell = id(bms${bms_id}_max_cell_voltage).state;
           const float min_cell = id(bms${bms_id}_min_cell_voltage).state;

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -27,11 +27,11 @@
 #   Equalizing = (real balancer balancing) OR (inferred / force).
 #
 # Include (one BMS id — YamBMS BMS ids start at 1):
-#   sim_equalizing: !include
+#   sim_eq: !include
 #     file: packages/balancer/balancer_simulate_equalizing.yaml
 #     vars:
 #       bms_id: '1'
-#       sim_eq_name: 'Sim Equalizing 1'
+#       sim_eq_name: 'Sim Eq 1'
 #
 # Requires:
 #   - bms${bms_id}_max_cell_voltage / _min_cell_voltage
@@ -68,7 +68,7 @@ switch:
   - platform: template
     id: sim_eq${bms_id}_switch_sim_eq
     device_id: sim_eq_${bms_id}
-    name: "Enable Sim Equalizing"
+    name: "Enable"
     entity_category: config
     lambda: return id(sim_eq${bms_id}_var_enable);
     turn_on_action:
@@ -84,7 +84,7 @@ switch:
   - platform: template
     id: sim_eq${bms_id}_switch_force_eq
     device_id: sim_eq_${bms_id}
-    name: "Force Equalizing"
+    name: "Force"
     entity_category: config
     lambda: return id(sim_eq${bms_id}_var_force);
     turn_on_action:
@@ -186,7 +186,7 @@ binary_sensor:
   - platform: template
     id: sim_eq${bms_id}_sim_eq_active
     device_id: sim_eq_${bms_id}
-    name: "Sim Eq Active"
+    name: "Active"
     entity_category: diagnostic
     icon: mdi:scale-balance
 

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.1.3
+# Version : 1.2.0
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -44,7 +44,8 @@
 # Contract:
 #   - Merges into: bms${bms_id}_var_ext_balancer_online / _equalizing every tick
 #   - Never clears online/equalizing out from under a live real balancer
-#   - Charge-end ceiling while Equalizing holds Cut-Off open: YamBMS EOC timer
+#   - Max Run Time caps how long sim (inferred/force) may assert Equalizing;
+#     YamBMS EOC timer is a separate compile-time charge-end ceiling
 #--------------------------------------------------------------------------------------------
 
 esphome:
@@ -96,6 +97,23 @@ switch:
           id(sim_eq${bms_id}_switch_force_eq).publish_state(false);
 
 number:
+  # Cap continuous sim Equalizing (inferred or force). Runtime alternative to
+  # raising the compile-time YamBMS EOC timer for longer weekly top-balance.
+  - platform: template
+    id: sim_eq${bms_id}_max_run_time
+    device_id: sim_eq_${bms_id}
+    name: "Max Run Time"
+    unit_of_measurement: min
+    min_value: 1
+    max_value: 360
+    step: 1
+    mode: slider
+    restore_value: true
+    optimistic: true
+    initial_value: 30
+    entity_category: config
+    icon: mdi:timer-outline
+
   # Enter when max cell >= this (Enerkey: Balance Starting Voltage)
   - platform: template
     id: sim_eq${bms_id}_balance_starting_voltage
@@ -177,9 +195,19 @@ interval:
     then:
       - lambda: |-
           static bool inferred = false;
+          static bool run_expired = false;   // latched after Max Run Time until re-arm
+          static bool prev_force = false;
+          static uint32_t started_ms = 0;    // when this sim assertion session began
 
           const bool sim_en = id(sim_eq${bms_id}_var_enable);
-          const bool force  = id(sim_eq${bms_id}_var_force);
+          bool force = id(sim_eq${bms_id}_var_force);
+
+          // Force rising edge starts a new timed session (weekly top-balance)
+          if (force && !prev_force) {
+            run_expired = false;
+            started_ms = 0;
+          }
+          prev_force = force;
 
           const float max_cell = id(bms${bms_id}_max_cell_voltage).state;
           const float min_cell = id(bms${bms_id}_min_cell_voltage).state;
@@ -187,6 +215,7 @@ interval:
           const float sleep_v  = id(sim_eq${bms_id}_balance_sleep_voltage).state;
           const float trig_v   = id(sim_eq${bms_id}_balance_trigger_voltage).state;
           const float stop_dv  = id(sim_eq${bms_id}_balance_stop_diff_voltage).state;
+          const float max_run_min = id(sim_eq${bms_id}_max_run_time).state;
 
           // Real balancer on this bms_id (Enerkey/Heltec/modbus client, or stub)
           const bool real_online = id(balancer${bms_id}_online_status).has_state()
@@ -194,12 +223,17 @@ interval:
           const bool real_eq = id(balancer${bms_id}_equalizing).has_state()
               && id(balancer${bms_id}_equalizing).state;
 
+          const bool cells_ok = !isnan(max_cell) && !isnan(min_cell);
+          const float delta = cells_ok ? (max_cell - min_cell) : NAN;
+          // Below enter thresholds → safe to re-arm after a Max Run Time expiry
+          const bool below_enter = cells_ok
+              && ((max_cell < start_v) || (delta < trig_v));
+
           if (!sim_en) {
             inferred = false;
-          } else if (!isnan(max_cell) && !isnan(min_cell)) {
-            const float delta = max_cell - min_cell;
+          } else if (cells_ok) {
             if (!inferred) {
-              if ((max_cell >= start_v) && (delta >= trig_v))
+              if (!run_expired && (max_cell >= start_v) && (delta >= trig_v))
                 inferred = true;
             } else {
               if ((max_cell < sleep_v) || (delta <= stop_dv))
@@ -207,7 +241,33 @@ interval:
             }
           }
 
-          const bool sim_eq = force || inferred;
+          bool sim_eq = force || inferred;
+
+          // Max Run Time: cap continuous sim Equalizing (inferred or force)
+          if (!sim_eq) {
+            started_ms = 0;
+            if (!force && below_enter)
+              run_expired = false;
+          } else if (run_expired) {
+            sim_eq = false;
+          } else {
+            const uint32_t now = millis();
+            if (started_ms == 0)
+              started_ms = now;
+            const uint32_t max_ms = (uint32_t)(max_run_min * 60000.0f);
+            if ((now - started_ms) >= max_ms) {
+              run_expired = true;
+              inferred = false;
+              started_ms = 0;
+              if (force) {
+                id(sim_eq${bms_id}_var_force) = false;
+                id(sim_eq${bms_id}_switch_force_eq).publish_state(false);
+                force = false;
+              }
+              sim_eq = false;
+            }
+          }
+
           const bool want_eq = sim_eq || real_eq;
 
           // Merge: keep override path alive if real balancer is online OR sim wants eq

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.1.0
+# Version : 1.1.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -57,7 +57,7 @@ switch:
   - platform: template
     id: sim_eq${bms_id}_switch_sim_eq
     device_id: sim_eq_${bms_id}
-    name: "Sim Equalizing"
+    name: "Enable Sim Equalizing"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: config

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.0.0
+# Version : 1.0.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -29,6 +29,7 @@
 #     file: packages/balancer/balancer_simulate_equalizing.yaml
 #     vars:
 #       bms_id: '1'
+#       balancer_name: 'Sim Equalizing 1'
 #
 # Contract:
 #   - Writes: bms${bms_id}_var_ext_balancer_online / _equalizing
@@ -36,11 +37,14 @@
 #     external balancer on that BMS is not permanently masked
 #--------------------------------------------------------------------------------------------
 
+packages:
+  sub_device: !include balancer_base_sub_device.yaml
+
 switch:
   # Auto: assert Equalizing when pack reaches Bulk − offset, hold for N minutes
   - platform: template
-    id: yambms${yambms_id}_switch_sim_eq
-    device_id: yambms_yambms${yambms_id}
+    id: balancer${bms_id}_switch_sim_eq
+    device_id: balancer_${bms_id}
     name: "Sim Equalizing"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
@@ -48,8 +52,8 @@ switch:
 
   # Manual / HA automation: force Equalizing while on (e.g. weekly top-balance)
   - platform: template
-    id: yambms${yambms_id}_switch_force_eq
-    device_id: yambms_yambms${yambms_id}
+    id: balancer${bms_id}_switch_force_eq
+    device_id: balancer_${bms_id}
     name: "Force Equalizing"
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
@@ -57,8 +61,8 @@ switch:
 
 number:
   - platform: template
-    id: yambms${yambms_id}_number_sim_eq_offset_v
-    device_id: yambms_yambms${yambms_id}
+    id: balancer${bms_id}_number_sim_eq_offset_v
+    device_id: balancer_${bms_id}
     name: "Sim Eq Offset"
     unit_of_measurement: V
     device_class: voltage
@@ -73,8 +77,8 @@ number:
     icon: mdi:delta
 
   - platform: template
-    id: yambms${yambms_id}_number_sim_eq_hold_min
-    device_id: yambms_yambms${yambms_id}
+    id: balancer${bms_id}_number_sim_eq_hold_min
+    device_id: balancer_${bms_id}
     name: "Sim Eq Hold"
     unit_of_measurement: min
     min_value: 1
@@ -89,8 +93,8 @@ number:
 
 binary_sensor:
   - platform: template
-    id: yambms${yambms_id}_sim_eq_active
-    device_id: yambms_yambms${yambms_id}
+    id: balancer${bms_id}_sim_eq_active
+    device_id: balancer_${bms_id}
     name: "Sim Eq Active"
     entity_category: diagnostic
     icon: mdi:scale-balance
@@ -104,13 +108,13 @@ interval:
           static bool owns_override = false;
           static uint32_t t0 = 0;
 
-          const bool sim_en = id(yambms${yambms_id}_switch_sim_eq).state;
-          const bool force  = id(yambms${yambms_id}_switch_force_eq).state;
+          const bool sim_en = id(balancer${bms_id}_switch_sim_eq).state;
+          const bool force  = id(balancer${bms_id}_switch_force_eq).state;
           const float V_pack = id(yambms${yambms_id}_total_voltage).state;
           const float V_bulk = id(yambms${yambms_id}_bulk_voltage).state;
-          const float offset = id(yambms${yambms_id}_number_sim_eq_offset_v).state;
+          const float offset = id(balancer${bms_id}_number_sim_eq_offset_v).state;
           const uint32_t hold_ms =
-              (uint32_t)(id(yambms${yambms_id}_number_sim_eq_hold_min).state * 60000.0f);
+              (uint32_t)(id(balancer${bms_id}_number_sim_eq_hold_min).state * 60000.0f);
           const float thresh = V_bulk - offset;
           constexpr float rearm_hyst = 0.05f;
 
@@ -141,4 +145,4 @@ interval:
             owns_override = false;
           }
 
-          id(yambms${yambms_id}_sim_eq_active).publish_state(want_eq);
+          id(balancer${bms_id}_sim_eq_active).publish_state(want_eq);

--- a/packages/balancer/balancer_simulate_equalizing.yaml
+++ b/packages/balancer/balancer_simulate_equalizing.yaml
@@ -1,5 +1,5 @@
 # Updated : 2026.07.17
-# Version : 1.2.0
+# Version : 1.2.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -52,6 +52,14 @@ esphome:
   devices:
     - id: sim_eq_${bms_id}
       name: "${sim_eq_name}"
+
+  # Globals restore before this; template switches need an explicit publish or HA shows OFF.
+  on_boot:
+    - priority: -100.0
+      then:
+        - lambda: |-
+            id(sim_eq${bms_id}_switch_sim_eq).publish_state(id(sim_eq${bms_id}_var_enable));
+            id(sim_eq${bms_id}_switch_force_eq).publish_state(id(sim_eq${bms_id}_var_force));
 
 globals:
   - id: sim_eq${bms_id}_var_enable


### PR DESCRIPTION
## Summary
- Optional per-BMS package that infers Equalizing from that BMS's max/min cell voltage using Enerkey-style thresholds (starting / sleep / trigger / stop-diff), for BMS that balance but never report a balancing flag (e.g. Seplos).
- Cooperates with a live external balancer on the same `bms_id` (`Equalizing = real OR inferred OR force`); includes a stub package when no hardware balancer is present.
- Docs and HA dashboard cards; Simulate Equalizing is documented after Current Taper for merge order with that PR.

## Test plan
- [ ] Include `balancer_simulate_equalizing.yaml` for one `bms_id` (with Enerkey/modbus client or stub) and confirm compile
- [ ] Enable Sim Equalizing: assert Equalizing when max cell ≥ starting and delta ≥ trigger; clear when max < sleep or delta ≤ stop-diff
- [ ] Force Equalizing asserts while on, independent of cell thresholds
- [ ] With a live Enerkey on the same BMS, Equalizing stays true if either sim or Enerkey is balancing; releasing sim does not clear Enerkey's equalizing
- [ ] Confirm Cut-Off holds while Equalizing is true and EOC timer remains the charge-end ceiling


Made with [Cursor](https://cursor.com)