### PR TITLE
Add 2xBMS dashboard and cell resistance highlighting

### DIFF
--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
@@ -523,7 +523,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -535,7 +535,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -562,7 +563,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -574,7 +575,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -751,7 +753,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -763,7 +765,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -790,7 +793,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -802,7 +805,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
@@ -523,38 +523,26 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
-                  {% if has_value(res_ent) %} / 
-                  {% set res_values = [] %}
-                  {% for i in range(1,17) %}
-                  {% set z = '0' if i < 10 else '' %}
-                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
-                  {% if has_value(e) %}
-                  {% set res_values = res_values + [states(e) | float(0)] %}
-                  {% endif %}
-                  {% endfor %}
-                  {% set res_max = res_values|max if res_values|length else none %}
-                  {% set res_min = res_values|min if res_values|length else none %}
-                  {% set res_val = states(res_ent) | float(0) %}
-                  {% if res_max is not none and res_val == res_max %}
-                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
-                  {% elif res_min is not none and res_val == res_min %}
-                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% else %}
-                  {{ states(res_ent, rounded=True) }} Ω
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
                   {% endif %}
                   {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -572,38 +560,26 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
-                  {% if has_value(res_ent) %} / 
-                  {% set res_values = [] %}
-                  {% for i in range(1,17) %}
-                  {% set z = '0' if i < 10 else '' %}
-                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
-                  {% if has_value(e) %}
-                  {% set res_values = res_values + [states(e) | float(0)] %}
-                  {% endif %}
-                  {% endfor %}
-                  {% set res_max = res_values|max if res_values|length else none %}
-                  {% set res_min = res_values|min if res_values|length else none %}
-                  {% set res_val = states(res_ent) | float(0) %}
-                  {% if res_max is not none and res_val == res_max %}
-                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
-                  {% elif res_min is not none and res_val == res_min %}
-                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% else %}
-                  {{ states(res_ent, rounded=True) }} Ω
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
                   {% endif %}
                   {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -771,38 +747,26 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
-                  {% if has_value(res_ent) %} / 
-                  {% set res_values = [] %}
-                  {% for i in range(1,17) %}
-                  {% set z = '0' if i < 10 else '' %}
-                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
-                  {% if has_value(e) %}
-                  {% set res_values = res_values + [states(e) | float(0)] %}
-                  {% endif %}
-                  {% endfor %}
-                  {% set res_max = res_values|max if res_values|length else none %}
-                  {% set res_min = res_values|min if res_values|length else none %}
-                  {% set res_val = states(res_ent) | float(0) %}
-                  {% if res_max is not none and res_val == res_max %}
-                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
-                  {% elif res_min is not none and res_val == res_min %}
-                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% else %}
-                  {{ states(res_ent, rounded=True) }} Ω
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
                   {% endif %}
                   {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -820,38 +784,26 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
-                  {% if has_value(res_ent) %} / 
-                  {% set res_values = [] %}
-                  {% for i in range(1,17) %}
-                  {% set z = '0' if i < 10 else '' %}
-                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
-                  {% if has_value(e) %}
-                  {% set res_values = res_values + [states(e) | float(0)] %}
-                  {% endif %}
-                  {% endfor %}
-                  {% set res_max = res_values|max if res_values|length else none %}
-                  {% set res_min = res_values|min if res_values|length else none %}
-                  {% set res_val = states(res_ent) | float(0) %}
-                  {% if res_max is not none and res_val == res_max %}
-                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
-                  {% elif res_min is not none and res_val == res_min %}
-                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% else %}
-                  {{ states(res_ent, rounded=True) }} Ω
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
                   {% endif %}
                   {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
@@ -28,7 +28,7 @@ views:
             heading: YamBMS - Battery
           - graph: line
             type: sensor
-            entity: sensor.yambms_yambms_1_total_voltage
+            entity: sensor.yambms_1_total_voltage
             detail: 2
             layout_options:
               grid_columns: 2
@@ -37,12 +37,12 @@ views:
             hours_to_show: 8
           - graph: line
             type: sensor
-            entity: sensor.yambms_yambms_1_battery_soc
+            entity: sensor.yambms_1_battery_soc
             detail: 2
             name: SoC
             hours_to_show: 8
           - type: gauge
-            entity: sensor.yambms_yambms_1_current
+            entity: sensor.yambms_1_current
             needle: true
             severity:
               green: 0
@@ -55,7 +55,7 @@ views:
               grid_columns: 2
               grid_rows: 3
           - type: gauge
-            entity: sensor.yambms_yambms_1_power
+            entity: sensor.yambms_1_power
             needle: true
             severity:
               green: 0
@@ -68,55 +68,55 @@ views:
               grid_columns: 2
               grid_rows: 3
           - type: tile
-            entity: sensor.yambms_yambms_1_installed_battery_capacity
+            entity: sensor.yambms_1_installed_battery_capacity
             name: Installed Battery Capacity
           - type: tile
-            entity: sensor.yambms_yambms_1_battery_soh
+            entity: sensor.yambms_1_battery_soh
             name: Battery SoH
           - type: tile
-            entity: sensor.yambms_yambms_1_battery_capacity
+            entity: sensor.yambms_1_battery_capacity
             name: Battery Capacity
           - type: tile
-            entity: sensor.yambms_yambms_1_capacity_remaining
+            entity: sensor.yambms_1_capacity_remaining
             name: Capacity Remaining
           - type: tile
-            entity: sensor.yambms_yambms_1_delta_cell_voltage
+            entity: sensor.yambms_1_delta_cell_voltage
             name: Delta Cell Voltage
           - type: tile
-            entity: binary_sensor.yambms_yambms_1_bms_equalizing_state
+            entity: binary_sensor.yambms_1_equalizing_state
             name: Equalizing state
           - type: entities
             entities:
-              - entity: sensor.yambms_yambms_1_max_cell_voltage
+              - entity: sensor.yambms_1_max_cell_voltage
                 name: Max Cell V.
-              - entity: sensor.yambms_yambms_1_max_voltage_cell
+              - entity: sensor.yambms_1_max_voltage_cell
                 name: Cell number
             layout_options:
               grid_columns: 2
               grid_rows: 2
           - type: entities
             entities:
-              - entity: sensor.yambms_yambms_1_min_cell_voltage
+              - entity: sensor.yambms_1_min_cell_voltage
                 name: Min Cell V.
-              - entity: sensor.yambms_yambms_1_min_voltage_cell
+              - entity: sensor.yambms_1_min_voltage_cell
                 name: Cell number
             layout_options:
               grid_columns: 2
               grid_rows: 2
           - type: entities
             entities:
-              - entity: sensor.yambms_yambms_1_max_temperature
+              - entity: sensor.yambms_1_max_temperature
                 name: Max temp.
-              - entity: sensor.yambms_yambms_1_max_temperature_sensor
+              - entity: sensor.yambms_1_max_temperature_sensor
                 name: Sensor number
             layout_options:
               grid_columns: 2
               grid_rows: 2
           - type: entities
             entities:
-              - entity: sensor.yambms_yambms_1_min_temperature
+              - entity: sensor.yambms_1_min_temperature
                 name: Min temp.
-              - entity: sensor.yambms_yambms_1_min_temperature_sensor
+              - entity: sensor.yambms_1_min_temperature_sensor
                 name: Sensor number
             layout_options:
               grid_columns: 2
@@ -133,43 +133,43 @@ views:
             entity: binary_sensor.yambms_board_online_status
             name: Board status
           - type: tile
-            entity: sensor.yambms_yambms_1_charging_status
+            entity: sensor.yambms_1_charging_status
             name: Charging Status
           - type: tile
-            entity: sensor.yambms_yambms_1_last_complete_charge
+            entity: sensor.yambms_1_last_complete_charge
             name: Last Complete Charge
           - type: tile
-            entity: sensor.yambms_yambms_1_charging_instruction
+            entity: sensor.yambms_1_charging_instruction
             name: Charging Instruction
           - type: tile
-            entity: binary_sensor.yambms_yambms_1_discharging_instruction
+            entity: binary_sensor.yambms_1_discharging_instruction
             name: Discharging Instruction
           - type: tile
-            entity: sensor.yambms_yambms_1_alarm
+            entity: sensor.yambms_1_alarm
             name: Alarm
           - type: tile
-            entity: sensor.yambms_yambms_1_warning
+            entity: sensor.yambms_1_warning
             name: Warning
           - type: entities
             entities:
-              - entity: sensor.yambms_yambms_1_bms_count
+              - entity: sensor.yambms_1_bms_count
                 name: BMS count
-              - entity: sensor.yambms_yambms_1_bms_combined
+              - entity: sensor.yambms_1_bms_combined
                 name: BMS combined
-              - entity: sensor.yambms_yambms_1_bms_blocking_charge
+              - entity: sensor.yambms_1_bms_blocking_charge
                 name: BMS blocking charge
-              - entity: sensor.yambms_yambms_1_bms_blocking_discharge
+              - entity: sensor.yambms_1_bms_blocking_discharge
                 name: BMS blocking discharge
-              - entity: sensor.yambms_yambms_1_bms_in_alarm
+              - entity: sensor.yambms_1_bms_in_alarm
                 name: BMS in alarm
             layout_options:
               grid_columns: 2
               grid_rows: 4
           - type: entities
             entities:
-              - entity: sensor.yambms_yambms_1_shunt_count
+              - entity: sensor.yambms_1_shunt_count
                 name: Shunt count
-              - entity: sensor.yambms_yambms_1_shunt_combined
+              - entity: sensor.yambms_1_shunt_combined
                 name: Shunt combined
             layout_options:
               grid_columns: 2
@@ -182,33 +182,31 @@ views:
             name: ESPHome version
           - type: entities
             entities:
-              - entity: sensor.yambms_yambms_1_requested_charge_voltage
+              - entity: sensor.yambms_1_requested_charge_voltage
                 name: Requested Charge Voltage
-              - entity: sensor.yambms_yambms_1_requested_charge_current
+              - entity: sensor.yambms_1_requested_charge_current
                 name: Requested Charge Current
-              - entity: sensor.yambms_yambms_1_requested_discharge_voltage
+              - entity: sensor.yambms_1_requested_discharge_voltage
                 name: Requested Discharge Voltage
-              - entity: sensor.yambms_yambms_1_requested_discharge_current
+              - entity: sensor.yambms_1_requested_discharge_current
                 name: Requested Discharge Current
-              - entity: binary_sensor.yambms_yambms_1_requested_force_charge
+              - entity: binary_sensor.yambms_1_requested_force_charge
                 name: Requested Force Charge
           - type: tile
-            entity: sensor.yambms_yambms_1_running_version
+            entity: sensor.yambms_1_running_version
             name: Running version
           - type: tile
-            entity: sensor.yambms_yambms_1_last_version
+            entity: sensor.yambms_1_last_version
             name: Last version
         column_span: 1
   - title: Control
     cards:
       - type: entity-filter
         entities:
-          - entity: select.canbus_1_yambms_name
+          - entity: select.yambms_1_canbus_1_yambms_name
             name: CANBUS YamBMS name
-          - entity: select.canbus_1_yambms_protocol
+          - entity: select.yambms_1_canbus_1_yambms_protocol
             name: CANBUS YamBMS protocol
-          - entity: select.rs485_1_yambms_protocol
-            name: RS485 YamBMS protocol
         conditions:
           - condition: state
             state_not: unavailable
@@ -216,125 +214,125 @@ views:
           title: YamBMS - Inverter Comm. Protocol
       - type: entities
         entities:
-          - entity: switch.yambms_yambms_1_charge_enabled
+          - entity: switch.yambms_1_charge_enabled
             name: YamBMS 1 Charge enabled
-          - entity: switch.yambms_yambms_1_discharge_enabled
+          - entity: switch.yambms_1_discharge_enabled
             name: YamBMS 1 Discharge enabled
-          - entity: binary_sensor.yambms_yambms_1_bms_charging_allowed
+          - entity: binary_sensor.yambms_1_charging_allowed
             name: YamBMS 1 BMS Charging allowed
-          - entity: binary_sensor.yambms_yambms_1_bms_discharging_allowed
+          - entity: binary_sensor.yambms_1_discharging_allowed
             name: YamBMS 1 BMS Discharging allowed
         title: YamBMS - Charge / Discharge switch
       - type: entities
         entities:
-          - entity: switch.yambms_yambms_1_automatic_charge_voltage
+          - entity: switch.yambms_1_automatic_charge_voltage
             name: Automatic Charge Voltage
-          - entity: number.yambms_yambms_1_auto_cvl_boost_charge_v
+          - entity: number.yambms_1_auto_cvl_boost_charge_v
             name: Auto CVL Boost Charge V.
         title: YamBMS - Auto CVL
       - type: entities
         entities:
-          - entity: sensor.yambms_yambms_1_charging_status
+          - entity: sensor.yambms_1_charging_status
             name: Charging Status
-          - entity: sensor.yambms_yambms_1_charging_instruction
+          - entity: sensor.yambms_1_charging_instruction
             name: Charging Instruction
-          - entity: switch.yambms_yambms_1_float_charge_enabled
+          - entity: switch.yambms_1_float_charge_enabled
             name: Float charge enabled
-          - entity: switch.yambms_yambms_1_eoc_timer_enabled
+          - entity: switch.yambms_1_eoc_timer_enabled
             name: EOC timer enabled
-          - entity: number.yambms_yambms_1_bulk_voltage
+          - entity: number.yambms_1_bulk_voltage
             name: Bulk voltage
-          - entity: number.yambms_yambms_1_float_voltage
+          - entity: number.yambms_1_float_voltage
             name: Float voltage
-          - entity: number.yambms_yambms_1_inverter_offset_v
+          - entity: number.yambms_1_inverter_offset_v
             name: Inverter Offset V.
         title: YamBMS - Charging Settings
       - type: entities
         entities:
-          - entity: switch.yambms_yambms_1_automatic_charge_current
+          - entity: switch.yambms_1_automatic_charge_current
             name: Automatic Charge Current
-          - entity: switch.yambms_yambms_1_automatic_discharge_current
+          - entity: switch.yambms_1_automatic_discharge_current
             name: Automatic Discharge Current
         title: YamBMS - Auto CCL / DCL
       - type: entities
         entities:
-          - entity: select.yambms_yambms_1_automatic_float_voltage
+          - entity: select.yambms_1_automatic_float_voltage
             name: Automatic Float Voltage
-          - entity: sensor.yambms_yambms_1_auto_float_voltage
+          - entity: sensor.yambms_1_auto_float_voltage
             name: Auto Float Voltage
-          - entity: number.yambms_yambms_1_auto_float_update_interval
+          - entity: number.yambms_1_auto_float_update_interval
             name: Update Interval
-          - entity: number.yambms_yambms_1_auto_float_voltage_step
+          - entity: number.yambms_1_auto_float_voltage_step
             name: Voltage Step
         title: YamBMS - Auto Float
       - type: entities
         entities:
-          - entity: switch.yambms_yambms_1_automatic_eoc_current
+          - entity: switch.yambms_1_automatic_eoc_current
             name: Automatic EOC Current
-          - entity: sensor.yambms_yambms_1_auto_eoc_status
+          - entity: sensor.yambms_1_auto_eoc_status
             name: Status
-          - entity: sensor.yambms_yambms_1_auto_eoc_current
+          - entity: sensor.yambms_1_auto_eoc_current
             name: Required Current
-          - entity: number.yambms_yambms_1_auto_eoc_target_hour
+          - entity: number.yambms_1_auto_eoc_target_hour
             name: Target hour
-          - entity: number.yambms_yambms_1_auto_eoc_target_minute
+          - entity: number.yambms_1_auto_eoc_target_minute
             name: Target minute
-          - entity: number.yambms_yambms_1_auto_eoc_correction
+          - entity: number.yambms_1_auto_eoc_correction
             name: Current Correction
-          - entity: number.yambms_yambms_1_auto_eoc_capacity_modifier
+          - entity: number.yambms_1_auto_eoc_capacity_modifier
             name: Capacity Modifier
-          - entity: number.yambms_yambms_1_auto_eoc_increase_stop_hours
+          - entity: number.yambms_1_auto_eoc_increase_stop_hours
             name: Stop hours
-          - entity: number.yambms_yambms_1_auto_eoc_increase_stop_soc
+          - entity: number.yambms_1_auto_eoc_increase_stop_soc
             name: Stop SoC
         title: YamBMS - Auto EOC
       - type: entities
         entities:
-          - entity: number.yambms_yambms_1_rebulk_soc
+          - entity: number.yambms_1_rebulk_soc
             name: Rebulk SoC
-          - entity: number.yambms_yambms_1_rebulk_v
+          - entity: number.yambms_1_rebulk_v
             name: Rebulk V.
-          - entity: switch.yambms_yambms_1_force_bulk_top_bal
+          - entity: switch.yambms_1_force_bulk
             name: Force Bulk (top bal)
         title: YamBMS - ReBulk
       - type: entities
         entities:
-          - entity: number.yambms_yambms_1_max_requested_charge_current
+          - entity: number.yambms_1_max_requested_charge_current
             name: Max charge current
-          - entity: number.yambms_yambms_1_max_requested_discharge_current
+          - entity: number.yambms_1_max_requested_discharge_current
             name: Max discharge current
-          - entity: switch.yambms_yambms_1_temperature_based_current_limitation
+          - entity: switch.yambms_1_temperature_based_current_limitation
             name: Temperature-based current limitation
-          - entity: sensor.yambms_yambms_1_ccl_derating_reason
+          - entity: sensor.yambms_1_ccl_derating_reason
             name: CCL Derating Reason
-          - entity: sensor.yambms_yambms_1_dcl_derating_reason
+          - entity: sensor.yambms_1_dcl_derating_reason
             name: DCL Derating Reason
         title: YamBMS - Max requested current
       - type: entities
         entities:
-          - entity: switch.yambms_yambms_1_request_force_charge
+          - entity: switch.yambms_1_request_force_charge
             name: Request force charge
-          - entity: number.yambms_yambms_1_request_force_charge_start_soc
+          - entity: number.yambms_1_request_force_charge_start_soc
             name: Force charge Start SoC
-          - entity: number.yambms_yambms_1_request_force_charge_stop_soc
+          - entity: number.yambms_1_request_force_charge_stop_soc
             name: Force charge Stop SoC
-          - entity: binary_sensor.yambms_yambms_1_requested_force_charge
+          - entity: binary_sensor.yambms_1_requested_force_charge
             name: Requested Force Charge
         title: YamBMS - Request force charge
       - type: entities
         entities:
-          - entity: sensor.yambms_yambms_1_requested_charge_voltage
+          - entity: sensor.yambms_1_requested_charge_voltage
             name: Requested Charge Voltage
-          - entity: sensor.yambms_yambms_1_requested_discharge_voltage
+          - entity: sensor.yambms_1_requested_discharge_voltage
             name: Requested Discharge Voltage
-          - entity: sensor.yambms_yambms_1_requested_charge_current
+          - entity: sensor.yambms_1_requested_charge_current
             name: Requested Charge Current
-          - entity: sensor.yambms_yambms_1_requested_discharge_current
+          - entity: sensor.yambms_1_requested_discharge_current
             name: Requested Discharge Current
         title: YamBMS - Requested Values
       - type: entities
         entities:
-          - entity: sensor.yambms_yambms_1_last_complete_charge
+          - entity: sensor.yambms_1_last_complete_charge
             name: Last Complete Charge
           - entity: binary_sensor.yambms_board_online_status
             name: Board Online Status
@@ -347,18 +345,12 @@ views:
         title: YamBMS - Diagnostic
       - type: entity-filter
         entities:
-          - entity: binary_sensor.canbus_1_status
+          - entity: binary_sensor.yambms_1_canbus_1_status
             name: CANBUS Status
-          - entity: switch.canbus_1_inverter_heartbeat_monitoring
+          - entity: switch.yambms_1_canbus_1_inverter_heartbeat_monitoring
             name: CANBUS Inverter Heartbeat Monitoring
-          - entity: sensor.canbus_1_inverter_heartbeat
+          - entity: sensor.yambms_1_canbus_1_inverter_heartbeat
             name: CANBUS Inverter Heartbeat
-          - entity: binary_sensor.rs485_1_status
-            name: RS485 Status
-          - entity: switch.rs485_1_inverter_heartbeat_monitoring
-            name: RS485 Inverter Heartbeat Monitoring
-          - entity: sensor.rs485_1_inverter_heartbeat
-            name: RS485 Inverter Heartbeat
         conditions:
           - condition: state
             state_not: unavailable
@@ -366,25 +358,21 @@ views:
           title: YamBMS - Inverter Status & Heartbeat
       - type: entity-filter
         entities:
-          - entity: sensor.yambms_debug_free_psram_percent
-            name: Debug Free PSRAM (%)
-          - entity: sensor.yambms_debug_free_psram
-            name: Debug Free PSRAM
-          - entity: sensor.yambms_debug_heap_free_percent
+          - entity: sensor.yambms_board_debug_heap_free_percent
             name: Debug Heap free (%)
-          - entity: sensor.yambms_debug_heap_free
+          - entity: sensor.yambms_board_debug_heap_free
             name: Debug Heap free
-          - entity: sensor.yambms_debug_heap_max_block_percent
+          - entity: sensor.yambms_board_debug_heap_max_block_percent
             name: Debug Heap max block (%)
-          - entity: sensor.yambms_debug_heap_max_block
+          - entity: sensor.yambms_board_debug_heap_max_block
             name: Debug Heap max block
-          - entity: sensor.yambms_debug_loop_time
+          - entity: sensor.yambms_board_debug_loop_time
             name: Debug Loop time
           - entity: sensor.yambms_board_uptime
             name: Board Uptime
           - entity: sensor.yambms_board_esphome_version
             name: Board ESPHome version
-          - entity: sensor.yambms_debug_reset_reason
+          - entity: sensor.yambms_board_debug_reset_reason
             name: Debug Reset reason
         conditions:
           - condition: state
@@ -638,8 +626,6 @@ views:
                 name: Discharge switch
               - entity: switch.jk_bms_1_balancing
                 name: Balance switch
-              - entity: switch.jk_bms_1_enable_bluetooth_connection
-                name: Bluetooth
               - entity: number.jk_bms_1_charging_cycles_offset
                 name: Charging Cycles Offset
             conditions:
@@ -888,86 +874,8 @@ views:
                 name: Discharge switch
               - entity: switch.jk_bms_2_balancing
                 name: Balance switch
-              - entity: switch.jk_bms_2_enable_bluetooth_connection
-                name: Bluetooth
               - entity: number.jk_bms_2_charging_cycles_offset
                 name: Charging Cycles Offset
             conditions:
               - condition: state
                 state_not: unavailable
-  - title: Shunt
-    type: sections
-    max_columns: 3
-    sections:
-      - type: grid
-        cards:
-          - graph: line
-            type: sensor
-            entity: sensor.shunt_1_voltage
-            detail: 2
-            layout_options:
-              grid_columns: 2
-              grid_rows: 2
-            name: Voltage
-            hours_to_show: 8
-          - graph: line
-            type: sensor
-            entity: sensor.shunt_1_state_of_charge
-            detail: 2
-            name: SoC
-            hours_to_show: 8
-          - type: gauge
-            entity: sensor.shunt_1_current
-            needle: true
-            severity:
-              green: 0
-              yellow: -250
-              red: -500
-            max: 500
-            min: -500
-            name: Current
-            layout_options:
-              grid_columns: 2
-              grid_rows: 3
-          - type: gauge
-            entity: sensor.shunt_1_power
-            needle: true
-            severity:
-              green: 0
-              yellow: -2500
-              red: -5000
-            max: 5000
-            min: -5000
-            name: Power
-            layout_options:
-              grid_columns: 2
-              grid_rows: 3
-          - type: entity-filter
-            entities:
-              - entity: sensor.shunt_1_voltage
-                name: Shunt 1 Voltage
-              - entity: sensor.shunt_1_current
-                name: Shunt 1 Current
-              - entity: sensor.shunt_1_power
-                name: Shunt 1 Power
-              - entity: sensor.shunt_1_state_of_charge
-                name: Shunt 1 SoC
-              - entity: sensor.shunt_1_temperature
-                name: Shunt 1 Temperature
-              - entity: sensor.shunt_1_charged_power
-                name: Shunt 1 Charged Power
-              - entity: sensor.shunt_1_discharged_power
-                name: Shunt 1 Discharged Power
-              - entity: sensor.shunt_1_battery_capacity
-                name: Shunt 1 Battery Capacity
-            conditions:
-              - condition: state
-                state_not: unavailable
-          - type: entities
-            entities:
-              - entity: switch.shunt_1_combine_enabled
-                name: Shunt 1 Combine enabled
-              - entity: binary_sensor.shunt_1_can_be_combined
-                name: Shunt 1 Can be combined
-        title: Shunt 1
-        column_span: 1

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
@@ -523,7 +523,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -533,7 +533,9 @@ views:
 
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -560,7 +562,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -570,7 +572,9 @@ views:
 
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -747,7 +751,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -757,7 +761,9 @@ views:
 
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -784,7 +790,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -794,7 +800,9 @@ views:
 
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml
@@ -1,0 +1,973 @@
+# Updated : 2026.01.14
+# Version : 1.6.0
+# GitHub  : https://github.com/Sleeper85/esphome-yambms
+
+# YamBMS ( Yet another multi-BMS Merging Solution )
+
+# This YAML is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+
+views:
+  - title: YamBMS 2xBMS
+    type: sections
+    max_columns: 3
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: YamBMS - Battery
+          - graph: line
+            type: sensor
+            entity: sensor.yambms_yambms_1_total_voltage
+            detail: 2
+            layout_options:
+              grid_columns: 2
+              grid_rows: 2
+            name: Voltage
+            hours_to_show: 8
+          - graph: line
+            type: sensor
+            entity: sensor.yambms_yambms_1_battery_soc
+            detail: 2
+            name: SoC
+            hours_to_show: 8
+          - type: gauge
+            entity: sensor.yambms_yambms_1_current
+            needle: true
+            severity:
+              green: 0
+              yellow: -250
+              red: -500
+            max: 500
+            min: -500
+            name: Current
+            layout_options:
+              grid_columns: 2
+              grid_rows: 3
+          - type: gauge
+            entity: sensor.yambms_yambms_1_power
+            needle: true
+            severity:
+              green: 0
+              yellow: -5000
+              red: -10000
+            max: 10000
+            min: -10000
+            name: Power
+            layout_options:
+              grid_columns: 2
+              grid_rows: 3
+          - type: tile
+            entity: sensor.yambms_yambms_1_installed_battery_capacity
+            name: Installed Battery Capacity
+          - type: tile
+            entity: sensor.yambms_yambms_1_battery_soh
+            name: Battery SoH
+          - type: tile
+            entity: sensor.yambms_yambms_1_battery_capacity
+            name: Battery Capacity
+          - type: tile
+            entity: sensor.yambms_yambms_1_capacity_remaining
+            name: Capacity Remaining
+          - type: tile
+            entity: sensor.yambms_yambms_1_delta_cell_voltage
+            name: Delta Cell Voltage
+          - type: tile
+            entity: binary_sensor.yambms_yambms_1_bms_equalizing_state
+            name: Equalizing state
+          - type: entities
+            entities:
+              - entity: sensor.yambms_yambms_1_max_cell_voltage
+                name: Max Cell V.
+              - entity: sensor.yambms_yambms_1_max_voltage_cell
+                name: Cell number
+            layout_options:
+              grid_columns: 2
+              grid_rows: 2
+          - type: entities
+            entities:
+              - entity: sensor.yambms_yambms_1_min_cell_voltage
+                name: Min Cell V.
+              - entity: sensor.yambms_yambms_1_min_voltage_cell
+                name: Cell number
+            layout_options:
+              grid_columns: 2
+              grid_rows: 2
+          - type: entities
+            entities:
+              - entity: sensor.yambms_yambms_1_max_temperature
+                name: Max temp.
+              - entity: sensor.yambms_yambms_1_max_temperature_sensor
+                name: Sensor number
+            layout_options:
+              grid_columns: 2
+              grid_rows: 2
+          - type: entities
+            entities:
+              - entity: sensor.yambms_yambms_1_min_temperature
+                name: Min temp.
+              - entity: sensor.yambms_yambms_1_min_temperature_sensor
+                name: Sensor number
+            layout_options:
+              grid_columns: 2
+              grid_rows: 2
+        column_span: 1
+      - type: grid
+        cards:
+          - type: heading
+            heading: YamBMS - Status
+          - type: tile
+            entity: binary_sensor.yambms_inverter_communication_status
+            name: Inverter comm. status
+          - type: tile
+            entity: binary_sensor.yambms_board_online_status
+            name: Board status
+          - type: tile
+            entity: sensor.yambms_yambms_1_charging_status
+            name: Charging Status
+          - type: tile
+            entity: sensor.yambms_yambms_1_last_complete_charge
+            name: Last Complete Charge
+          - type: tile
+            entity: sensor.yambms_yambms_1_charging_instruction
+            name: Charging Instruction
+          - type: tile
+            entity: binary_sensor.yambms_yambms_1_discharging_instruction
+            name: Discharging Instruction
+          - type: tile
+            entity: sensor.yambms_yambms_1_alarm
+            name: Alarm
+          - type: tile
+            entity: sensor.yambms_yambms_1_warning
+            name: Warning
+          - type: entities
+            entities:
+              - entity: sensor.yambms_yambms_1_bms_count
+                name: BMS count
+              - entity: sensor.yambms_yambms_1_bms_combined
+                name: BMS combined
+              - entity: sensor.yambms_yambms_1_bms_blocking_charge
+                name: BMS blocking charge
+              - entity: sensor.yambms_yambms_1_bms_blocking_discharge
+                name: BMS blocking discharge
+              - entity: sensor.yambms_yambms_1_bms_in_alarm
+                name: BMS in alarm
+            layout_options:
+              grid_columns: 2
+              grid_rows: 4
+          - type: entities
+            entities:
+              - entity: sensor.yambms_yambms_1_shunt_count
+                name: Shunt count
+              - entity: sensor.yambms_yambms_1_shunt_combined
+                name: Shunt combined
+            layout_options:
+              grid_columns: 2
+              grid_rows: 2
+          - type: tile
+            entity: sensor.yambms_board_uptime
+            name: Board Uptime
+          - type: tile
+            entity: sensor.yambms_board_esphome_version
+            name: ESPHome version
+          - type: entities
+            entities:
+              - entity: sensor.yambms_yambms_1_requested_charge_voltage
+                name: Requested Charge Voltage
+              - entity: sensor.yambms_yambms_1_requested_charge_current
+                name: Requested Charge Current
+              - entity: sensor.yambms_yambms_1_requested_discharge_voltage
+                name: Requested Discharge Voltage
+              - entity: sensor.yambms_yambms_1_requested_discharge_current
+                name: Requested Discharge Current
+              - entity: binary_sensor.yambms_yambms_1_requested_force_charge
+                name: Requested Force Charge
+          - type: tile
+            entity: sensor.yambms_yambms_1_running_version
+            name: Running version
+          - type: tile
+            entity: sensor.yambms_yambms_1_last_version
+            name: Last version
+        column_span: 1
+  - title: Control
+    cards:
+      - type: entity-filter
+        entities:
+          - entity: select.canbus_1_yambms_name
+            name: CANBUS YamBMS name
+          - entity: select.canbus_1_yambms_protocol
+            name: CANBUS YamBMS protocol
+          - entity: select.rs485_1_yambms_protocol
+            name: RS485 YamBMS protocol
+        conditions:
+          - condition: state
+            state_not: unavailable
+        card:
+          title: YamBMS - Inverter Comm. Protocol
+      - type: entities
+        entities:
+          - entity: switch.yambms_yambms_1_charge_enabled
+            name: YamBMS 1 Charge enabled
+          - entity: switch.yambms_yambms_1_discharge_enabled
+            name: YamBMS 1 Discharge enabled
+          - entity: binary_sensor.yambms_yambms_1_bms_charging_allowed
+            name: YamBMS 1 BMS Charging allowed
+          - entity: binary_sensor.yambms_yambms_1_bms_discharging_allowed
+            name: YamBMS 1 BMS Discharging allowed
+        title: YamBMS - Charge / Discharge switch
+      - type: entities
+        entities:
+          - entity: switch.yambms_yambms_1_automatic_charge_voltage
+            name: Automatic Charge Voltage
+          - entity: number.yambms_yambms_1_auto_cvl_boost_charge_v
+            name: Auto CVL Boost Charge V.
+        title: YamBMS - Auto CVL
+      - type: entities
+        entities:
+          - entity: sensor.yambms_yambms_1_charging_status
+            name: Charging Status
+          - entity: sensor.yambms_yambms_1_charging_instruction
+            name: Charging Instruction
+          - entity: switch.yambms_yambms_1_float_charge_enabled
+            name: Float charge enabled
+          - entity: switch.yambms_yambms_1_eoc_timer_enabled
+            name: EOC timer enabled
+          - entity: number.yambms_yambms_1_bulk_voltage
+            name: Bulk voltage
+          - entity: number.yambms_yambms_1_float_voltage
+            name: Float voltage
+          - entity: number.yambms_yambms_1_inverter_offset_v
+            name: Inverter Offset V.
+        title: YamBMS - Charging Settings
+      - type: entities
+        entities:
+          - entity: switch.yambms_yambms_1_automatic_charge_current
+            name: Automatic Charge Current
+          - entity: switch.yambms_yambms_1_automatic_discharge_current
+            name: Automatic Discharge Current
+        title: YamBMS - Auto CCL / DCL
+      - type: entities
+        entities:
+          - entity: select.yambms_yambms_1_automatic_float_voltage
+            name: Automatic Float Voltage
+          - entity: sensor.yambms_yambms_1_auto_float_voltage
+            name: Auto Float Voltage
+          - entity: number.yambms_yambms_1_auto_float_update_interval
+            name: Update Interval
+          - entity: number.yambms_yambms_1_auto_float_voltage_step
+            name: Voltage Step
+        title: YamBMS - Auto Float
+      - type: entities
+        entities:
+          - entity: switch.yambms_yambms_1_automatic_eoc_current
+            name: Automatic EOC Current
+          - entity: sensor.yambms_yambms_1_auto_eoc_status
+            name: Status
+          - entity: sensor.yambms_yambms_1_auto_eoc_current
+            name: Required Current
+          - entity: number.yambms_yambms_1_auto_eoc_target_hour
+            name: Target hour
+          - entity: number.yambms_yambms_1_auto_eoc_target_minute
+            name: Target minute
+          - entity: number.yambms_yambms_1_auto_eoc_correction
+            name: Current Correction
+          - entity: number.yambms_yambms_1_auto_eoc_capacity_modifier
+            name: Capacity Modifier
+          - entity: number.yambms_yambms_1_auto_eoc_increase_stop_hours
+            name: Stop hours
+          - entity: number.yambms_yambms_1_auto_eoc_increase_stop_soc
+            name: Stop SoC
+        title: YamBMS - Auto EOC
+      - type: entities
+        entities:
+          - entity: number.yambms_yambms_1_rebulk_soc
+            name: Rebulk SoC
+          - entity: number.yambms_yambms_1_rebulk_v
+            name: Rebulk V.
+          - entity: switch.yambms_yambms_1_force_bulk_top_bal
+            name: Force Bulk (top bal)
+        title: YamBMS - ReBulk
+      - type: entities
+        entities:
+          - entity: number.yambms_yambms_1_max_requested_charge_current
+            name: Max charge current
+          - entity: number.yambms_yambms_1_max_requested_discharge_current
+            name: Max discharge current
+          - entity: switch.yambms_yambms_1_temperature_based_current_limitation
+            name: Temperature-based current limitation
+          - entity: sensor.yambms_yambms_1_ccl_derating_reason
+            name: CCL Derating Reason
+          - entity: sensor.yambms_yambms_1_dcl_derating_reason
+            name: DCL Derating Reason
+        title: YamBMS - Max requested current
+      - type: entities
+        entities:
+          - entity: switch.yambms_yambms_1_request_force_charge
+            name: Request force charge
+          - entity: number.yambms_yambms_1_request_force_charge_start_soc
+            name: Force charge Start SoC
+          - entity: number.yambms_yambms_1_request_force_charge_stop_soc
+            name: Force charge Stop SoC
+          - entity: binary_sensor.yambms_yambms_1_requested_force_charge
+            name: Requested Force Charge
+        title: YamBMS - Request force charge
+      - type: entities
+        entities:
+          - entity: sensor.yambms_yambms_1_requested_charge_voltage
+            name: Requested Charge Voltage
+          - entity: sensor.yambms_yambms_1_requested_discharge_voltage
+            name: Requested Discharge Voltage
+          - entity: sensor.yambms_yambms_1_requested_charge_current
+            name: Requested Charge Current
+          - entity: sensor.yambms_yambms_1_requested_discharge_current
+            name: Requested Discharge Current
+        title: YamBMS - Requested Values
+      - type: entities
+        entities:
+          - entity: sensor.yambms_yambms_1_last_complete_charge
+            name: Last Complete Charge
+          - entity: binary_sensor.yambms_board_online_status
+            name: Board Online Status
+          - entity: sensor.yambms_board_uptime
+            name: Board Uptime
+          - entity: sensor.yambms_board_esphome_version
+            name: Board ESPHome version
+          - entity: button.yambms_board_restart
+            name: Board Restart
+        title: YamBMS - Diagnostic
+      - type: entity-filter
+        entities:
+          - entity: binary_sensor.canbus_1_status
+            name: CANBUS Status
+          - entity: switch.canbus_1_inverter_heartbeat_monitoring
+            name: CANBUS Inverter Heartbeat Monitoring
+          - entity: sensor.canbus_1_inverter_heartbeat
+            name: CANBUS Inverter Heartbeat
+          - entity: binary_sensor.rs485_1_status
+            name: RS485 Status
+          - entity: switch.rs485_1_inverter_heartbeat_monitoring
+            name: RS485 Inverter Heartbeat Monitoring
+          - entity: sensor.rs485_1_inverter_heartbeat
+            name: RS485 Inverter Heartbeat
+        conditions:
+          - condition: state
+            state_not: unavailable
+        card:
+          title: YamBMS - Inverter Status & Heartbeat
+      - type: entity-filter
+        entities:
+          - entity: sensor.yambms_debug_free_psram_percent
+            name: Debug Free PSRAM (%)
+          - entity: sensor.yambms_debug_free_psram
+            name: Debug Free PSRAM
+          - entity: sensor.yambms_debug_heap_free_percent
+            name: Debug Heap free (%)
+          - entity: sensor.yambms_debug_heap_free
+            name: Debug Heap free
+          - entity: sensor.yambms_debug_heap_max_block_percent
+            name: Debug Heap max block (%)
+          - entity: sensor.yambms_debug_heap_max_block
+            name: Debug Heap max block
+          - entity: sensor.yambms_debug_loop_time
+            name: Debug Loop time
+          - entity: sensor.yambms_board_uptime
+            name: Board Uptime
+          - entity: sensor.yambms_board_esphome_version
+            name: Board ESPHome version
+          - entity: sensor.yambms_debug_reset_reason
+            name: Debug Reset reason
+        conditions:
+          - condition: state
+            state_not: unavailable
+        card:
+          title: YamBMS - DEBUG
+  - title: BMS
+    type: sections
+    max_columns: 3
+    sections:
+      - type: grid
+        column_span: 1
+        cards:
+          - type: heading
+            heading: BMS 1
+            heading_style: title
+            badges:
+              - type: entity
+                show_state: true
+                show_icon: true
+                entity: binary_sensor.jk_bms_1_status_online
+                color: state
+                name: Online
+                state_content: name
+              - type: entity
+                show_state: true
+                show_icon: true
+                entity: binary_sensor.jk_bms_1_can_be_combined
+                color: state
+                name: Combined
+                state_content: name
+          - type: grid
+            square: false
+            columns: 1
+            cards:
+              - type: markdown
+                content: >-
+                  <center>Time : <b><font color=red>{{
+                  states('sensor.jk_bms_1_total_runtime_formatted', rounded=True)
+                  | upper }}</font>
+            layout_options:
+              grid_columns: 2
+              grid_rows: 1
+          - type: grid
+            square: false
+            columns: 1
+            cards:
+              - type: markdown
+                content: >-
+                  <center>Error : <b><font color=red>{{
+                  states('sensor.jk_bms_1_errors', rounded=True)}}</font>
+            layout_options:
+              grid_columns: 2
+              grid_rows: 1
+          - type: grid
+            square: false
+            columns: 3
+            cards:
+              - type: markdown
+                content: >-
+                  <center>Charge : <b>{% if
+                  states('binary_sensor.jk_bms_1_status_charging', rounded=True) == 'on'
+                  %} <font color=#41CD52>{{
+                  states('binary_sensor.jk_bms_1_status_charging', rounded=True) | upper
+                  }}</font> {% else %} <font color=#3090C7>{{
+                  states('binary_sensor.jk_bms_1_status_charging', rounded=True) | upper
+                  }}</font> {% endif %}
+              - type: markdown
+                content: >-
+                  <center>Discharge : <b> {% if
+                  states('binary_sensor.jk_bms_1_status_discharging', rounded=True) ==
+                  'on' %} <font color=#41CD52>{{
+                  states('binary_sensor.jk_bms_1_status_discharging', rounded=True) |
+                  upper }}</font> {% else %} <font color=#3090C7>{{
+                  states('binary_sensor.jk_bms_1_status_discharging', rounded=True) |
+                  upper }}</font> {% endif %}
+              - type: markdown
+                content: >-
+                  <center>Balance : <b> {% if
+                  states('binary_sensor.jk_bms_1_equalizing', rounded=True) ==
+                  'on' %} <font color=#41CD52>{{
+                  states('binary_sensor.jk_bms_1_equalizing', rounded=True) |
+                  upper }}</font> {% else %} <font color=#3090C7>{{
+                  states('binary_sensor.jk_bms_1_equalizing', rounded=True) |
+                  upper }}</font> {% endif %}
+              - type: markdown
+                content: >-
+                  <center><b><font color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_1_battery_voltage', rounded=True) }}
+                  V</font></b>
+              - type: markdown
+                content: >-
+                  <center><b><font color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_1_battery_current', rounded=True) }} A</font></b>
+              - type: markdown
+                content: >-
+                  <center><b><font color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_1_battery_power', rounded=True) }} W</font>
+          - type: grid
+            square: false
+            columns: 2
+            cards:
+              - type: markdown
+                content: >-
+                  <center><b><font size=4>SoC :&nbsp;&nbsp;<font
+                  color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_1_battery_soc', rounded=True) }}
+                  %</font></font>
+              - type: markdown
+                content: >-
+                  <center><b><font size=4>SoH :&nbsp;&nbsp;<font
+                  color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_1_battery_soh_valuation', rounded=True) }}
+                  %</font></font>
+              - type: markdown
+                content: >-
+                  <center> Battery Capacity :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('number.jk_bms_1_battery_capacity_total_setting', rounded=True)
+                  }} Ah</font><br> Cycle Capacity :&nbsp;&nbsp;<font
+                  color=#41CD52>{{
+                  states('sensor.jk_bms_1_total_charging_cycle_capacity', rounded=True)
+                  }} Ah</font><br> Ave. Cell Vol. :&nbsp;&nbsp;<font
+                  color=#41CD52>{{
+                  states('sensor.jk_bms_1_cell_average_voltage', rounded=True) }}
+                  V</font><br> Balance Cur. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_1_balancing_current', rounded=True) }}
+                  A</font><br> Max temp. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_1_max_temperature', rounded=True) }}
+                  °C</font>
+              - type: markdown
+                content: >-
+                  <center> Remain Capacity :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_1_battery_capacity_remaining', rounded=True) }}
+                  Ah</font><br> Cycle Count :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_1_charging_cycles', rounded=True)
+                  }}</font><br> Delta Cell Vol. :&nbsp;&nbsp;<font
+                  color=#41CD52>{{
+                  states('sensor.jk_bms_1_cell_delta_voltage', rounded=True) }}
+                  V</font><br> MOS temp. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_1_temperature_powertube', rounded=True)
+                  }} °C</font><br> Min temp. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_1_min_temperature', rounded=True) }}
+                  °C</font>
+          - type: grid
+            square: false
+            columns: 2
+            cards:
+              - type: markdown
+                content: >-
+                  
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
+                  {% if has_value(res_ent) %} / 
+                  {% set res_values = [] %}
+                  {% for i in range(1,17) %}
+                  {% set z = '0' if i < 10 else '' %}
+                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
+                  {% if has_value(e) %}
+                  {% set res_values = res_values + [states(e) | float(0)] %}
+                  {% endif %}
+                  {% endfor %}
+                  {% set res_max = res_values|max if res_values|length else none %}
+                  {% set res_min = res_values|min if res_values|length else none %}
+                  {% set res_val = states(res_ent) | float(0) %}
+                  {% if res_max is not none and res_val == res_max %}
+                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% elif res_min is not none and res_val == res_min %}
+                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% else %}
+                  {{ states(res_ent, rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
+                  <center>
+                  
+                  {{ cell_v(lead_zero=1, num=1, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=2, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=3, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=4, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=5, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=6, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=7, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=1, num=8, entity='.jk_bms_1') }}                  
+                  
+                  </center>
+              - type: markdown
+                content: >-
+                  
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
+                  {% if has_value(res_ent) %} / 
+                  {% set res_values = [] %}
+                  {% for i in range(1,17) %}
+                  {% set z = '0' if i < 10 else '' %}
+                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
+                  {% if has_value(e) %}
+                  {% set res_values = res_values + [states(e) | float(0)] %}
+                  {% endif %}
+                  {% endfor %}
+                  {% set res_max = res_values|max if res_values|length else none %}
+                  {% set res_min = res_values|min if res_values|length else none %}
+                  {% set res_val = states(res_ent) | float(0) %}
+                  {% if res_max is not none and res_val == res_max %}
+                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% elif res_min is not none and res_val == res_min %}
+                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% else %}
+                  {{ states(res_ent, rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
+                  <center>
+                  
+                  {{ cell_v(lead_zero=1, num=9, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=10, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=11, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=12, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=13, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=14, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=15, entity='.jk_bms_1') }}
+                  {{ cell_v(lead_zero=0, num=16, entity='.jk_bms_1') }}              
+                  
+                  </center>
+          - type: entity-filter
+            entities:
+              - entity: switch.jk_bms_1_charging
+                name: Charge switch
+              - entity: switch.jk_bms_1_discharging
+                name: Discharge switch
+              - entity: switch.jk_bms_1_balancing
+                name: Balance switch
+              - entity: switch.jk_bms_1_enable_bluetooth_connection
+                name: Bluetooth
+              - entity: number.jk_bms_1_charging_cycles_offset
+                name: Charging Cycles Offset
+            conditions:
+              - condition: state
+                state_not: unavailable
+      - type: grid
+        column_span: 1
+        cards:
+          - type: heading
+            heading: BMS 2
+            heading_style: title
+            badges:
+              - type: entity
+                show_state: true
+                show_icon: true
+                entity: binary_sensor.jk_bms_2_status_online
+                color: state
+                name: Online
+                state_content: name
+              - type: entity
+                show_state: true
+                show_icon: true
+                entity: binary_sensor.jk_bms_2_can_be_combined
+                color: state
+                name: Combined
+                state_content: name
+          - type: grid
+            square: false
+            columns: 1
+            cards:
+              - type: markdown
+                content: >-
+                  <center>Time : <b><font color=red>{{
+                  states('sensor.jk_bms_2_total_runtime_formatted', rounded=True)
+                  | upper }}</font>
+            layout_options:
+              grid_columns: 2
+              grid_rows: 1
+          - type: grid
+            square: false
+            columns: 1
+            cards:
+              - type: markdown
+                content: >-
+                  <center>Error : <b><font color=red>{{
+                  states('sensor.jk_bms_2_errors', rounded=True)}}</font>
+            layout_options:
+              grid_columns: 2
+              grid_rows: 1
+          - type: grid
+            square: false
+            columns: 3
+            cards:
+              - type: markdown
+                content: >-
+                  <center>Charge : <b>{% if
+                  states('binary_sensor.jk_bms_2_status_charging', rounded=True) == 'on'
+                  %} <font color=#41CD52>{{
+                  states('binary_sensor.jk_bms_2_status_charging', rounded=True) | upper
+                  }}</font> {% else %} <font color=#3090C7>{{
+                  states('binary_sensor.jk_bms_2_status_charging', rounded=True) | upper
+                  }}</font> {% endif %}
+              - type: markdown
+                content: >-
+                  <center>Discharge : <b> {% if
+                  states('binary_sensor.jk_bms_2_status_discharging', rounded=True) ==
+                  'on' %} <font color=#41CD52>{{
+                  states('binary_sensor.jk_bms_2_status_discharging', rounded=True) |
+                  upper }}</font> {% else %} <font color=#3090C7>{{
+                  states('binary_sensor.jk_bms_2_status_discharging', rounded=True) |
+                  upper }}</font> {% endif %}
+              - type: markdown
+                content: >-
+                  <center>Balance : <b> {% if
+                  states('binary_sensor.jk_bms_2_equalizing', rounded=True) ==
+                  'on' %} <font color=#41CD52>{{
+                  states('binary_sensor.jk_bms_2_equalizing', rounded=True) |
+                  upper }}</font> {% else %} <font color=#3090C7>{{
+                  states('binary_sensor.jk_bms_2_equalizing', rounded=True) |
+                  upper }}</font> {% endif %}
+              - type: markdown
+                content: >-
+                  <center><b><font color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_2_battery_voltage', rounded=True) }}
+                  V</font></b>
+              - type: markdown
+                content: >-
+                  <center><b><font color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_2_battery_current', rounded=True) }} A</font></b>
+              - type: markdown
+                content: >-
+                  <center><b><font color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_2_battery_power', rounded=True) }} W</font>
+          - type: grid
+            square: false
+            columns: 2
+            cards:
+              - type: markdown
+                content: >-
+                  <center><b><font size=4>SoC :&nbsp;&nbsp;<font
+                  color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_2_battery_soc', rounded=True) }}
+                  %</font></font>
+              - type: markdown
+                content: >-
+                  <center><b><font size=4>SoH :&nbsp;&nbsp;<font
+                  color=#41CD52 size=4>{{
+                  states('sensor.jk_bms_2_battery_soh_valuation', rounded=True) }}
+                  %</font></font>
+              - type: markdown
+                content: >-
+                  <center> Battery Capacity :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('number.jk_bms_2_battery_capacity_total_setting', rounded=True)
+                  }} Ah</font><br> Cycle Capacity :&nbsp;&nbsp;<font
+                  color=#41CD52>{{
+                  states('sensor.jk_bms_2_total_charging_cycle_capacity', rounded=True)
+                  }} Ah</font><br> Ave. Cell Vol. :&nbsp;&nbsp;<font
+                  color=#41CD52>{{
+                  states('sensor.jk_bms_2_cell_average_voltage', rounded=True) }}
+                  V</font><br> Balance Cur. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_2_balancing_current', rounded=True) }}
+                  A</font><br> Max temp. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_2_max_temperature', rounded=True) }}
+                  °C</font>
+              - type: markdown
+                content: >-
+                  <center> Remain Capacity :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_2_battery_capacity_remaining', rounded=True) }}
+                  Ah</font><br> Cycle Count :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_2_charging_cycles', rounded=True)
+                  }}</font><br> Delta Cell Vol. :&nbsp;&nbsp;<font
+                  color=#41CD52>{{
+                  states('sensor.jk_bms_2_cell_delta_voltage', rounded=True) }}
+                  V</font><br> MOS temp. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_2_temperature_powertube', rounded=True)
+                  }} °C</font><br> Min temp. :&nbsp;&nbsp;<font color=#41CD52>{{
+                  states('sensor.jk_bms_2_min_temperature', rounded=True) }}
+                  °C</font>
+          - type: grid
+            square: false
+            columns: 2
+            cards:
+              - type: markdown
+                content: >-
+                  
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
+                  {% if has_value(res_ent) %} / 
+                  {% set res_values = [] %}
+                  {% for i in range(1,17) %}
+                  {% set z = '0' if i < 10 else '' %}
+                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
+                  {% if has_value(e) %}
+                  {% set res_values = res_values + [states(e) | float(0)] %}
+                  {% endif %}
+                  {% endfor %}
+                  {% set res_max = res_values|max if res_values|length else none %}
+                  {% set res_min = res_values|min if res_values|length else none %}
+                  {% set res_val = states(res_ent) | float(0) %}
+                  {% if res_max is not none and res_val == res_max %}
+                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% elif res_min is not none and res_val == res_min %}
+                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% else %}
+                  {{ states(res_ent, rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
+                  <center>
+                  
+                  {{ cell_v(lead_zero=1, num=1, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=2, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=3, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=4, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=5, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=6, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=7, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=1, num=8, entity='.jk_bms_2') }}                  
+                  
+                  </center>
+              - type: markdown
+                content: >-
+                  
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
+                  {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ max_color }}'>
+                  {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                  <font color='{{ min_color }}'>
+                  {% else %} <font> {% endif %}
+                  
+                  {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
+                  {% set res_ent = 'sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) %}
+                  {% if has_value(res_ent) %} / 
+                  {% set res_values = [] %}
+                  {% for i in range(1,17) %}
+                  {% set z = '0' if i < 10 else '' %}
+                  {% set e = 'sensor{}_cell_resistance_{}{}'.format(entity, z, i) %}
+                  {% if has_value(e) %}
+                  {% set res_values = res_values + [states(e) | float(0)] %}
+                  {% endif %}
+                  {% endfor %}
+                  {% set res_max = res_values|max if res_values|length else none %}
+                  {% set res_min = res_values|min if res_values|length else none %}
+                  {% set res_val = states(res_ent) | float(0) %}
+                  {% if res_max is not none and res_val == res_max %}
+                  <font color='red'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% elif res_min is not none and res_val == res_min %}
+                  <font color='#41CD52'>{{ states(res_ent, rounded=True) }} Ω</font>
+                  {% else %}
+                  {{ states(res_ent, rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
+                  <br>
+                  
+                  {% endmacro %}
+                  
+                  <center>
+                  
+                  {{ cell_v(lead_zero=1, num=9, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=10, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=11, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=12, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=13, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=14, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=15, entity='.jk_bms_2') }}
+                  {{ cell_v(lead_zero=0, num=16, entity='.jk_bms_2') }}              
+                  
+                  </center>
+          - type: entity-filter
+            entities:
+              - entity: switch.jk_bms_2_charging
+                name: Charge switch
+              - entity: switch.jk_bms_2_discharging
+                name: Discharge switch
+              - entity: switch.jk_bms_2_balancing
+                name: Balance switch
+              - entity: switch.jk_bms_2_enable_bluetooth_connection
+                name: Bluetooth
+              - entity: number.jk_bms_2_charging_cycles_offset
+                name: Charging Cycles Offset
+            conditions:
+              - condition: state
+                state_not: unavailable
+  - title: Shunt
+    type: sections
+    max_columns: 3
+    sections:
+      - type: grid
+        cards:
+          - graph: line
+            type: sensor
+            entity: sensor.shunt_1_voltage
+            detail: 2
+            layout_options:
+              grid_columns: 2
+              grid_rows: 2
+            name: Voltage
+            hours_to_show: 8
+          - graph: line
+            type: sensor
+            entity: sensor.shunt_1_state_of_charge
+            detail: 2
+            name: SoC
+            hours_to_show: 8
+          - type: gauge
+            entity: sensor.shunt_1_current
+            needle: true
+            severity:
+              green: 0
+              yellow: -250
+              red: -500
+            max: 500
+            min: -500
+            name: Current
+            layout_options:
+              grid_columns: 2
+              grid_rows: 3
+          - type: gauge
+            entity: sensor.shunt_1_power
+            needle: true
+            severity:
+              green: 0
+              yellow: -2500
+              red: -5000
+            max: 5000
+            min: -5000
+            name: Power
+            layout_options:
+              grid_columns: 2
+              grid_rows: 3
+          - type: entity-filter
+            entities:
+              - entity: sensor.shunt_1_voltage
+                name: Shunt 1 Voltage
+              - entity: sensor.shunt_1_current
+                name: Shunt 1 Current
+              - entity: sensor.shunt_1_power
+                name: Shunt 1 Power
+              - entity: sensor.shunt_1_state_of_charge
+                name: Shunt 1 SoC
+              - entity: sensor.shunt_1_temperature
+                name: Shunt 1 Temperature
+              - entity: sensor.shunt_1_charged_power
+                name: Shunt 1 Charged Power
+              - entity: sensor.shunt_1_discharged_power
+                name: Shunt 1 Discharged Power
+              - entity: sensor.shunt_1_battery_capacity
+                name: Shunt 1 Battery Capacity
+            conditions:
+              - condition: state
+                state_not: unavailable
+          - type: entities
+            entities:
+              - entity: switch.shunt_1_combine_enabled
+                name: Shunt 1 Combine enabled
+              - entity: binary_sensor.shunt_1_can_be_combined
+                name: Shunt 1 Can be combined
+        title: Shunt 1
+        column_span: 1

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -779,7 +779,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -791,7 +791,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -818,7 +819,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -830,7 +831,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1009,7 +1011,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1021,7 +1023,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1048,7 +1051,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1060,7 +1063,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1239,7 +1243,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1251,7 +1255,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1278,7 +1283,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1290,7 +1295,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_3xBMS.yaml
@@ -779,19 +779,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -809,19 +818,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -991,19 +1009,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1021,19 +1048,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1203,19 +1239,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1233,19 +1278,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -779,7 +779,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -791,7 +791,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -818,7 +819,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -830,7 +831,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1009,7 +1011,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1021,7 +1023,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1048,7 +1051,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1060,7 +1063,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1239,7 +1243,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1251,7 +1255,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1278,7 +1283,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1290,7 +1295,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1469,7 +1475,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1481,7 +1487,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1508,7 +1515,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1520,7 +1527,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1699,7 +1707,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1711,7 +1719,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1738,7 +1747,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1750,7 +1759,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1929,7 +1939,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1941,7 +1951,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -1968,7 +1979,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -1980,7 +1991,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -2159,7 +2171,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -2171,7 +2183,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
@@ -2198,7 +2211,7 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, res_abs_threshold = 0.15, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
@@ -2210,7 +2223,8 @@ views:
                   {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
                   {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
                   {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
-                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                  {% set res_v = states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) | float(0) %}
+                  {% if (states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold) or res_v > res_abs_threshold %}
                    / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
                   {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                    / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>

--- a/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
+++ b/HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_7xBMS.yaml
@@ -779,19 +779,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -809,19 +818,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -991,19 +1009,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1021,19 +1048,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1203,19 +1239,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1233,19 +1278,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1415,19 +1469,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1445,19 +1508,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1627,19 +1699,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1657,19 +1738,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1839,19 +1929,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -1869,19 +1968,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -2051,19 +2159,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>
@@ -2081,19 +2198,28 @@ views:
               - type: markdown
                 content: >-
                   
-                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', lead_zero = 0, spaces=3) -%}
+                  {% macro cell_v(num, entity, max_color = 'red' , min_color = '#3090C9', max_res_color = 'red', min_res_color = 'green', res_threshold = 0.20, lead_zero = 0, spaces=3) -%}
                   {% if lead_zero %}0{% endif %}{{num}}.{% for spaces in range(0, spaces) -%} {{ '&nbsp;' }} {%- endfor %}
                   {% if states('sensor{}_cell_voltage_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ max_color }}'>
                   {% elif states('sensor{}_cell_voltage_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
                   <font color='{{ min_color }}'>
                   {% else %} <font> {% endif %}
-                  
+
                   {{ states('sensor{}_cell_voltage_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} V</font>
-                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %} / 
-                  {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num) , rounded=True) }} Ω {% endif %}
+                  {% if has_value('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num)) %}
+                  {% set res_max_v = states('sensor{}_cell_resistance_max'.format(entity)) | float(0) %}
+                  {% set res_min_v = states('sensor{}_cell_resistance_min'.format(entity)) | float(0) %}
+                  {% if states('sensor{}_cell_resistance_max_cell_number'.format(entity), rounded=True) == '{}'.format(num) and res_min_v > 0 and (res_max_v - res_min_v) / res_min_v > res_threshold %}
+                   / <font color='{{ max_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% elif states('sensor{}_cell_resistance_min_cell_number'.format(entity), rounded=True) == '{}'.format(num) %}
+                   / <font color='{{ min_res_color }}'>{{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω</font>
+                  {% else %}
+                   / {{ states('sensor{}_cell_resistance_{}{}'.format(entity, ''.zfill(lead_zero), num), rounded=True) }} Ω
+                  {% endif %}
+                  {% endif %}
                   <br>
-                  
+
                   {% endmacro %}
                   
                   <center>


### PR DESCRIPTION
## Summary

- Add a new `HomeAssistant_Dashboards/YamBMS_HA_Dashboard_JK_RS485_2xBMS.yaml` dashboard for 2-BMS JK RS485 installs (analogous to the existing 3xBMS/7xBMS ones), including cell voltage AND cell resistance min/max highlighting.
- Add threshold-based cell resistance min/max highlighting to the existing `3xBMS`/`7xBMS` dashboards, which currently show resistance as plain, uncolored text.

## Cell resistance highlighting details

Cell resistance ("balance-wire loop resistance" per the JK register map, offset `CellWireRes0..31`) is now colored the same way voltage already is, but inverted (lower = healthier):
- **Red**: the cell is the pack's resistance outlier by relative deviation (`(max-min)/min > 20%`), OR its own resistance exceeds an absolute `0.15 Ω` threshold regardless of the pack's spread (catches uniform pack-wide degradation that relative deviation alone would miss).
- **Green**: the cell has the pack's minimum resistance.
- Both thresholds are macro parameters (`res_threshold`, `res_abs_threshold`), easy to tune per-install.

Uses the dedicated `cell_resistance_max`/`cell_resistance_min`/`*_cell_number` sensors the `jk_rs485_bms` component already publishes — no extra per-cell iteration needed.

## Test plan

- [x] All three touched dashboard YAML files parse cleanly (`yaml.safe_load`).
- [x] Verified live against a real 2xBMS JK RS485 installation (own production dashboard): cell voltage/resistance min/max highlighting renders correctly across both BMS, resistance values below both thresholds show no false-positive red, survives multiple full page reloads.
- [x] Resistance-highlighting logic (relative + absolute threshold) verified via Home Assistant's `/api/template` render endpoint for 3xBMS/7xBMS (no live 3/7-BMS hardware available to test end-to-end).
- Not covered: `YamBMS_HA_Dashboard_JK_UART-GPS_BLE_3xBMS.yaml` uses a different sensor-naming convention for voltage min/max and has no existing resistance-highlighting reference to confirm the equivalent resistance sensor names — left untouched pending access to that hardware variant.
